### PR TITLE
[codex] スマホQR共有URLのブラウザ遷移を修正

### DIFF
--- a/Group/group_routes_room.py
+++ b/Group/group_routes_room.py
@@ -42,6 +42,39 @@ from .group_storage import UPLOAD_FOLDER
 logger = logging.getLogger(__name__)
 
 
+def _render_group_room(request: Request, room_id: str, record: dict):
+    user_id = record.get("id", "不明")
+    retention_days = record.get("retention_days", 7)
+    share_token = get_group_room_share_token(request, room_id)
+    password = get_group_room_password(request, room_id)
+    share_url = (
+        build_share_url(request, service_key=ServiceKey.GROUP, token=share_token)
+        if share_token
+        else ""
+    )
+    created_at = record.get("time")
+    deletion_date = None
+    if created_at:
+        try:
+            deletion_date = (created_at + timedelta(days=retention_days)).strftime(
+                "%Y-%m-%d %H:%M"
+            )
+        except Exception:
+            deletion_date = None
+
+    return render_template(
+        request,
+        "group_room.html",
+        room_id=room_id,
+        user_id=user_id,
+        password=password,
+        share_url=share_url,
+        retention_days=retention_days,
+        deletion_date=deletion_date,
+        websocket_csrf_token=get_or_create_csrf_token(request),
+    )
+
+
 def register_group_room_access_route(router: APIRouter):
     @router.get("/group/s/{token}", name="group.share_entry")
     async def group_share_entry(request: Request, token: str):
@@ -68,10 +101,7 @@ def register_group_room_access_route(router: APIRouter):
 
         await register_success(SCOPE_GROUP, ip)
         remember_group_room_access(request, room_id, token)
-        return RedirectResponse(
-            build_room_url(request, service_key=ServiceKey.GROUP, resource_id=room_id),
-            status_code=302,
-        )
+        return _render_group_room(request, room_id, record)
 
     @router.get("/group/r/{room_id}", name="group.group_room")
     async def group_room(request: Request, room_id: str):
@@ -92,37 +122,7 @@ def register_group_room_access_route(router: APIRouter):
             )
 
         await register_success(SCOPE_GROUP, ip)
-
-        user_id = record.get("id", "不明")
-        retention_days = record.get("retention_days", 7)
-        share_token = get_group_room_share_token(request, room_id)
-        password = get_group_room_password(request, room_id)
-        share_url = (
-            build_share_url(request, service_key=ServiceKey.GROUP, token=share_token)
-            if share_token
-            else ""
-        )
-        created_at = record.get("time")
-        deletion_date = None
-        if created_at:
-            try:
-                deletion_date = (created_at + timedelta(days=retention_days)).strftime(
-                    "%Y-%m-%d %H:%M"
-                )
-            except Exception:
-                deletion_date = None
-
-        return render_template(
-            request,
-            "group_room.html",
-            room_id=room_id,
-            user_id=user_id,
-            password=password,
-            share_url=share_url,
-            retention_days=retention_days,
-            deletion_date=deletion_date,
-            websocket_csrf_token=get_or_create_csrf_token(request),
-        )
+        return _render_group_room(request, room_id, record)
 
     @router.get("/group/{room_id}/{password}", name="group.group_legacy_room")
     async def group_legacy_room(request: Request, room_id: str, password: str):

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -84,6 +84,37 @@ async def _get_room_if_valid(room_id):
     return meta
 
 
