### PR TITLE
Ensure upload directory exists and add home links

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,8 @@ MASTER_PW = admin_key
 
 BASE_DIR = os.path.dirname(__file__)
 STATIC = os.path.join(BASE_DIR, 'static', 'upload')
+# Ensure the upload directory exists to avoid FileNotFoundError
+os.makedirs(STATIC, exist_ok=True)
 
 app.register_blueprint(group_bp)
 app.register_blueprint(note_bp)

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -66,6 +66,9 @@
         <!-- ナビゲーション -->
         <ul class="nav justify-content-center mb-3">
           <li class="nav-item">
+            <a class="nav-link" href="/group">ホーム</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="/about">サイト概要</a>
           </li>
           <li class="nav-item">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -64,6 +64,9 @@
         <!-- ナビゲーション -->
         <ul class="nav justify-content-center mb-3">
           <li class="nav-item">
+            <a class="nav-link" href="/fs-qr">ホーム</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="/about">サイト概要</a>
           </li>
           <li class="nav-item">


### PR DESCRIPTION
## Summary
- create missing `static/upload` directory on startup to prevent upload errors
- add "ホーム" links to main and group footers for easier navigation

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a02fde71b8832095d46fa5339eb6ac