### PR TITLE
Serve QR codes on-the-fly

### DIFF
--- a/fs_data.py
+++ b/fs_data.py
@@ -18,7 +18,6 @@ pw_key = os.getenv("SQL_PW")
 db_key = os.getenv("SQL_DB")
 
 BASE_DIR = os.path.dirname(__file__)
-QR = os.path.join(BASE_DIR, 'static', 'qrcode')
 STATIC = os.path.join(BASE_DIR, 'static', 'upload')
 
 # SQLAlchemyエンジンの作成（接続プール設定を含む）
@@ -108,8 +107,7 @@ def get_all():
 def remove_data(secure_id):
     try:
         paths = [
-            os.path.join(STATIC, f"{secure_id}.zip"),
-            os.path.join(QR, f"qrcode-{secure_id}.jpg")
+            os.path.join(STATIC, f"{secure_id}.zip")
         ]
 
         for file_path in paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
 Flask
 python-dotenv
-qrcode
 uuid
 apscheduler
 mysqlclient
-Pillow
-sqlalchemy 
+sqlalchemy
 pymysql
-apscheduler
 diff-match-patch

--- a/templates/info.html
+++ b/templates/info.html
@@ -32,9 +32,8 @@
     </table>
 
     <div class="text-center mt-4">
-      <a>
-        <img src="/static/qrcode/qrcode-{{ secure_id }}.jpg" class="img-fluid" style="max-width: 200px; height: auto;">
-      </a>
+      <img src="https://api.qrserver.com/v1/create-qr-code?size=200x200&data={{ url | urlencode }}"
+           class="img-fluid" style="max-width: 200px; height: auto;" alt="QR">
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Generate file-share QR codes on the fly without storing images server-side
- Clean up QR image handling from database utilities and app cleanup
- Update dependencies after removing qrcode library

## Testing
- `python -m py_compile app.py fs_data.py`
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a016a4dbe083208cfa454432acc1e8