### PR TITLE
アップロード待機中のプログレスバーを画面中央へ自動スクロール

### DIFF
--- a/static/js/fs_qr_upload/spinner.js
+++ b/static/js/fs_qr_upload/spinner.js
@@ -55,9 +55,23 @@
       }
     }
 
+    function scrollSpinnerIntoCenter() {
+      if (!spinnerRoot || typeof spinnerRoot.scrollIntoView !== 'function') {
+        return;
+      }
+      window.requestAnimationFrame(function () {
+        try {
+          spinnerRoot.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch (error) {
+          spinnerRoot.scrollIntoView(true);
+        }
+      });
+    }
+
     function showSpinner() {
       if (spinnerRoot) {
         spinnerRoot.style.display = 'grid';
+        scrollSpinnerIntoCenter();
       }
     }
 

--- a/static/js/group_room/upload-submit.js
+++ b/static/js/group_room/upload-submit.js
@@ -114,6 +114,19 @@
       return formData;
     }
 
+    function scrollProgressIntoCenter() {
+      if (!uploadProgressContainer || typeof uploadProgressContainer.scrollIntoView !== 'function') {
+        return;
+      }
+      window.requestAnimationFrame(function () {
+        try {
+          uploadProgressContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch (error) {
+          uploadProgressContainer.scrollIntoView(true);
+        }
+      });
+    }
+
     function showUploadProgressStart() {
       core.showElement(uploadProgressContainer);
       core.setProgressScale(uploadProgressBar, 0);
@@ -121,6 +134,7 @@
       resetStatusMessage();
       uploadBtn.disabled = true;
       uploadBtn.textContent = translate('upload.uploading', 'Uploading...');
+      scrollProgressIntoCenter();
     }
 
     function showUploadError(xhr) {


### PR DESCRIPTION
## 概要

GroupとFS!QRのファイルアップロード待機中にプログレスバーが表示されるとき、そのプログレスバー部分が画面の中央になるように自動でスクロールするようにしました。

ファイル選択後にアップロードボタンを押すと、ボタン直下にプログレスバーが現れますが、画面下部に隠れて見えないことがありました。表示と同時に中央へスクロールすることで、進捗が常に見えるようになります。

## 変更内容

- **FS!QR** (`static/js/fs_qr_upload/spinner.js`): `showSpinner()` でプログレスバーカードを表示する際に、画面中央へ自動スクロールする処理を追加。
- **Group** (`static/js/group_room/upload-submit.js`): `showUploadProgressStart()` でプログレスバーを表示する際に、画面中央へ自動スクロールする処理を追加。

いずれも `scrollIntoView({ behavior: 'smooth', block: 'center' })` を使用し、非対応環境向けに `scrollIntoView(true)` のフォールバックを用意。レイアウト確定後にスクロールするよう `requestAnimationFrame` 経由で実行しています。

## テスト

- JS側のロジック変更のみで、既存の自動テスト（バックエンド）への影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)