### PR TITLE
共有ボタンをカードヘッダー右上のアイコンボタンに変更＋ダウンロード画面に追加

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -21,7 +21,12 @@
 
         <div class="room-info-container room-info-container--stacked">
           <div class="room-info-card">
-            <div class="room-info-header">ダウンロード先の情報</div>
+            <div class="room-info-header">
+              <span class="room-info-header-title">ダウンロード先の情報</span>
+              <button type="button" class="room-info-share-button share-url-button" data-share-url="{{ url }}" data-share-title="FS!QR ファイル共有" aria-label="このファイルを共有する" title="共有">
+                {{ icons.icon('arrow_up', size='md') }}
+              </button>
+            </div>
             <div class="room-info-body">
               <div class="room-info-row">
                 <span class="room-info-label">ID</span>
@@ -100,14 +105,6 @@
           </div>
         </div>
 
-        <!-- 共有ボタン -->
-        <div class="share-action">
-          <button type="button" class="share-action-button share-url-button" data-share-url="{{ url }}" data-share-title="FS!QR ファイル共有" aria-label="このファイルを共有する">
-            {{ icons.icon('arrow_up', size='md') }}
-            <span>このファイルを共有</span>
-          </button>
-        </div>
-
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>
@@ -118,6 +115,7 @@
     {% else %}
     <div class="card-body info-box-content">
       <div class="text-center info-content-inner">
+        <div id="shareFeedback" class="share-feedback" role="status" aria-live="polite"></div>
         <div class="share-priority-card">
           <strong>この画面を開けていれば受け取り準備は完了です</strong>
           共有リンクから開いた場合は、追加の入力なしでそのままダウンロードできます。
@@ -125,7 +123,12 @@
 
         <div class="room-info-container room-info-container--stacked">
           <div class="room-info-card">
-            <div class="room-info-header">ファイル情報</div>
+            <div class="room-info-header">
+              <span class="room-info-header-title">ファイル情報</span>
+              <button type="button" class="room-info-share-button share-url-button" data-share-title="FS!QR ファイル共有" aria-label="このファイルを共有する" title="共有">
+                {{ icons.icon('arrow_up', size='md') }}
+              </button>
+            </div>
             <div class="room-info-body">
               <div class="room-info-row">
                 <span class="room-info-label">ID</span>

--- a/FSQR/templates/fs_qr_info/_scripts.html
+++ b/FSQR/templates/fs_qr_info/_scripts.html
@@ -189,7 +189,7 @@
 
       document.querySelectorAll('.share-url-button').forEach((button) => {
         button.addEventListener('click', async () => {
-          const url = button.getAttribute('data-share-url') || '';
+          const url = button.getAttribute('data-share-url') || window.location.href;
           if (!url) {
             return;
           }

--- a/FSQR/templates/fs_qr_info/_styles.html
+++ b/FSQR/templates/fs_qr_info/_styles.html
@@ -210,48 +210,6 @@
   background: var(--theme-fsqr-copy-copied-gradient);
 }
 
-/* 目立つ共有ボタン */
-.share-action {
-  display: flex;
-  justify-content: center;
-  margin-top: 1.5rem;
-}
-
-.share-action-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  min-height: 52px;
-  padding: 0.85rem 2rem;
-  border: none;
-  border-radius: var(--radius-pill);
-  background: var(--theme-fsqr-gradient-reverse);
-  color: var(--bg-white);
-  font-size: 1.05rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  box-shadow: 0 12px 20px -10px var(--theme-fsqr-copy-shadow);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.share-action-button svg {
-  width: 1.4rem;
-  height: 1.4rem;
-  flex: none;
-}
-
-.share-action-button:hover,
-.share-action-button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 26px -10px var(--theme-fsqr-copy-shadow);
-}
-
-.share-action-button:active {
-  transform: translateY(0);
-}
-
 .share-priority-card {
   margin-bottom: 1rem;
   padding: 1rem 1.1rem 0.9rem;

--- a/Group/templates/group_room/_content.html
+++ b/Group/templates/group_room/_content.html
@@ -13,7 +13,12 @@
             <!-- Room Info + QR Code -->
             <div class="room-info-container">
                 <div class="room-info-card">
-                    <div class="room-info-header">Room情報</div>
+                    <div class="room-info-header">
+                        <span class="room-info-header-title">Room情報</span>
+                        <button type="button" class="room-info-share-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR グループ共有" aria-label="このグループを共有する" title="共有">
+                            {{ icons.icon('arrow_up', size='md') }}
+                        </button>
+                    </div>
                     <div class="room-info-body">
                         <div class="room-info-row">
                             <span class="room-info-label">ルームID</span>
@@ -69,14 +74,6 @@
                 <div class="qr-code-container" id="groupShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
                     <noscript>QRコードを表示するにはJavaScriptを有効にしてください。</noscript>
                 </div>
-            </div>
-
-            <!-- 共有ボタン -->
-            <div class="share-action">
-                <button type="button" class="share-action-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR グループ共有" aria-label="このグループを共有する">
-                    {{ icons.icon('arrow_up', size='md') }}
-                    <span>このグループを共有</span>
-                </button>
             </div>
 
             <!-- Upload Area -->

--- a/Group/templates/group_room/_styles.html
+++ b/Group/templates/group_room/_styles.html
@@ -52,48 +52,6 @@
   transform: translateY(0);
 }
 
-/* 目立つ共有ボタン */
-.share-action {
-  display: flex;
-  justify-content: center;
-  margin-top: 1.5rem;
-}
-
-.share-action-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  min-height: 52px;
-  padding: 0.85rem 2rem;
-  border: none;
-  border-radius: var(--radius-pill);
-  background: var(--theme-group-gradient);
-  color: var(--bg-white);
-  font-size: 1.05rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  box-shadow: 0 12px 20px -10px var(--theme-group-shadow-soft);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.share-action-button svg {
-  width: 1.4rem;
-  height: 1.4rem;
-  flex: none;
-}
-
-.share-action-button:hover,
-.share-action-button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 26px -10px var(--theme-group-shadow-soft);
-}
-
-.share-action-button:active {
-  transform: translateY(0);
-}
-
 .copy-url-button.copied {
   background: var(--theme-group-copy-copied-gradient);
 }

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -14,7 +14,12 @@
             <!-- Room Info + QR Code -->
             <div class="room-info-container">
                 <div class="room-info-card">
-                    <div class="room-info-header">Room情報</div>
+                    <div class="room-info-header">
+                        <span class="room-info-header-title">Room情報</span>
+                        <button type="button" class="room-info-share-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR ノート共有" aria-label="このノートを共有する" title="共有">
+                            {{ icons.icon('arrow_up', size='md') }}
+                        </button>
+                    </div>
                     <div class="room-info-body">
                         <div class="room-info-row">
                             <span class="room-info-label">ルームID</span>
@@ -70,14 +75,6 @@
                 <div class="qr-code-container" id="noteShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
                     <noscript>QRコードを表示するにはJavaScriptを有効にしてください。</noscript>
                 </div>
-            </div>
-
-            <!-- 共有ボタン -->
-            <div class="share-action">
-                <button type="button" class="share-action-button share-url-button" data-share-url="{{ share_url | e }}" data-share-title="FS!QR ノート共有" aria-label="このノートを共有する">
-                    {{ icons.icon('arrow_up', size='md') }}
-                    <span>このノートを共有</span>
-                </button>
             </div>
 
             <!-- Editor -->

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -49,48 +49,6 @@
   background: var(--theme-note-copy-copied-gradient);
 }
 
