### PR TITLE
Add footers with page-matched colors

### DIFF
--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -25,6 +25,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- アイコン用 FontAwesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" type="text/css" href="{{staticfile('style.css')}}">
     <!-- カスタムCSS -->
     <script type="application/ld+json">
     {
@@ -46,15 +47,17 @@
             background: linear-gradient(135deg, #c2bf20 10%, #1aa866 100%);
             min-height: 100vh;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
             align-items: center;
             padding: 20px;
         }
         .menu-container {
+            flex: 1;
             display: flex;
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
+            align-items: center;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }
@@ -141,6 +144,14 @@
                 <a href="/">戻る</a>
             </div>
         </div>
+        <footer class="simple-footer" style="color:#95d420;text-shadow:0 1px 2px rgba(0,0,0,0.6);">
+            <a href="/">ホーム</a>
+            <a href="/about">サイト概要</a>
+            <a href="/privacy-policy">プライバシーポリシー</a>
+            <a href="/contact">お問い合わせ</a>
+            <a href="/usage">使い方</a>
+            <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
+        </footer>
     </div>
 
     <!-- Bootstrap JSと依存関係 -->

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -144,7 +144,7 @@
                 <a href="/">戻る</a>
             </div>
         </div>
-        <footer class="simple-footer text-white">
+        <footer class="simple-footer" style="color:#dbe72f;text-shadow:0 1px 2px rgba(0,0,0,0.6);">
             <a href="/">ホーム</a>
             <a href="/about">サイト概要</a>
             <a href="/privacy-policy">プライバシーポリシー</a>

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -144,7 +144,7 @@
                 <a href="/">戻る</a>
             </div>
         </div>
-        <footer class="simple-footer text-white">
+        <footer class="simple-footer" style="color:#23c3df;text-shadow:0 1px 2px rgba(0,0,0,0.6);">
             <a href="/">ホーム</a>
             <a href="/about">サイト概要</a>
             <a href="/privacy-policy">プライバシーポリシー</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -190,7 +190,7 @@
         </li>
       </ul>
     </div>
-    <footer class="simple-footer text-white">
+    <footer class="simple-footer" style="color:#ffffff;text-shadow:0 1px 2px rgba(0,0,0,0.6);">
       <a href="/">ホーム</a>
       <a href="/about">サイト概要</a>
       <a href="/privacy-policy">プライバシーポリシー</a>


### PR DESCRIPTION
## Summary
- color-match minimalist footers on menu pages
- ensure group, index, fs-qr, and note menus all share simple link-only footer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a56775ca788320bf82af66bbb6bed9