### PR TITLE
Add minimalist footer across FS!QR menus

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -145,3 +145,22 @@ th { text-align: right; }
   text-align: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+/* Simple footer with text-only links */
+.simple-footer {
+  text-align: center;
+  font-size: 0.9rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.simple-footer a {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  margin-bottom: 0.25rem;
+}
+
+.simple-footer a:hover {
+  text-decoration: underline;
+}

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -21,10 +21,11 @@
     <title>グループ管理</title>
     <link rel="icon" href="{{staticfile('favicon2.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon2.png')}}">
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- アイコン用 FontAwesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+      <!-- Bootstrap CSS -->
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+      <!-- アイコン用 FontAwesome -->
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+      <link rel="stylesheet" type="text/css" href="{{staticfile('style.css')}}">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -46,15 +47,17 @@
             background: linear-gradient(135deg, #dbe72f 10%, #026810 100%);
             min-height: 100vh;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
             align-items: center;
             padding: 20px;
         }
         .menu-container {
+            flex: 1;
             display: flex;
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
+            align-items: center;
             padding: 10px; /* 画面端にカードが寄らないよう調整 */
             max-width: 100%; /* 画面幅に収まる */
         }
@@ -141,6 +144,14 @@
                 <a href="/">戻る</a>
             </div>
         </div>
+        <footer class="simple-footer text-white">
+            <a href="/">ホーム</a>
+            <a href="/about">サイト概要</a>
+            <a href="/privacy-policy">プライバシーポリシー</a>
+            <a href="/contact">お問い合わせ</a>
+            <a href="/usage">使い方</a>
+            <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
+        </footer>
     </div>
 
     <!-- Bootstrap JSと依存関係 -->

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -21,11 +21,12 @@
     <title>ファイル管理</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- アイコン用 FontAwesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <!-- カスタムCSS -->
+      <!-- Bootstrap CSS -->
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+      <!-- アイコン用 FontAwesome -->
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+     <link rel="stylesheet" type="text/css" href="{{staticfile('style.css')}}">
+      <!-- カスタムCSS -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -46,15 +47,17 @@
             background: linear-gradient(135deg, #23c3df 10%, #1f27c7 100%);
             min-height: 100vh;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
             align-items: center;
             padding: 20px;
         }
         .menu-container {
+            flex: 1;
             display: flex;
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
+            align-items: center;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }
@@ -141,6 +144,14 @@
                 <a href="/">戻る</a>
             </div>
         </div>
+        <footer class="simple-footer text-white">
+            <a href="/">ホーム</a>
+            <a href="/about">サイト概要</a>
+            <a href="/privacy-policy">プライバシーポリシー</a>
+            <a href="/contact">お問い合わせ</a>
+            <a href="/usage">使い方</a>
+            <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
+        </footer>
     </div>
 
     <!-- Bootstrap JSと依存関係 -->

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -86,31 +86,13 @@
       </div>
     </div>
 
-    <footer class="py-4 bg-dark text-light">
-      <div class="container text-center">
-        <!-- ナビゲーション -->
-        <ul class="nav justify-content-center mb-3">
-          <li class="nav-item">
-            <a class="nav-link" href="/group">ホーム</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/about">サイト概要</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/privacy-policy">プライバシーポリシー</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/contact">お問い合わせ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/usage">使い方</a>
-          </li>
-        </ul>
-        <!-- /ナビゲーション -->
-        <p>
-          <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
-        </p>
-      </div>
+    <footer class="simple-footer">
+      <a href="/">ホーム</a>
+      <a href="/about">サイト概要</a>
+      <a href="/privacy-policy">プライバシーポリシー</a>
+      <a href="/contact">お問い合わせ</a>
+      <a href="/usage">使い方</a>
+      <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
 
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,9 +22,10 @@
   <link rel="icon" href="{{staticfile('favicon3.ico')}}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon3.png')}}">
   <!-- Bootstrap CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <!-- FontAwesome -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- FontAwesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" type="text/css" href="{{staticfile('style.css')}}">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -43,21 +44,24 @@
     }
 
     /* グラデーション背景をコンテナに移動 */