+def _render_note_room(request: Request, room_id: str, meta: dict):
+    retention_days = meta.get("retention_days", 7)
+    expires_at = meta.get("expires_at")
+    deletion_date = None
+    if expires_at:
+        try:
+            deletion_date = expires_at.strftime("%Y-%m-%d %H:%M")
+        except Exception:
+            deletion_date = None
+
+    share_token = get_note_room_share_token(request, room_id)
+    password = get_note_room_password(request, room_id)
+    share_url = (
+        build_share_url(request, service_key=ServiceKey.NOTE, token=share_token)
+        if share_token
+        else ""
+    )
+
+    return render_template(
+        request,
+        "note_room.html",
+        room_id=room_id,
+        user_id=meta["id"],
+        password=password,
+        share_url=share_url,
+        retention_days=retention_days,
+        deletion_date=deletion_date,
+        websocket_csrf_token=get_or_create_csrf_token(request),
+    )
+
+
 @router.get("/note_menu", name="note.note_menu")
 async def note_menu(request: Request):
     canonical = _canonical_redirect(request)
@@ -300,11 +331,13 @@ async def note_share(request: Request, token: str):
         return _gone_response(
             request, "このノートルームは期限切れ、または削除済みです。"
         )
+    row = await nd.get_row(room_id)
+    if not row:
+        return _gone_response(
+            request, "このノートルームは期限切れ、または削除済みです。"
+        )
     remember_note_room_access(request, room_id, share_token=token)
-    return RedirectResponse(
-        build_room_url(request, service_key=ServiceKey.NOTE, resource_id=room_id),
-        status_code=302,
-    )
+    return _render_note_room(request, room_id, meta)
 
 
 @router.get("/note/r/{room_id}", name="note.note_room")
@@ -338,35 +371,7 @@ async def note_room(request: Request, room_id: str):
         )
 
     await register_success(SCOPE_NOTE, ip)
-
-    retention_days = meta.get("retention_days", 7)
-    expires_at = meta.get("expires_at")
-    deletion_date = None
-    if expires_at:
-        try:
-            deletion_date = expires_at.strftime("%Y-%m-%d %H:%M")
-        except Exception:
-            deletion_date = None
-
-    share_token = get_note_room_share_token(request, room_id)
-    password = get_note_room_password(request, room_id)
-    share_url = (
-        build_share_url(request, service_key=ServiceKey.NOTE, token=share_token)
-        if share_token
-        else ""
-    )
-
-    return render_template(
-        request,
-        "note_room.html",
-        room_id=room_id,
-        user_id=meta["id"],
-        password=password,
-        share_url=share_url,
-        retention_days=retention_days,
-        deletion_date=deletion_date,
-        websocket_csrf_token=get_or_create_csrf_token(request),
-    )
+    return _render_note_room(request, room_id, meta)
 
 
 @router.get("/note/{room_id}/{password}", name="note.note_legacy_room")

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -238,10 +238,7 @@ def test_group_share_entry_renders_room_without_redirect(test_client: TestClient
     assert "location" not in response.headers
     html = response.text
     assert "グループファイル共有" in html
-    assert (
-        f'data-share-url="http://testserver/group/s/{share_token}"'
-        in html
-    )
+    assert f'data-share-url="http://testserver/group/s/{share_token}"' in html
 
 
 # --- group_upload: 認証失敗 → 400 ---

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -210,6 +210,40 @@ def test_group_room_uses_modular_scripts_without_legacy_inline_logic(
     assert "function fetchAndDisplayOtherFiles()" not in html
 
 
+def test_group_share_entry_renders_room_without_redirect(test_client: TestClient):
+    """QRの共有URLはスマホのブラウザ移動で壊れないよう直接ルームを表示する"""
+    mock_room = {"id": "tester", "retention_days": 7, "time": None}
+    share_token = "group-share-token-1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    with (
+        patch(
+            "Group.group_routes_room.check_rate_limit",
+            new_callable=AsyncMock,
+            return_value=(True, None, None),
+        ),
+        patch(
+            "Group.group_routes_room.resolve_share_link",
+            new_callable=AsyncMock,
+            return_value={"service_key": "group", "resource_id": "grp999"},
+        ),
+        patch(
+            "Group.group_routes_room.get_room_if_active",
+            new_callable=AsyncMock,
+            return_value=mock_room,
+        ),
+        patch("Group.group_routes_room.register_success", new_callable=AsyncMock),
+    ):
+        response = test_client.get(f"/group/s/{share_token}")
+
+    assert response.status_code == 200
+    assert "location" not in response.headers
+    html = response.text
+    assert "グループファイル共有" in html
+    assert (
+        f'data-share-url="http://testserver/group/s/{share_token}"'
+        in html
+    )
+
+
 # --- group_upload: 認証失敗 → 400 ---
 
 

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -137,6 +137,51 @@ def test_note_room_injects_realtime_limits_into_config(test_client: TestClient):
     assert "api.qrserver.com" not in html
 
 
+def test_note_share_entry_renders_room_without_redirect(test_client: TestClient):
+    """QRの共有URLはスマホのブラウザ移動で壊れないよう直接ルームを表示する"""
+    from datetime import datetime
+
+    share_token = "note-share-token-1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    mock_meta = {
+        "id": "tester",
+        "retention_days": 7,
+        "expires_at": datetime(2026, 1, 8, 0, 0, 0),
+    }
+    mock_row = {
+        "content": "",
+        "updated_at": datetime(2026, 1, 1, 0, 0, 0),
+        "version": 0,
+    }
+    with (
+        patch(
+            "Note.note_app.check_rate_limit",
+            new_callable=AsyncMock,
+            return_value=(True, None, None),
+        ),
+        patch(
+            "Note.note_app.resolve_share_link",
+            new_callable=AsyncMock,
+            return_value={"service_key": "note", "resource_id": "not999"},
+        ),
+        patch(
+            "Note.note_app._get_room_if_valid",
+            new_callable=AsyncMock,
+            return_value=mock_meta,
+        ),
+        patch(
+            "Note.note_app.nd.get_row", new_callable=AsyncMock, return_value=mock_row
+        ),
+        patch("Note.note_app.register_success", new_callable=AsyncMock),
+    ):
+        response = test_client.get(f"/note/s/{share_token}")
+
+    assert response.status_code == 200
+    assert "location" not in response.headers
+    html = response.text
+    assert "リアルタイムノート" in html
+    assert f'data-share-url="http://testserver/note/s/{share_token}"' in html
+
+
 def test_note_direct_not_found(test_client: TestClient):
     """note_direct_access は停止済みなので 410 を返す"""
     response = test_client.get("/note_direct/abc123/000000")


