### PR TITLE
日本語以外の言語でボタンが押せない・QRコードが表示されない不具合を修正

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -635,14 +635,20 @@ def _apply_phrase_replacements(content: str, phrases: dict[str, Any]) -> str:
     last = 0
     for block in _PROTECTED_BLOCK_RE.finditer(content):
         # Regular HTML before the protected block is translated normally.
-        result.append(_replace_phrases_in_html(content[last : block.start()], sources, phrases))
-        result.append(_replace_phrases_in_protected_block(block.group(0), sources, phrases))
+        result.append(
+            _replace_phrases_in_html(content[last : block.start()], sources, phrases)
+        )
+        result.append(
+            _replace_phrases_in_protected_block(block.group(0), sources, phrases)
+        )
         last = block.end()
     result.append(_replace_phrases_in_html(content[last:], sources, phrases))
     return "".join(result)
 
 
-def _replace_phrases_in_html(segment: str, sources: list[str], phrases: dict[str, Any]) -> str:
+def _replace_phrases_in_html(
+    segment: str, sources: list[str], phrases: dict[str, Any]
+) -> str:
     if not segment:
         return segment
     for source in sources:

--- a/i18n.py
+++ b/i18n.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 from functools import lru_cache
-from html import escape
 from typing import Any
 
 from fastapi import Request
@@ -281,6 +280,17 @@ _GEO_REGION_RE = re.compile(
 )
 _GEO_PLACENAME_RE = re.compile(
     r"<meta\s+name=[\"']geo\.placename[\"']\s+content=[\"'][^\"']*[\"']", re.I
+)
+# <script>/<style> blocks are protected from plain phrase replacement: blindly
+# substituting a Japanese source string that happens to live inside JavaScript or
+# CSS can inject quote characters from the translation (e.g. French "Copier l'URL")
+# and break the surrounding string literal, which kills the whole block. When a
+# block stops executing, buttons stop responding and QR codes never render.
+_PROTECTED_BLOCK_RE = re.compile(
+    r"<(?P<tag>script|style)\b[^>]*>.*?</(?P=tag)\s*>", re.I | re.S
+)
+_LD_JSON_OPEN_RE = re.compile(
+    r"<script\b[^>]*\btype=[\"']application/ld\+json[\"']", re.I
 )
 
 
@@ -598,16 +608,59 @@ def translate_rendered_html(content: str, language: str) -> str:
         fallback_phrases = translations.get(fallback_language, {}).get("phrases", {})
         if isinstance(fallback_phrases, dict):
             phrases.update(fallback_phrases)
-    language_phrases = translations.get(language, {}).get("phrases", {})
+    language_phrases = translations.get(normalized_language, {}).get("phrases", {})
     if isinstance(language_phrases, dict):
         phrases.update(language_phrases)
     if not phrases:
         return content
 
-    for source in sorted(phrases, key=len, reverse=True):
-        translated = phrases.get(source)
-        if not isinstance(translated, str):
-            continue
-        content = content.replace(source, translated)
-        content = content.replace(escape(source), escape(translated))
-    return content
+    return _apply_phrase_replacements(content, phrases)
+
+
+def _json_string_escape(text: str) -> str:
+    """Escape a value for safe embedding inside a JSON string literal."""
+    return json.dumps(text, ensure_ascii=False)[1:-1]
+
+
+def _apply_phrase_replacements(content: str, phrases: dict[str, Any]) -> str:
+    sources = [
+        source
+        for source in sorted(phrases, key=len, reverse=True)
+        if isinstance(phrases.get(source), str)
+    ]
+    if not sources:
+        return content
+
+    result: list[str] = []
+    last = 0
+    for block in _PROTECTED_BLOCK_RE.finditer(content):
+        # Regular HTML before the protected block is translated normally.
+        result.append(_replace_phrases_in_html(content[last : block.start()], sources, phrases))
+        result.append(_replace_phrases_in_protected_block(block.group(0), sources, phrases))
+        last = block.end()
+    result.append(_replace_phrases_in_html(content[last:], sources, phrases))
+    return "".join(result)
+
+
+def _replace_phrases_in_html(segment: str, sources: list[str], phrases: dict[str, Any]) -> str:
+    if not segment:
+        return segment
+    for source in sources:
+        segment = segment.replace(source, phrases[source])
+    return segment
+
+
+def _replace_phrases_in_protected_block(
+    block: str, sources: list[str], phrases: dict[str, Any]
+) -> str:
+    if not _LD_JSON_OPEN_RE.match(block):
+        # Executable <script> / <style>: never substitute. User-facing strings in
+        # these blocks are localized at runtime via window.FSQR_I18N (see
+        # templates/cookie-consent.html), so the Japanese source text is only an
+        # inert fallback here.
+        return block
+    # JSON-LD structured data: still translate, but escape each translation so the
+    # embedded JSON stays syntactically valid even when it contains quotes.
+    for source in sources:
+        block = block.replace(source, _json_string_escape(phrases[source]))
+    return block

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -183,6 +183,43 @@ def test_translate_rendered_html_updates_language_metadata():
     assert "الرئيسية" in translated_ar
 
 
