### PR TITLE
[codex] 関連サービスCTAの可読性とデザインを改善

### DIFF
--- a/Articles/templates/_article_cta.html
+++ b/Articles/templates/_article_cta.html
@@ -99,16 +99,18 @@
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
     border-radius: 999px;
-    background: var(--primary-gradient);
+    background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
     color: #fff;
     font-weight: 600;
     text-decoration: none;
     white-space: nowrap;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 10px 22px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   }
   .article-cta-button:hover {
     transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
+    background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
+    box-shadow: 0 14px 28px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
     color: #fff;
     text-decoration: none;
   }

--- a/Articles/templates/_article_cta.html
+++ b/Articles/templates/_article_cta.html
@@ -16,27 +16,33 @@
     "name": "FS!QR",
     "url": "/fs-qr_menu",
     "icon": "fa-qrcode",
+    "tag": "ファイル共有",
     "desc": "QRコードでかんたん・安全にファイルを共有。アプリ不要、ブラウザだけで完結します。"
   },
   "group": {
     "name": "Group",
     "url": "/group_menu",
     "icon": "fa-users",
+    "tag": "グループ共有",
     "desc": "複数人でファイルをアップロード・ダウンロードできる共有ルーム。授業やチームでの配布に便利です。"
   },
   "note": {
     "name": "Note",
     "url": "/note_menu",
     "icon": "fa-pen-to-square",
+    "tag": "共同編集",
     "desc": "リアルタイムに同時編集できる共有ノート。メモや議事録の共同編集に活用できます。"
   }
 } %}
 {% set _c = _services.get(_svc, _services["fsqr"]) %}
-<aside class="article-cta">
-  <div class="article-cta-icon"><i class="fas {{ _c.icon }}"></i></div>
+<aside class="article-cta article-cta--{{ _svc }}">
+  <div class="article-cta-icon" aria-hidden="true"><i class="fas {{ _c.icon }}"></i></div>
   <div class="article-cta-body">
-    <p class="article-cta-eyebrow">関連サービス</p>
-    <h3 class="article-cta-title">{{ _c.name }}</h3>
+    <div class="article-cta-meta">
+      <span class="article-cta-eyebrow">関連サービス</span>
+      <span class="article-cta-tag">{{ _c.tag }}</span>
+    </div>
+    <h3 class="article-cta-title">{{ _c.name }}を使ってみる</h3>
     <p class="article-cta-desc">{{ _c.desc }}</p>
   </div>
   <a class="article-cta-button" href="{{ _c.url }}">
@@ -45,43 +51,78 @@
 </aside>
 <style>
   .article-cta {
-    display: flex;
+    --article-cta-accent: #075985;
+    --article-cta-accent-strong: #0f766e;
+    --article-cta-accent-soft: rgba(7, 89, 133, 0.09);
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 1.25rem;
+    gap: 1rem 1.25rem;
     margin-top: 2.5rem;
-    padding: 1.75rem;
-    border-radius: 16px;
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.08) 0%, rgba(99, 102, 241, 0.03) 100%);
-    border: 1px solid var(--border-light);
+    padding: 1.35rem 1.45rem;
+    border-radius: 12px;
+    background:
+      linear-gradient(90deg, var(--article-cta-accent-soft) 0 5px, transparent 5px),
+      linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.92) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+  }
+  .article-cta--group {
+    --article-cta-accent: #166534;
+    --article-cta-accent-strong: #15803d;
+    --article-cta-accent-soft: rgba(22, 101, 52, 0.1);
+  }
+  .article-cta--note {
+    --article-cta-accent: #4d7c0f;
+    --article-cta-accent-strong: #3f6212;
+    --article-cta-accent-soft: rgba(77, 124, 15, 0.11);
   }
   .article-cta-icon {
-    flex: 0 0 auto;
     width: 56px;
     height: 56px;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 14px;
-    background: var(--primary-gradient);
+    border-radius: 12px;
+    background: linear-gradient(135deg, var(--article-cta-accent) 0%, var(--article-cta-accent-strong) 100%);
     color: #fff;
     font-size: 1.5rem;
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
   }
   .article-cta-body {
-    flex: 1 1 240px;
     min-width: 0;
   }
+  .article-cta-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-bottom: 0.35rem;
+  }
+  .article-cta-eyebrow,
+  .article-cta-tag {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.45rem;
+  }
   .article-cta-eyebrow {
-    margin: 0 0 0.2rem;
     font-size: 0.75rem;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--primary-color);
