### PR TITLE
共有ボタンをわかりやすい上矢印ボタンに刷新

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -32,9 +32,6 @@
                       <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1Zm4 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h12v14Z"/></svg>
                       <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>
                     </button>
-                    <button type="button" class="copy-inline-btn share-url-button" data-share-url="{{ url }}" aria-label="URLを共有" style="display: none;">
-                      {{ icons.icon('share', size='md') }}
-                    </button>
                   </span>
                 </span>
               </div>
@@ -102,7 +99,15 @@
             <noscript>QRコードを表示するにはJavaScriptを有効にしてください。</noscript>
           </div>
         </div>
-        
+
+        <!-- 共有ボタン -->
+        <div class="share-action">
+          <button type="button" class="share-action-button share-url-button" data-share-url="{{ url }}" data-share-title="FS!QR ファイル共有" aria-label="このファイルを共有する">
+            {{ icons.icon('arrow_up', size='md') }}
+            <span>このファイルを共有</span>
+          </button>
+        </div>
+
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>

--- a/FSQR/templates/fs_qr_info/_scripts.html
+++ b/FSQR/templates/fs_qr_info/_scripts.html
@@ -112,6 +112,9 @@
           if (urlCopyButton) {
             urlCopyButton.setAttribute('data-copy-value', fullShareUrl);
           }
+          document.querySelectorAll('.share-url-button').forEach((shareButton) => {
+            shareButton.setAttribute('data-share-url', fullShareUrl);
+          });
           renderShareQrCode(fullShareUrl);
         }
       }
@@ -184,25 +187,32 @@
         });
       });
 
-      if (navigator.share) {
-        document.querySelectorAll('.share-url-button').forEach((button) => {
-          button.style.display = 'inline-flex';
-          button.addEventListener('click', async () => {
-            const url = button.getAttribute('data-share-url') || '';
-            if (!url) {
-              return;
-            }
+      document.querySelectorAll('.share-url-button').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const url = button.getAttribute('data-share-url') || '';
+          if (!url) {
+            return;
+          }
+          const title = button.getAttribute('data-share-title') || document.title;
+          if (navigator.share) {
             try {
-              await navigator.share({
-                title: 'FS!QR ファイル共有',
-                url: url
-              });
+              await navigator.share({ title: title, url: url });
             } catch (error) {
+              if (error && error.name === 'AbortError') {
+                return;
+              }
               console.error('Error sharing:', error);
             }
-          });
+            return;
+          }
+          try {
+            await copyTextToClipboard(url);
+            setShareFeedback(translate('share.copied_to_clipboard', 'URLをコピーしました。貼り付けて共有できます。'), 'success');
+          } catch (error) {
+            setShareFeedback(translate('share.copy_manual_error', 'コピーに失敗しました。URLを表示して手動でコピーしてください。'), 'error');
+          }
         });
-      }
+      });
     });
   </script>
 

--- a/FSQR/templates/fs_qr_info/_styles.html
+++ b/FSQR/templates/fs_qr_info/_styles.html
@@ -175,8 +175,7 @@
   min-width: 0;
 }
 
-.copy-url-button,
-.share-url-button {
+.copy-url-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -191,28 +190,66 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.copy-url-button svg,
-.share-url-button svg {
+.copy-url-button svg {
   width: var(--size-action-icon);
   height: var(--size-action-icon);
   flex: none;
 }
 
 .copy-url-button:hover,
-.copy-url-button:focus-visible,
-.share-url-button:hover,
-.share-url-button:focus-visible {
+.copy-url-button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 10px 15px -8px var(--theme-fsqr-copy-shadow);
 }
 
-.copy-url-button:active,
-.share-url-button:active {
+.copy-url-button:active {
   transform: translateY(0);
 }
 
 .copy-url-button.copied {
   background: var(--theme-fsqr-copy-copied-gradient);
+}
+
+/* 目立つ共有ボタン */
+.share-action {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.share-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 52px;
+  padding: 0.85rem 2rem;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--theme-fsqr-gradient-reverse);
+  color: var(--bg-white);
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 12px 20px -10px var(--theme-fsqr-copy-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-action-button svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: none;
+}
+
+.share-action-button:hover,
+.share-action-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 26px -10px var(--theme-fsqr-copy-shadow);
+}
+
+.share-action-button:active {
+  transform: translateY(0);
 }
 
 .share-priority-card {

--- a/Group/templates/group_room/_content.html
+++ b/Group/templates/group_room/_content.html
@@ -24,9 +24,6 @@
                                         <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1Zm4 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h12v14Z"/></svg>
                                         <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>
                                     </button>
-                                    <button type="button" class="copy-inline-btn share-url-button" data-share-url="{{ share_url | e }}" aria-label="URLを共有" style="display: none;">
-                                        {{ icons.icon('share', size='md') }}
-                                    </button>
                                 </span>
                             </span>
                         </div>
@@ -72,6 +69,14 @@
                 <div class="qr-code-container" id="groupShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
                     <noscript>QRコードを表示するにはJavaScriptを有効にしてください。</noscript>
                 </div>
+            </div>
+
+            <!-- 共有ボタン -->
+            <div class="share-action">
+                <button type="button" class="share-action-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR グループ共有" aria-label="このグループを共有する">
+                    {{ icons.icon('arrow_up', size='md') }}
+                    <span>このグループを共有</span>
+                </button>
             </div>
 
             <!-- Upload Area -->

--- a/Group/templates/group_room/_scripts.html
+++ b/Group/templates/group_room/_scripts.html
@@ -99,25 +99,32 @@
         });
     });
 