-    .menu-container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
+      .menu-container {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        box-sizing: border-box;
+        padding: 40px 40px calc(40px + env(safe-area-inset-bottom));
+        background: linear-gradient(135deg, #342ae3, #23cf32);
+        background-repeat: no-repeat;
+        background-size: cover;
+      }
 
-      /* ビューポート以上に伸びてもグラデーションは一度だけ */
-      min-height: 100vh;
-      box-sizing: border-box;
-      padding: 40px 40px calc(40px + env(safe-area-inset-bottom));
-
-      background: linear-gradient(135deg, #342ae3, #23cf32);
-      background-repeat: no-repeat;
-      background-size: cover;
-    }
+      .menu-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
 
     .menu-header {
       text-align: center;
@@ -160,30 +164,40 @@
 </head>
 <body>
   <div class="menu-container">
-    <div class="menu-header">
-      <h1>ファイル共有メニュー</h1>
-      <p>利用したいファイル共有方法を選んでください。</p>
+    <div class="menu-content">
+      <div class="menu-header">
+        <h1>ファイル共有メニュー</h1>
+        <p>利用したいファイル共有方法を選んでください。</p>
+      </div>
+      <ul class="menu-list">
+        <li>
+          <a href="/group" class="menu-item group">
+            <i class="fas fa-users"></i>
+            <h3>グループで共有</h3>
+          </a>
+        </li>
+        <li>
+          <a href="/fs-qr" class="menu-item fs-qr">
+            <i class="fas fa-qrcode"></i>
+            <h3>QRコード共有</h3>
+          </a>
+        </li>
+        <li>
+          <a href="/note" class="menu-item note mb-3">
+            <i class="fas fa-pencil-alt"></i>
+            <h3>ノート共有</h3>
+          </a>
+        </li>
+      </ul>
     </div>
-    <ul class="menu-list">
-      <li>
-        <a href="/group" class="menu-item group">
-          <i class="fas fa-users"></i>
-          <h3>グループで共有</h3>
-        </a>
-      </li>
-      <li>
-        <a href="/fs-qr" class="menu-item fs-qr">
-          <i class="fas fa-qrcode"></i>
-          <h3>QRコード共有</h3>
-        </a>
-      </li>
-      <li>
-        <a href="/note" class="menu-item note mb-3">
-          <i class="fas fa-pencil-alt"></i>
-          <h3>ノート共有</h3>
-        </a>
-      </li>
-    </ul>
+    <footer class="simple-footer text-white">
+      <a href="/">ホーム</a>
+      <a href="/about">サイト概要</a>
+      <a href="/privacy-policy">プライバシーポリシー</a>
+      <a href="/contact">お問い合わせ</a>
+      <a href="/usage">使い方</a>
+      <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
+    </footer>
   </div>
 
   <!-- Bootstrap JS -->

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,31 +84,13 @@
       </div>
     </div>
 
-    <footer class="py-4 bg-dark text-light">
-      <div class="container text-center">
-        <!-- ナビゲーション -->
-        <ul class="nav justify-content-center mb-3">
-          <li class="nav-item">
-            <a class="nav-link" href="/fs-qr">ホーム</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/about">サイト概要</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/privacy-policy">プライバシーポリシー</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/contact">お問い合わせ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/usage">使い方</a>
-          </li>
-        </ul>
-        <!-- /ナビゲーション -->
-        <p>
-          <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
-        </p>
-      </div>
+    <footer class="simple-footer">
+      <a href="/">ホーム</a>
+      <a href="/about">サイト概要</a>
+      <a href="/privacy-policy">プライバシーポリシー</a>
+      <a href="/contact">お問い合わせ</a>
+      <a href="/usage">使い方</a>
+      <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
 
   </body>


### PR DESCRIPTION
## Summary
- Replace dark nav footers with simple text-only footers
- Show consistent footer links on top-level menus
- Style footer via shared CSS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a564c9e8c083209c87f388ff088af5