### PR TITLE
Add SEO metadata across all services

### DIFF
--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -3,6 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="NoteShareはFS!QRのリアルタイムノート共有サービス。共同編集でノートを共有できます。" />
+  <meta name="keywords" content="ノート共有, リアルタイム編集, コラボレーション, FS QR Note" />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="ja_JP" />
+  <meta property="og:site_name" content="FS!QR Note" />
+  <meta property="og:title" content="FS!QR Note | リアルタイムノート共有" />
+  <meta property="og:description" content="複数人で同時編集できるノート共有サービス。" />
+  <meta property="og:url" content="{{ request.url }}" />
+  <meta property="og:image" content="{{staticfile('note_logo.png')}}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="FS!QR Note | リアルタイムノート共有" />
+  <meta name="twitter:description" content="リアルタイムでノートを共同編集し共有できます。" />
+  <meta name="twitter:image" content="{{staticfile('note_logo.png')}}" />
+  <link rel="canonical" href="{{ request.url }}" />
   <link rel="stylesheet" href="{{staticfile('bootstrap.min.css')}}">
   <link rel="stylesheet" href="{{staticfile('style.css')}}">
   <link rel="icon" href="{{staticfile('note_favicon.ico')}}">
@@ -13,6 +28,16 @@
   <link href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
         rel="stylesheet">
   <title>Realtime Note Share</title>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "FS!QR Note",
+    "url": "{{ request.url_root }}note",
+    "description": "FS!QRのリアルタイムノート共有サービス。複数人でノートを共同編集できます。"
+  }
+  </script>
 </head>
 
 <body>

--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -3,6 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="FS!QR Noteのメニュー。ノートルームの作成や検索を行うページです。" />
+    <meta name="keywords" content="ノート共有, ルーム作成, リアルタイム, FS QR" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:site_name" content="FS!QR Note" />
+    <meta property="og:title" content="ノート共有メニュー | FS!QR" />
+    <meta property="og:description" content="ノートルームの作成や検索ができるメニュー。" />
+    <meta property="og:url" content="{{ request.url }}" />
+    <meta property="og:image" content="{{staticfile('note_logo.png')}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="ノート共有メニュー | FS!QR" />
+    <meta name="twitter:description" content="リアルタイムでノートを共有するルームを作成・検索できます。" />
+    <meta name="twitter:image" content="{{staticfile('note_logo.png')}}" />
+    <link rel="canonical" href="{{ request.url }}" />
     <title>ファイル管理</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">
@@ -11,6 +26,15 @@
     <!-- アイコン用 FontAwesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <!-- カスタムCSS -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "FS!QR Note",
+      "url": "{{ request.url_root }}note",
+      "description": "FS!QR Noteのメニュー。ノートルームの作成や検索を行うページです。"
+    }
+    </script>
     <style>
         body, html {
             height: 100%;

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -3,6 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="FS!QR Groupのメニュー。グループを作成・検索してファイルを共有できます。" />
+    <meta name="keywords" content="グループ管理, ファイル共有, ルーム検索, FS QR" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:site_name" content="FS!QR Group" />
+    <meta property="og:title" content="グループ管理メニュー | FS!QR" />
+    <meta property="og:description" content="グループを作成・検索してファイルを共有するメニュー。" />
+    <meta property="og:url" content="{{ request.url }}" />
+    <meta property="og:image" content="{{staticfile('group_logo.png')}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="グループ管理メニュー | FS!QR" />
+    <meta name="twitter:description" content="グループルームの作成と検索ができるメニューです。" />
+    <meta name="twitter:image" content="{{staticfile('group_logo.png')}}" />
+    <link rel="canonical" href="{{ request.url }}" />
     <title>グループ管理</title>
     <link rel="icon" href="{{staticfile('favicon2.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon2.png')}}">
@@ -10,6 +25,15 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- アイコン用 FontAwesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "FS!QR Group",
+      "url": "{{ request.url_root }}group",
+      "description": "FS!QR Groupのメニュー。グループを作成・検索してファイルを共有できます。"
+    }
+    </script>
 
     <style>
         body, html {

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -3,6 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="FS!QRのファイル共有メニュー。ファイルのアップロードや検索が可能です。" />
+    <meta name="keywords" content="ファイル管理, ファイル共有, QRコード, FS QR" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:site_name" content="FS!QR" />
+    <meta property="og:title" content="ファイル管理メニュー | FS!QR" />
+    <meta property="og:description" content="ファイルをアップロード・検索できるFS!QRのメニュー。" />
+    <meta property="og:url" content="{{ request.url }}" />
+    <meta property="og:image" content="{{staticfile('logo.png')}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="ファイル管理メニュー | FS!QR" />
+    <meta name="twitter:description" content="QRコードでのファイル共有や検索が簡単に行えます。" />
+    <meta name="twitter:image" content="{{staticfile('logo.png')}}" />
+    <link rel="canonical" href="{{ request.url }}" />
     <title>ファイル管理</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">
@@ -11,6 +26,15 @@
     <!-- アイコン用 FontAwesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <!-- カスタムCSS -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "FS!QR",
+      "url": "{{ request.url_root }}fs-qr",
+      "description": "FS!QRのファイル共有メニュー。ファイルのアップロードや検索が可能です。"
+    }
+    </script>
     <style>
         body, html {
             height: 100%;

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -1,8 +1,23 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="GroupはFS!QRのグループ共有サービス。ルームを作成して複数ファイルを簡単に共有できます。" />
+    <meta name="keywords" content="グループ共有, ファイル共有, ルーム作成, FS QR Group" />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:site_name" content="FS!QR Group" />
+    <meta property="og:title" content="FS!QR Group | グループでファイル共有" />
+    <meta property="og:description" content="ルームを作成して安全に複数ファイルを共有できるグループサービス。" />
+    <meta property="og:url" content="{{ request.url }}" />
+    <meta property="og:image" content="{{staticfile('group_logo.png')}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="FS!QR Group | グループでファイル共有" />
+    <meta name="twitter:description" content="ルームを作成し、グループでファイルを簡単に共有できます。" />
+    <meta name="twitter:image" content="{{staticfile('group_logo.png')}}" />
+    <link rel="canonical" href="{{ request.url }}" />
     <link rel="stylesheet" type="text/css" href="{{staticfile('style.css')}}">
     <link rel="stylesheet" href="{{staticfile('bootstrap.min.css')}}">
     <link rel="icon" href="{{staticfile('favicon2.ico')}}">
@@ -14,6 +29,16 @@
       href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
       rel="stylesheet">
     <title>Groupでファイルを共有</title>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "FS!QR Group",
+      "url": "{{ request.url_root }}group",
+      "description": "FS!QRのグループ共有サービス。ルームを作成しファイルを共同管理できます。"
+    }
+    </script>
 
  <!--
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4557554518872474"


### PR DESCRIPTION
## Summary
- Enhance FS!QR file menu with full SEO meta tags and structured data
- Add search-friendly metadata to Group layout and menu
- Optimize Note service pages with Open Graph, Twitter cards, and canonical links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a14924e8e88320bc46679af11e3464