### PR TITLE
Make group and note menu cards square

### DIFF
--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -64,6 +64,7 @@
         .menu-card {
             flex: 1 1 100%; /* モバイル: フル幅 */
             max-width: 300px;
+            width: 100%;
             aspect-ratio: 1 / 1;
             padding: 20px;
             text-align: center;
@@ -73,6 +74,8 @@
             transition: transform 0.2s ease, box-shadow 0.2s ease;
             display: flex; /* 追加 */
             flex-direction: column; /* 追加 */
+            justify-content: space-between; /* 追加: コンテンツ間の余白を均等に */
+            overflow: hidden; /* 追加: コンテンツのはみ出しを防止 */
         }
         @media (min-width: 576px) { /* スマホ以上 */
             .menu-card {
@@ -106,7 +109,7 @@
         .menu-card p {
             color: #555;
             font-size: 1rem;
-            flex-grow: 1; /* 追加: この要素が利用可能なスペースを埋めるようにする */
+            flex-grow: 0; /* 高さを固定してカードを正方形に保つ */
         }
         .menu-card a {
             display: inline-block;

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -64,6 +64,7 @@
         .menu-card {
             flex: 1 1 100%; /* モバイルでフル幅 */
             max-width: 300px;
+            width: 100%;
             aspect-ratio: 1 / 1;
             padding: 20px;
             text-align: center;
@@ -73,6 +74,8 @@
             transition: transform 0.2s ease, box-shadow 0.2s ease;
             display: flex; /* 追加 */
             flex-direction: column; /* 追加 */
+            justify-content: space-between; /* 追加: コンテンツ間の余白を均等に */
+            overflow: hidden; /* 追加: コンテンツのはみ出しを防止 */
         }
         @media (min-width: 576px) { /* スマホ以上 */
             .menu-card {
@@ -106,7 +109,7 @@
         .menu-card p {
             color: #555;
             font-size: 1rem;
-            flex-grow: 1; /* 追加: この要素が利用可能なスペースを埋めるようにする */
+            flex-grow: 0; /* 高さを固定してカードを正方形に保つ */
         }
         .menu-card a {
             display: inline-block;


### PR DESCRIPTION
## Summary
- Ensure group menu cards maintain a square shape and prevent overflow
- Apply same square-card styling to note menu

## Testing
- `pytest`
- `flake8` *(fails: many style warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a56f179a088320880e16e8e9ff7af5