### PR TITLE
Ensure square menu cards on feature pages

### DIFF
--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: stretch;
+            align-items: center;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: stretch;
+            align-items: center;
             padding: 10px; /* 画面端にカードが寄らないよう調整 */
             max-width: 100%; /* 画面幅に収まる */
         }

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -57,7 +57,7 @@
             gap: 20px;
             flex-wrap: wrap;
             justify-content: center;
-            align-items: stretch;
+            align-items: center;
             padding: 10px;
             max-width: 100%; /* 画面幅に収まる */
         }


### PR DESCRIPTION
## Summary
- Prevent menu cards from stretching vertically on the Group menu
- Prevent menu cards from stretching vertically on the file management menu
- Prevent menu cards from stretching vertically on the Note menu

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5745a9f748320bec57bf22942d81b