### PR TITLE
Style info pages with centered rounded boxes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -133,3 +133,15 @@ th { text-align: right; }
 .search-link:hover img {
   transform: scale(1.2);
 }
+
+/* central content box styling for about/privacy/contact pages */
+.info-box {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  border: 1px solid #dedede;
+  border-radius: 15px;
+  background-color: #ffffff;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,11 +1,13 @@
 {% extends "layout.html" %}
 {% block contents %}
 <div class="container my-5">
-  <h2 class="mb-4">サイト概要</h2>
-  <p>FS!QRは、ファイルをQRコードを通じて簡単に共有できるサービスです。</p>
-  <p>ユーザーはアップロードしたファイルをQRコードで共有し、パスワードを設定することで安全に配布できます。</p>
-  <h3 class="mt-4">運営者情報</h3>
-  <p>運営者: FS!QR運営チーム</p>
-  <p>お問い合わせ: <a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
+  <div class="info-box">
+    <h2 class="mb-4">サイト概要</h2>
+    <p>FS!QRは、ファイルをQRコードを通じて簡単に共有できるサービスです。</p>
+    <p>ユーザーはアップロードしたファイルをQRコードで共有し、パスワードを設定することで安全に配布できます。</p>
+    <h3 class="mt-4">運営者情報</h3>
+    <p>運営者: FS!QR運営チーム</p>
+    <p>お問い合わせ: <a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
+  </div>
 </div>
 {% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,8 +1,10 @@
 {% extends "layout.html" %}
 {% block contents %}
 <div class="container my-5">
-  <h2 class="mb-4">お問い合わせ</h2>
-  <p>ご意見・ご質問などがございましたら、以下のフォームからお問い合わせください。</p>
-  <p><a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
+  <div class="info-box">
+    <h2 class="mb-4">お問い合わせ</h2>
+    <p>ご意見・ご質問などがございましたら、以下のフォームからお問い合わせください。</p>
+    <p><a href="https://docs.google.com/forms/d/187L9ICmitA7QHKMrwSGRcWQ2HPUfaoHKmXae2hcjbG8/edit?hl=ja" target="_blank" rel="noopener">お問い合わせフォーム</a></p>
+  </div>
 </div>
 {% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,11 +1,13 @@
 {% extends "layout.html" %}
 {% block contents %}
 <div class="container my-5">
-  <h2 class="mb-4">プライバシーポリシー</h2>
-  <p>当サイトでは、Google などの第三者配信事業者が Cookie を使用して、ユーザーの過去のアクセス情報に基づいて広告を配信しています。</p>
-  <p>これらの Cookie を利用することで、ユーザーの興味・関心に合わせたパーソナライズド広告が表示される場合があります。</p>
+  <div class="info-box">
+    <h2 class="mb-4">プライバシーポリシー</h2>
+    <p>当サイトでは、Google などの第三者配信事業者が Cookie を使用して、ユーザーの過去のアクセス情報に基づいて広告を配信しています。</p>
+    <p>これらの Cookie を利用することで、ユーザーの興味・関心に合わせたパーソナライズド広告が表示される場合があります。</p>
     <p>ユーザーは <a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">Google 広告設定</a> や <a href="https://www.aboutads.info/choices/" target="_blank" rel="noopener">aboutads.info</a> のページから、パーソナライズド広告に使用される Cookie を無効にできます。</p>
     <p>アップロードされたファイルは暗号化された状態で一時的に保存され、一定期間後に自動的に削除されます。ファイルを第三者と共有することはありません。</p>
     <p>その他、ご不明な点がございましたら <a href="/contact">お問い合わせ</a> ください。</p>
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Center and add rounded bordered boxes around about, privacy policy, and contact page contents
- Introduce reusable `.info-box` styling for consistent appearance

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a022d4d1cc8320adfd44ddbb89b0b4