### PR TITLE
Unify note footer design

### DIFF
--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -71,27 +71,13 @@
   </div>
 
   <!-- ── Footer ────────────────────────── -->
-  <footer class="py-4 bg-dark text-light">
-    <div class="container text-center">
-      <ul class="nav justify-content-center mb-3">
-          <li class="nav-item">
-            <a class="nav-link" href="/note">ホーム</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/about">サイト概要</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/privacy-policy">プライバシーポリシー</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/contact">お問い合わせ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/usage">使い方</a>
-          </li>
-      </ul>
-      <p><small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small></p>
-    </div>
+  <footer class="simple-footer">
+    <a href="/note">ホーム</a>
+    <a href="/about">サイト概要</a>
+    <a href="/privacy-policy">プライバシーポリシー</a>
+    <a href="/contact">お問い合わせ</a>
+    <a href="/usage">使い方</a>
+    <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Align note pages' footer with the rest of the site by switching to the `simple-footer` style.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6850d3ef08320a345208a2dd64eed