### PR DESCRIPTION
## 概要
- Group / Note の共有URLエントリ（`/group/s/{token}` / `/note/s/{token}`）を、`/r/{room_id}` へリダイレクトせずその場でルーム画面を返すように変更しました。
- ルーム画面描画処理をヘルパー化し、共有URL経由と既存のセッション付き `/r/{room_id}` 経由で同じ表示内容を使うようにしました。
- QR共有URLがリダイレクトしないことを Group / Note のテストで追加確認しました。

## 修正理由
スマホでQRコードを読み取ったあと、QRビューアやアプリ内ブラウザから外部ブラウザへ移動すると、リダイレクト後の `/r/{room_id}` だけが渡り、共有URLで付与したセッションが引き継がれない場合がありました。その結果、Group / Note で「共有URLからアクセスしてください」相当のエラーになり、ルームへ入れませんでした。

FSQR は共有URL上で直接ダウンロード画面を表示していたため、Group / Note も同じ考え方に揃えています。

## 影響
- QRコードやコピー用URLは引き続きトークン付き共有URLです。
- 共有URLをブラウザで開いた時の最終URLが `/s/{token}` のままになるため、スマホの「ブラウザで開く」操作でも同じ共有URLを再利用できます。
- 既存の `/group/r/{room_id}` / `/note/r/{room_id}` は、セッションを持つ利用者向けのアクセスとして維持しています。

## 確認
- `pytest tests/test_fsqr.py tests/test_group.py tests/test_note.py`
- `pytest`
