### PR TITLE
Unify menu card sizes across sections

### DIFF
--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: center;
+            align-items: stretch;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: center;
+            align-items: stretch;
             padding: 10px; /* 画面端にカードが寄らないよう調整 */
             max-width: 100%; /* 画面幅に収まる */
         }

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: center;
+            align-items: stretch;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }


### PR DESCRIPTION
## Summary
- Ensure uniform menu card heights in fs-qr, group, and note menus by stretching cards within their containers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a56b8ed4e48320be1ad67ddfd6cc7c