### PR TITLE
Add explanatory articles page and footer link

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,15 @@ def contact():
 def usage():
     return render_template('usage.html')
 
+@app.route('/articles')
+def articles():
+    articles = [
+        {"title": "FS!QRの基本的な使い方", "url": "/usage"},
+        {"title": "QRコード生成の仕組み", "url": "#"},
+        {"title": "セキュリティ対策の概要", "url": "#"},
+    ]
+    return render_template('articles.html', articles=articles)
+
 @app.route('/ads.txt')
 def ads_txt():
     return send_from_directory(app.root_path, 'ads.txt')

--- a/templates/Group/group.html
+++ b/templates/Group/group.html
@@ -154,6 +154,7 @@
             <a href="/privacy-policy">プライバシーポリシー</a>
             <a href="/contact">お問い合わせ</a>
             <a href="/usage">使い方</a>
+            <a href="/articles">解説記事</a>
             <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
         </footer>
     </div>

--- a/templates/articles.html
+++ b/templates/articles.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block contents %}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h2 class="card-title mb-4 text-center">解説記事</h2>
+          <ul class="list-group list-group-flush">
+            {% for art in articles %}
+            <li class="list-group-item"><a href="{{ art.url }}">{{ art.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/fs-qr.html
+++ b/templates/fs-qr.html
@@ -151,6 +151,7 @@
             <a href="/privacy-policy">プライバシーポリシー</a>
             <a href="/contact">お問い合わせ</a>
             <a href="/usage">使い方</a>
+            <a href="/articles">解説記事</a>
             <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
         </footer>
     </div>

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -92,6 +92,7 @@
       <a href="/privacy-policy">プライバシーポリシー</a>
       <a href="/contact">お問い合わせ</a>
       <a href="/usage">使い方</a>
+      <a href="/articles">解説記事</a>
       <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,6 +196,7 @@
       <a href="/privacy-policy">プライバシーポリシー</a>
       <a href="/contact">お問い合わせ</a>
       <a href="/usage">使い方</a>
+      <a href="/articles">解説記事</a>
       <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
   </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -90,6 +90,7 @@
       <a href="/privacy-policy">プライバシーポリシー</a>
       <a href="/contact">お問い合わせ</a>
       <a href="/usage">使い方</a>
+      <a href="/articles">解説記事</a>
       <small>Copyright &copy;2025 FS!QR, All Rights Reserved.</small>
     </footer>
 


### PR DESCRIPTION
## Summary
- style `articles` listing page with Bootstrap card and list group
- add `解説記事` link to footers across site templates

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a68cc6c3408320885083c563319bfd