-/* 目立つ共有ボタン */
-.share-action {
-  display: flex;
-  justify-content: center;
-  margin-top: 1.5rem;
-}
-
-.share-action-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  min-height: 52px;
-  padding: 0.85rem 2rem;
-  border: none;
-  border-radius: var(--radius-pill);
-  background: var(--theme-note-gradient);
-  color: var(--bg-white);
-  font-size: 1.05rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  box-shadow: 0 12px 20px -10px var(--theme-note-shadow-soft);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.share-action-button svg {
-  width: 1.4rem;
-  height: 1.4rem;
-  flex: none;
-}
-
-.share-action-button:hover,
-.share-action-button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 26px -10px var(--theme-note-shadow-soft);
-}
-
-.share-action-button:active {
-  transform: translateY(0);
-}
-
 
 /* Clean room info values */
 .room-info-value-row {

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -182,8 +182,12 @@
 }
 
 .room-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   color: white;
-  padding: 0.7rem 1.25rem;
+  padding: 0.55rem 0.7rem 0.55rem 1.25rem;
   font-weight: 600;
   font-size: 0.85rem;
   letter-spacing: 0.05em;
@@ -192,6 +196,39 @@
   border-top-right-radius: inherit;
   position: relative;
   isolation: isolate;
+}
+
+/* カードヘッダー右上のアイコンのみ共有ボタン */
+.room-info-share-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.room-info-share-button svg {
+  width: 18px;
+  height: 18px;
+  flex: none;
+}
+
+.room-info-share-button:hover,
+.room-info-share-button:focus-visible {
+  background: rgba(255, 255, 255, 0.38);
+  transform: translateY(-1px);
+}
+
+.room-info-share-button:active {
+  transform: translateY(0);
 }
 
 .room-info-header::before {


### PR DESCRIPTION
## 概要

共有ボタンの配置・形状を見直し、対応画面を追加しました（#150 のフォローアップ）。

## 変更内容

### 1. カードヘッダー右上のアイコンのみボタンに変更
- ID・パスワード・URL などが並ぶ情報カードの**ヘッダー右上**（「ルーム情報」「ファイル情報」などのタイトルと同じ高さ）に配置。
- **文字なしのアイコンのみ**の円形ボタン（上矢印アイコン `arrow_up`）。ヘッダーのグラデーション上で見やすい半透明の白ボタン。
- `#150` で追加していたカード下部のラベル付き大ボタンは廃止。

### 2. 「ダウンロードできます」画面にも共有ボタンを追加
- これまで共有ボタンが無かった受信側（ダウンロード）画面の「ファイル情報」カードヘッダーにも追加。
- このボタンは現在開いているページのURL（復号キーのフラグメントを含む共有リンク）をそのまま共有します。

### 3. 共通化
- `room-info-header` を flex レイアウト化し、共通クラス `.room-info-share-button` を `static/css/07-modern-components.css` に追加（Note / Group / FS!QR で共通利用）。

## 挙動
- 常時表示。`navigator.share` 対応端末ではネイティブ共有シート、非対応端末（PC等）ではURLをクリップボードにコピーしてフィードバック表示。

## 対象ファイル
- `static/css/07-modern-components.css`（共通ヘッダー＋共有ボタンのスタイル）
- `Note/templates/note_room_partials/_content.html` / `_styles.html`
- `Group/templates/group_room/_content.html` / `_styles.html`
- `FSQR/templates/fs_qr_info/_content.html` / `_styles.html` / `_scripts.html`

## テスト
- `tests/test_note.py` / `tests/test_group.py` / `tests/test_fsqr.py` 計 100 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)