### PR TITLE
スマホ表示時に設定モーダルが自動でスクロール下部へ移動する問題を修正

### DIFF
--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -362,6 +362,10 @@
       syncTogglesFromStoredConsent();
       settingsBackAction = options.backAction || 'summary';
       switchView(overlay, 'settings');
+      const settingsBody = overlay.querySelector('.cookie-consent-settings-body');
+      if (settingsBody) {
+        settingsBody.scrollTop = 0;
+      }
       focusOnTarget(settingsFocus || toggles[0]);
     }
 

--- a/templates/cookie-consent.html
+++ b/templates/cookie-consent.html
@@ -121,7 +121,14 @@
                   <option value="{{ option.code }}" {% if option.code == current_language %}selected{% endif %}>{{ option.label }}</option>
                 {% endfor %}
               </select>
-              <button type="button" class="lang-select-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="{{ t('settings.language.title') }}">
+              <button
+                type="button"
+                class="lang-select-trigger"
+                aria-haspopup="listbox"
+                aria-expanded="false"
+                aria-label="{{ t('settings.language.title') }}"
+                data-cookie-consent-settings-focus
+              >
                 <span class="lang-select-flag-current" aria-hidden="true"></span>
                 <span class="lang-select-label-current"></span>
                 <svg class="lang-select-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
@@ -156,7 +163,6 @@
                 type="checkbox"
                 data-cookie-consent-toggle="analytics"
                 aria-label="{{ t('settings.cookie.analytics.aria') }}"
-                data-cookie-consent-settings-focus
               />
               <span class="cookie-consent-toggle-slider" aria-hidden="true"></span>
             </span>


### PR DESCRIPTION
### 概要
スマートフォンなどの縦長画面で設定モーダルを開いた際、モーダルが自動的に下部までスクロールしてしまい、言語選択を行うためにユーザーが手動で上方向へスクロールし直さなければならない問題を修正しました。

### 原因
設定モーダル内の `analytics` クッキーのチェックボックス（モーダルの下部付近）に `data-cookie-consent-settings-focus` 属性が付与されていたため、モーダル表示時にその要素へ自動フォーカスが当たり、ブラウザによって下部へとスクロールされていました。

### 変更内容
1. **フォーカス対象の変更 (`templates/cookie-consent.html`):**
   - 設定モーダル下部にある `analytics` トグル入力要素から `data-cookie-consent-settings-focus` 属性を削除しました。
   - モーダル最上部にある言語選択（`.lang-select-trigger` ボタン）に `data-cookie-consent-settings-focus` 属性を付与しました。
2. **スクロール位置のリセット (`static/cookie-consent.js`):**
   - 設定モーダル表示時（`showSettingsView` 呼び出し時）に、モーダルのスクロールコンテナ（`.cookie-consent-settings-body`）の `scrollTop` を `0` に明示的にリセットし、常に最上部から表示が始まるように調整しました。

### 動作確認・検証
- モバイルビューポートにおいて「設定」モーダルを開いた際、モーダルの最上部（言語選択部分）が最初に表示され、余計な自動スクロールが発生しないことを確認しました。
