### PR TITLE
Add explanatory articles page and footer link

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,15 @@ def contact():
 def usage():
     return render_template('usage.html')
 
+@app.route('/articles')
+def articles():
+    articles = [
+        {"title": "FS!QRの基本的な使い方", "url": "/usage"},
+        {"title": "QRコード生成の仕組み", "url": "#"},
+        {"title": "セキュリティ対策の概要", "url": "#"},
+    ]
+    return render_template('articles.html', articles=articles)
+
 @app.route('/ads.txt')
 def ads_txt():
     return send_from_directory(app.root_path, 'ads.txt')

--- a/templates/articles.html
+++ b/templates/articles.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block contents %}
+<div class="container my-5">
+  <div class="info-box">
+    <h2 class="mb-4">解説記事</h2>
+    <ul class="text-start">
+      {% for art in articles %}
+      <li><a href="{{ art.url }}">{{ art.title }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -90,6 +90,7 @@
       <a href="/privacy-policy">プライバシーポリシー</a>
       <a href="/contact">お問い合わせ</a>
       <a href="/usage">使い方</a>
+      <a href="/articles">解説記事</a>
       <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
 


### PR DESCRIPTION
## Summary
- add `解説記事` link to footer
- create articles listing page and Flask route

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a68cc6c3408320885083c563319bfd