-    if (navigator.share) {
-        document.querySelectorAll('.share-url-button').forEach((button) => {
-            button.style.display = 'inline-flex';
-            button.addEventListener('click', async () => {
-                const url = button.getAttribute('data-share-url') || '';
-                if (!url) {
-                    return;
-                }
+    document.querySelectorAll('.share-url-button').forEach((button) => {
+        button.addEventListener('click', async () => {
+            const url = button.getAttribute('data-share-url') || '';
+            if (!url) {
+                return;
+            }
+            const title = button.getAttribute('data-share-title') || document.title;
+            if (navigator.share) {
                 try {
-                    await navigator.share({
-                        title: 'FS!QR グループ共有',
-                        url: url
-                    });
+                    await navigator.share({ title: title, url: url });
                 } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        return;
+                    }
                     console.error('Error sharing:', error);
                 }
-            });
+                return;
+            }
+            try {
+                await copyTextToClipboard(url);
+                setShareFeedback(translate('share.copied_to_clipboard', 'URLをコピーしました。貼り付けて共有できます。'), 'success');
+            } catch (error) {
+                setShareFeedback(translate('share.copy_manual_error', 'コピーに失敗しました。URLを表示して手動でコピーしてください。'), 'error');
+            }
         });
-    }
+    });
 </script>
 <script src="{{staticfile('qrcode.min.js')}}"></script>
 <script>

--- a/Group/templates/group_room/_styles.html
+++ b/Group/templates/group_room/_styles.html
@@ -21,8 +21,7 @@
   padding-bottom: 1rem;
 }
 
-.copy-url-button,
-.share-url-button {
+.copy-url-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -37,23 +36,61 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.copy-url-button svg,
-.share-url-button svg {
+.copy-url-button svg {
   width: var(--size-action-icon);
   height: var(--size-action-icon);
   flex: none;
 }
 
 .copy-url-button:hover,
-.copy-url-button:focus-visible,
-.share-url-button:hover,
-.share-url-button:focus-visible {
+.copy-url-button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 10px 15px -8px var(--theme-group-shadow-soft);
 }
 
-.copy-url-button:active,
-.share-url-button:active {
+.copy-url-button:active {
+  transform: translateY(0);
+}
+
+/* 目立つ共有ボタン */
+.share-action {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.share-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 52px;
+  padding: 0.85rem 2rem;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--theme-group-gradient);
+  color: var(--bg-white);
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 12px 20px -10px var(--theme-group-shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-action-button svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: none;
+}
+
+.share-action-button:hover,
+.share-action-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 26px -10px var(--theme-group-shadow-soft);
+}
+
+.share-action-button:active {
   transform: translateY(0);
 }
 

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -25,9 +25,6 @@
                                         <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1Zm4 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h12v14Z"/></svg>
                                         <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>
                                     </button>
-                                    <button type="button" class="copy-inline-btn share-url-button" data-share-url="{{ share_url | e }}" aria-label="URLを共有" style="display: none;">
-                                        {{ icons.icon('share', size='md') }}
-                                    </button>
                                 </span>
                             </span>
                         </div>
@@ -73,6 +70,14 @@
                 <div class="qr-code-container" id="noteShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
                     <noscript>QRコードを表示するにはJavaScriptを有効にしてください。</noscript>
                 </div>
+            </div>
+
+            <!-- 共有ボタン -->
+            <div class="share-action">
+                <button type="button" class="share-action-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR ノート共有" aria-label="このノートを共有する">
+                    {{ icons.icon('arrow_up', size='md') }}
+                    <span>このノートを共有</span>
+                </button>
             </div>
 
             <!-- Editor -->

--- a/Note/templates/note_room_partials/_scripts.html
+++ b/Note/templates/note_room_partials/_scripts.html
@@ -99,25 +99,32 @@
     });
   });
 