+def test_translate_rendered_html_does_not_corrupt_script_blocks():
+    """Phrase replacement must never rewrite text inside <script>/<style>.
+
+    The French translation of "URLをコピー" is "Copier l'URL"; injecting that
+    apostrophe into a JS string literal used to break the whole <script> block,
+    which stopped buttons from working and QR codes from rendering.
+    """
+    import json
+
+    from i18n import translate_rendered_html
+
+    content = (
+        "<html lang=\"ja\"><head>"
+        '<script type="application/ld+json">'
+        '{"name": "URLをコピー", "inLanguage": "ja-JP"}'
+        "</script></head><body>"
+        '<button class="share">URLをコピー</button>'
+        "<script>\n"
+        "  setShareFeedback('URLをコピーしました。', 'success');\n"
+        "</script>"
+        "</body></html>"
+    )
+
+    translated = translate_rendered_html(content, "fr")
+
+    # Body text outside scripts is still translated.
+    assert ">Copier l'URL<" in translated
+    # The executable script keeps its Japanese fallback literal verbatim, so the
+    # apostrophe is never injected and the block stays valid JavaScript.
+    assert "setShareFeedback('URLをコピーしました。', 'success');" in translated
+    assert "l'URL" not in translated.split("<script>")[-1]
+    # JSON-LD is still translated, but escaped so it remains valid JSON.
+    ld_json = translated.split('application/ld+json">')[1].split("</script>")[0]
+    parsed = json.loads(ld_json)
+    assert parsed["name"] == "Copier l'URL"
+
+
 def test_language_query_only_accepts_supported_language_aliases():
     import i18n
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -195,7 +195,7 @@ def test_translate_rendered_html_does_not_corrupt_script_blocks():
     from i18n import translate_rendered_html
 
     content = (
-        "<html lang=\"ja\"><head>"
+        '<html lang="ja"><head>'
         '<script type="application/ld+json">'
         '{"name": "URLをコピー", "inLanguage": "ja-JP"}'
         "</script></head><body>"


### PR DESCRIPTION
## 概要

日本語以外の一部の言語（フランス語・イタリア語・韓国語・アラビア語など）で、**ボタンがクリックできない**、**QRコードが表示されない**といった不具合がありました。本PRはその原因を修正し、どの言語でも同じように動作するようにします。

## 原因

i18n は「レンダリング済みHTML全体に対してフレーズ辞書を無差別に文字列置換する」方式です（`i18n.py` の `translate_rendered_html`）。この置換が **`<script>` ブロック内の日本語フォールバック文字列にも適用されていました**。

例（フランス語で発生）:

- 実行JSに `setShareFeedback('URLをコピーしました。', ...)` のように**日本語を含む文字列リテラル**がある
- フレーズ辞書に `URLをコピー` → 仏語 `Copier l'URL`（アポストロフィ入り）がある
- 部分一致置換で `'Copier l'URL...'` となり、`'` でJS文字列が途中で閉じて**構文エラー → `<script>` ブロック全体が実行されない**
- 結果、ボタンの `addEventListener` が登録されず、同一ブロック内のQR生成（`renderShareQrCode`）も走らない

該当する実行スクリプトは共有/QRページだけでなく、Group・Note の各 `_scripts.html`、各 `*_access.html`、`all-in-one-gpt` など多数あり、翻訳結果に `'` や `"` を含む言語で広く壊れていました。日本語・英語では当該フレーズに引用符が出ないため無傷で、「特定言語だけ壊れる」症状になっていました。

## 修正内容

`translate_rendered_html` のフレーズ置換を、ブロック種別を意識した処理に変更しました（`i18n.py`）。

- **`<script>` / `<style>` ブロック**: フレーズ置換の対象から除外。内部のユーザー向け文言は実行時に `window.FSQR_I18N.t(key, fallback)` で多言語化される設計のため、日本語ソースは無害なフォールバックに過ぎず置換不要
- **JSON-LD（`application/ld+json`）**: 構造化データなので翻訳は維持しつつ、`json.dumps` でエスケープして常にvalidなJSONに
- **それ以外の本文・属性**: 従来どおり置換（属性への `"` 注入は全22言語で発生しないことを事前検証済み）
- あわせて `translations.get(language, ...)` が正規化前の言語コードを使っていた潜在バグも `normalized_language` に修正

## 検証

- 仏・伊・韓・アラビア語で「実行JSのリテラルが無傷」「本文は翻訳継続」「JSON-LDがvalid」であることをシミュレーションで確認
- 回帰テスト `test_translate_rendered_html_does_not_corrupt_script_blocks` を追加
- 既存テスト（i18n / seo / basic_routes / fsqr / group / note / share_links）計169件すべてパス、ruff・mypy もクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)