### PR TITLE
Use Google Form for inquiries and unify footer links

### DIFF
--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -49,11 +49,13 @@
   <footer class="py-4 bg-dark text-light">
     <div class="container text-center">
       <ul class="nav justify-content-center mb-3">
-        <li class="nav-item"><a class="nav-link" href="/">ホーム</a></li>
-        <li class="nav-item"><a class="nav-link" href="https://project-kk.com/">問い合わせ</a></li>
+        <li class="nav-item"><a class="nav-link" href="/about">サイト概要</a></li>
+        <li class="nav-item"><a class="nav-link" href="/privacy-policy">プライバシーポリシー</a></li>
+        <li class="nav-item"><a class="nav-link" href="/contact">お問い合わせ</a></li>
       </ul>
       <p><small>&copy;2025 NoteShare, All Rights Reserved.</small></p>
     </div>
   </footer>
 </body>
 </html>
+

--- a/templates/about.html
+++ b/templates/about.html
@@ -6,6 +6,6 @@
   <p>ユーザーはアップロードしたファイルをQRコードで共有し、パスワードを設定することで安全に配布できます。</p>
   <h3 class="mt-4">運営者情報</h3>
   <p>運営者: FS!QR運営チーム</p>
-  <p>連絡先: <a href="mailto:contact@example.com">contact@example.com</a></p>
+  <p>お問い合わせ: <a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
 </div>
 {% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -2,7 +2,7 @@
 {% block contents %}
 <div class="container my-5">
   <h2 class="mb-4">お問い合わせ</h2>
-  <p>ご意見・ご質問などがございましたら、以下のメールアドレスまでご連絡ください。</p>
-  <p><a href="mailto:contact@example.com">contact@example.com</a></p>
+  <p>ご意見・ご質問などがございましたら、以下のフォームからお問い合わせください。</p>
+  <p><a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
 </div>
 {% endblock %}

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -66,10 +66,13 @@
         <!-- ナビゲーション -->
         <ul class="nav justify-content-center mb-3">
           <li class="nav-item">
-            <a class="nav-link" href="/">ホーム</a>
+            <a class="nav-link" href="/about">サイト概要</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://project-kk.com/">問い合わせ</a>
+            <a class="nav-link" href="/privacy-policy">プライバシーポリシー</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/contact">お問い合わせ</a>
           </li>
         </ul>
         <!-- /ナビゲーション -->
@@ -79,5 +82,5 @@
       </div>
     </footer>
 
-  </body>
+</body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -64,9 +64,6 @@
         <!-- ナビゲーション -->
         <ul class="nav justify-content-center mb-3">
           <li class="nav-item">
-            <a class="nav-link" href="/">ホーム</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="/about">サイト概要</a>
           </li>
           <li class="nav-item">

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -4,7 +4,8 @@
   <h2 class="mb-4">プライバシーポリシー</h2>
   <p>当サイトでは、Google などの第三者配信事業者が Cookie を使用して、ユーザーの過去のアクセス情報に基づいて広告を配信しています。</p>
   <p>これらの Cookie を利用することで、ユーザーの興味・関心に合わせたパーソナライズド広告が表示される場合があります。</p>
-  <p>ユーザーは <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">Google 広告設定</a> や <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener">aboutads.info</a> のページから、パーソナライズド広告に使用される Cookie を無効にできます。</p>
-  <p>その他、ご不明な点がございましたら <a href="/contact">お問い合わせ</a> ください。</p>
-</div>
+    <p>ユーザーは <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">Google 広告設定</a> や <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener">aboutads.info</a> のページから、パーソナライズド広告に使用される Cookie を無効にできます。</p>
+    <p>アップロードされたファイルは暗号化された状態で一時的に保存され、一定期間後に自動的に削除されます。ファイルを第三者と共有することはありません。</p>
+    <p>その他、ご不明な点がございましたら <a href="/contact">お問い合わせ</a> ください。</p>
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace email addresses with Google Form contact link and update site overview
- Add file handling details in privacy policy
- Show footer links to overview, privacy policy, and contact across layouts

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a02115086c83209ff5107d15743bf4