-    if (navigator.share) {
-        document.querySelectorAll('.share-url-button').forEach((button) => {
-            button.style.display = 'inline-flex';
-            button.addEventListener('click', async () => {
-                const url = button.getAttribute('data-share-url') || '';
-                if (!url) {
-                    return;
-                }
+    document.querySelectorAll('.share-url-button').forEach((button) => {
+        button.addEventListener('click', async () => {
+            const url = button.getAttribute('data-share-url') || '';
+            if (!url) {
+                return;
+            }
+            const title = button.getAttribute('data-share-title') || document.title;
+            if (navigator.share) {
                 try {
-                    await navigator.share({
-                        title: 'FS!QR ノート共有',
-                        url: url
-                    });
+                    await navigator.share({ title: title, url: url });
                 } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        return;
+                    }
                     console.error('Error sharing:', error);
                 }
-            });
+                return;
+            }
+            try {
+                await copyTextToClipboard(url);
+                setShareFeedback(translate('share.copied_to_clipboard', 'URLをコピーしました。貼り付けて共有できます。'), 'success');
+            } catch (error) {
+                setShareFeedback(translate('share.copy_manual_error', 'コピーに失敗しました。URLを表示して手動でコピーしてください。'), 'error');
+            }
         });
-    }
+    });
 </script>
 
 <script src="{{staticfile('qrcode.min.js')}}"></script>

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -14,8 +14,7 @@
   --usage-header-accent: var(--theme-note-accent);
 }
 
-.copy-url-button,
-.share-url-button {
+.copy-url-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -30,28 +29,66 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.copy-url-button svg,
-.share-url-button svg {
+.copy-url-button svg {
   width: var(--size-action-icon);
   height: var(--size-action-icon);
   flex: none;
 }
 
 .copy-url-button:hover,
-.copy-url-button:focus-visible,
-.share-url-button:hover,
-.share-url-button:focus-visible {
+.copy-url-button:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 10px 15px -8px var(--theme-note-shadow-soft);
 }
 
-.copy-url-button:active,
-.share-url-button:active {
+.copy-url-button:active {
   transform: translateY(0);
 }
 
 .copy-url-button.copied {
   background: var(--theme-note-copy-copied-gradient);
+}
+
+/* 目立つ共有ボタン */
+.share-action {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.share-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 52px;
+  padding: 0.85rem 2rem;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--theme-note-gradient);
+  color: var(--bg-white);
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 12px 20px -10px var(--theme-note-shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-action-button svg {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: none;
+}
+
+.share-action-button:hover,
+.share-action-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 26px -10px var(--theme-note-shadow-soft);
+}
+
+.share-action-button:active {
+  transform: translateY(0);
 }
 
 


### PR DESCRIPTION
## 概要

Note・Group・FS!QR の3画面にある共有ボタンを、よりわかりやすいデザイン・配置・表示に統一しました。アイコンも一般的な「上矢印（箱＋上矢印）」に変更しています。

## 変更前の課題

- ルームID欄の横にある小さなアイコンのみのボタンで目立たない
- `navigator.share` 対応端末でしか表示されず、PCでは非表示
- アイコンがネットワーク状の共有マークでわかりにくい

## 変更内容

- **配置** — 情報カード（ID/URL/QRコード）の直下に、中央寄せで独立配置。情報を確認したあと自然に共有へ進める流れに。
- **デザイン** — テーマカラーのグラデーション・ピル型・ホバーで浮き上がる、ラベル付きの大きなボタン（高さ52px）。
  - `このノートを共有` / `このグループを共有` / `このファイルを共有`
- **アイコン** — 一般的な「箱＋上矢印」アイコン（既存の `arrow_up`）に変更。
- **表示** — 常時表示に変更。`navigator.share` 対応端末ではネイティブ共有シートを開き、非対応端末（PC等）ではURLをクリップボードにコピーするフォールバックを追加。
- **FS!QR** — 復号キーのハッシュ（`#key=...`）付きの完全URLを共有するよう修正し、コピー/QRと同じく実際に開けるリンクを共有。

## 対象ファイル

各画面の content / styles / scripts（計9ファイル）:
- `Note/templates/note_room_partials/`
- `Group/templates/group_room/`
- `FSQR/templates/fs_qr_info/`

## テスト

- `tests/test_note.py` / `tests/test_group.py` のページレンダリングテスト 66 件パス
- ※ `test_group_upload_invalid_auth` は本変更前から失敗している既存の不具合で、本PRとは無関係（テンプレートのみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)