### PR TITLE
Add privacy and contact pages with ads.txt support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.zip
 *.pptx
 *.txt
+!ads.txt
 
 
 

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4557554518872474, DIRECT, f08c47fec0942fa0

--- a/app.py
+++ b/app.py
@@ -1,4 +1,14 @@
-from flask import Flask, request, send_file, jsonify, render_template, redirect, url_for, abort
+from flask import (
+    Flask,
+    request,
+    send_file,
+    send_from_directory,
+    jsonify,
+    render_template,
+    redirect,
+    url_for,
+    abort,
+)
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 import os
@@ -69,6 +79,26 @@ def index():
 @app.route('/fs-qr')
 def fs_qr():
     return render_template('fs-qr.html')
+
+
+@app.route('/privacy-policy')
+def privacy_policy():
+    return render_template('privacy.html')
+
+
+@app.route('/about')
+def about():
+    return render_template('about.html')
+
+
+@app.route('/contact')
+def contact():
+    return render_template('contact.html')
+
+
+@app.route('/ads.txt')
+def ads_txt():
+    return send_from_directory(app.root_path, 'ads.txt')
 
 @app.route('/fs-qr-upload')
 def fs_qr_upload():

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,11 @@
+{% extends "layout.html" %}
+{% block contents %}
+<div class="container my-5">
+  <h2 class="mb-4">サイト概要</h2>
+  <p>FS!QRは、ファイルをQRコードを通じて簡単に共有できるサービスです。</p>
+  <p>ユーザーはアップロードしたファイルをQRコードで共有し、パスワードを設定することで安全に配布できます。</p>
+  <h3 class="mt-4">運営者情報</h3>
+  <p>運営者: FS!QR運営チーム</p>
+  <p>連絡先: <a href="mailto:contact@example.com">contact@example.com</a></p>
+</div>
+{% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,8 @@
+{% extends "layout.html" %}
+{% block contents %}
+<div class="container my-5">
+  <h2 class="mb-4">お問い合わせ</h2>
+  <p>ご意見・ご質問などがございましたら、以下のメールアドレスまでご連絡ください。</p>
+  <p><a href="mailto:contact@example.com">contact@example.com</a></p>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -67,7 +67,13 @@
             <a class="nav-link" href="/">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://project-kk.com/">問い合わせ</a>
+            <a class="nav-link" href="/about">サイト概要</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/privacy-policy">プライバシーポリシー</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/contact">お問い合わせ</a>
           </li>
         </ul>
         <!-- /ナビゲーション -->

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+{% block contents %}
+<div class="container my-5">
+  <h2 class="mb-4">プライバシーポリシー</h2>
+  <p>当サイトでは、Google などの第三者配信事業者が Cookie を使用して、ユーザーの過去のアクセス情報に基づいて広告を配信しています。</p>
+  <p>これらの Cookie を利用することで、ユーザーの興味・関心に合わせたパーソナライズド広告が表示される場合があります。</p>
+  <p>ユーザーは <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">Google 広告設定</a> や <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener">aboutads.info</a> のページから、パーソナライズド広告に使用される Cookie を無効にできます。</p>
+  <p>その他、ご不明な点がございましたら <a href="/contact">お問い合わせ</a> ください。</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add routes and templates for privacy policy, site overview, and contact information
- Serve ads.txt with AdSense publisher ID and link new pages in footer navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a01a0375dc8320a51764f3e3e316b1