+    color: var(--article-cta-accent);
+  }
+  .article-cta-tag {
+    padding: 0 0.5rem;
+    border-radius: 999px;
+    background: var(--article-cta-accent-soft);
+    color: var(--article-cta-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
   }
   .article-cta-title {
     margin: 0 0 0.35rem;
-    font-size: 1.3rem;
+    font-size: 1.25rem;
     font-weight: 700;
     color: var(--text-dark);
     font-family: 'Kaisei Opti', serif;
@@ -103,6 +144,7 @@
     color: #fff;
     font-weight: 600;
     text-decoration: none;
+    border-bottom: 0;
     white-space: nowrap;
     box-shadow: 0 10px 22px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
@@ -113,12 +155,25 @@
     box-shadow: 0 14px 28px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
     color: #fff;
     text-decoration: none;
+    border-bottom-color: transparent;
+  }
+  .info-box-content .article-cta-button,
+  .info-box-content .article-cta-button:hover {
+    border-bottom-color: transparent;
+    color: #fff;
   }
   .article-cta-button i { transition: transform 0.2s ease; }
   .article-cta-button:hover i { transform: translateX(4px); }
 
   @media (max-width: 600px) {
-    .article-cta { padding: 1.5rem; }
-    .article-cta-button { width: 100%; justify-content: center; }
+    .article-cta {
+      grid-template-columns: auto minmax(0, 1fr);
+      padding: 1.25rem;
+    }
+    .article-cta-button {
+      grid-column: 1 / -1;
+      width: 100%;
+      justify-content: center;
+    }
   }
 </style>

--- a/Articles/templates/articles.html
+++ b/Articles/templates/articles.html
@@ -100,7 +100,7 @@
     color: var(--primary-color);
   }
   .filter-chip.active {
-    background: var(--primary-gradient);
+    background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
     color: white;
     border-color: transparent;
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1058,6 +1058,10 @@
     "新しく公開した記事": "Recently published articles",
     "関連サービス": "Related service",
     "今すぐ使ってみる": "Try it now",
+    "FS!QRを使ってみる": "Try FS!QR",
+    "Groupを使ってみる": "Try Group",
+    "Noteを使ってみる": "Try Note",
+    "共同編集": "Collaborative editing",
     "QRコードでかんたん・安全にファイルを共有。アプリ不要、ブラウザだけで完結します。": "Share files easily and securely with QR codes. No app required—everything works in your browser.",
     "複数人でファイルをアップロード・ダウンロードできる共有ルーム。授業やチームでの配布に便利です。": "A shared room where multiple people can upload and download files. Convenient for handing out materials in class or on a team.",
     "リアルタイムに同時編集できる共有ノート。メモや議事録の共同編集に活用できます。": "A shared note you can edit together in real time. Useful for collaborative memos and meeting minutes."

--- a/static/css/02-design-retention.css
+++ b/static/css/02-design-retention.css
@@ -3,6 +3,10 @@
   --primary-color: rgb(0, 109, 128);
   --primary-light: rgba(0, 109, 128, 0.1);
   --primary-gradient: linear-gradient(135deg, rgb(0, 109, 128) 0%, rgb(32, 178, 170) 100%);
+  --primary-action-gradient: linear-gradient(135deg, #075985 0%, #0f766e 100%);
+  --primary-action-gradient-hover: linear-gradient(135deg, #064e7a 0%, #115e59 100%);
+  --primary-action-shadow: rgba(7, 89, 133, 0.28);
+  --primary-action-shadow-hover: rgba(7, 89, 133, 0.38);
   --focus-ring-color: rgba(37, 99, 235, 0.32);
   --focus-ring-strong: 0 0 0 3px var(--focus-ring-color);
   --focus-ring-offset: 0 0 0 3px rgba(255, 255, 255, 0.95), 0 0 0 7px var(--focus-ring-color);

--- a/static/css/03-info-box-contact.css
+++ b/static/css/03-info-box-contact.css
@@ -155,7 +155,7 @@
 .contact-form-link {
   display: inline-flex;
   align-items: center;
-  background: var(--primary-gradient);
+  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
   color: white;
   padding: 1rem 2rem;
   border-radius: 50px;
@@ -168,6 +168,7 @@
 }
 
 .contact-form-link:hover {
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
   color: white;

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -142,7 +142,7 @@
 }
 
 .upload-button-modern {
-  background: var(--primary-gradient);
+  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
   color: white;
   border: none;
   border-radius: 12px;
@@ -151,12 +151,13 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(0, 109, 128, 0.3);
+  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
 }
 
 .upload-button-modern:hover {
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 109, 128, 0.4);
+  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
 }
 
 /* ===============================================
@@ -335,7 +336,7 @@
 }
 
 .modern-btn {
-  background: var(--primary-gradient);
+  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
   color: white;
   border: none;
   border-radius: 12px;
@@ -344,7 +345,7 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(0, 109, 128, 0.3);
+  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -352,8 +353,9 @@
 }
 
 .modern-btn:hover {
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 109, 128, 0.4);
+  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
   color: white;
   text-decoration: none;
 }


### PR DESCRIPTION
## 概要

記事末尾の「関連サービス」CTAについて、ボタンの可読性とカード全体の見た目を改善しました。

## 変更内容

- 白文字が読みやすい濃いアクション用グラデーションを追加
- 関連サービスCTAのボタン、記事フィルタ、共通ボタン系に高コントラスト配色を適用
- 関連サービスCTAにサービス種別ラベルを追加
- CTAカードをグリッドレイアウト化し、アイコン・説明・ボタンの整列を改善
- サービスごとのアクセントカラー、左アクセント、影を追加
- モバイルではCTAボタンが下段フル幅になるよう調整

## 背景

関連サービスの「今すぐ使ってみる」ボタンで、背景色と白文字のコントラストが弱く読みにくい状態でした。あわせて、記事末尾の導線として見つけやすく、サービス内容を把握しやすい表示へ整えています。

## 影響

記事ページの関連サービスCTAと、一部の同系統ボタンの視認性が向上します。機能変更はありません。

## 検証

- `pytest tests/test_articles.py -q`
- 結果: `22 passed`