### PR TITLE
fix: 日本語以外の言語でスピナーが左にずれる問題を修正

### DIFF
--- a/Group/templates/create_group_room.html
+++ b/Group/templates/create_group_room.html
@@ -331,7 +331,7 @@
 
 <div id="loading-screen" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(6, 10, 20, 0.36); display: none; justify-content: center; align-items: center; z-index: var(--z-overlay);">
     <div style="text-align: center;">
-        <div style="width: 60px; height: 60px; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(34, 197, 94); border-radius: 50%; animation: spin 1s linear infinite;"></div>
+        <div style="width: 60px; height: 60px; margin: 0 auto; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(34, 197, 94); border-radius: 50%; animation: spin 1s linear infinite;"></div>
         <div style="margin-top: 1rem; color: white; font-size: 1.1rem;">処理中...</div>
     </div>
 </div>

--- a/Group/templates/group_room_access.html
+++ b/Group/templates/group_room_access.html
@@ -239,7 +239,7 @@
 <!-- Spinner overlay -->
 <div id="spinner-overlay" class="glossy-spinner-overlay" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(6, 10, 20, 0.36); display: none; justify-content: center; align-items: center; z-index: var(--z-overlay);">
     <div style="text-align: center;">
-        <div style="width: 60px; height: 60px; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(34, 197, 94); border-radius: 50%; animation: spin 1s linear infinite;"></div>
+        <div style="width: 60px; height: 60px; margin: 0 auto; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(34, 197, 94); border-radius: 50%; animation: spin 1s linear infinite;"></div>
         <div style="margin-top: 1rem; color: white; font-size: 1.1rem;">処理中...</div>
     </div>
 </div>

--- a/Note/templates/create_note_room.html
+++ b/Note/templates/create_note_room.html
@@ -331,7 +331,7 @@
 
 <div id="loading-screen" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(6, 10, 20, 0.36); display: none; justify-content: center; align-items: center; z-index: var(--z-overlay);">
     <div style="text-align: center;">
-        <div style="width: 60px; height: 60px; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(163, 230, 53); border-radius: 50%; animation: spin 1s linear infinite;"></div>
+        <div style="width: 60px; height: 60px; margin: 0 auto; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(163, 230, 53); border-radius: 50%; animation: spin 1s linear infinite;"></div>
         <div style="margin-top: 1rem; color: white; font-size: 1.1rem;">処理中...</div>
     </div>
 </div>

--- a/Note/templates/note_room_access.html
+++ b/Note/templates/note_room_access.html
@@ -203,7 +203,7 @@
 <!-- Spinner overlay -->
 <div id="spinner-overlay" class="glossy-spinner-overlay" style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(6, 10, 20, 0.36); display: none; justify-content: center; align-items: center; z-index: var(--z-overlay);">
     <div style="text-align: center;">
-        <div style="width: 60px; height: 60px; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(163, 230, 53); border-radius: 50%; animation: spin 1s linear infinite;"></div>
+        <div style="width: 60px; height: 60px; margin: 0 auto; border: 6px solid rgba(255, 255, 255, 0.55); border-top: 6px solid rgb(163, 230, 53); border-radius: 50%; animation: spin 1s linear infinite;"></div>
         <div style="margin-top: 1rem; color: white; font-size: 1.1rem;">処理中...</div>
     </div>
 </div>


### PR DESCRIPTION
## 概要

日本語以外の一部の言語で、Group / Note のルーム関連ページに表示される「処理中...」オーバーレイスピナーが、画面中央ではなく**左にずれて表示される**問題を修正しました。

## 原因

スピナーの内側マークアップが以下の構造でした。

```html
<div style="text-align: center;">
    <div style="width: 60px; height: 60px; ... border-radius: 50%; animation: spin ..."></div>  <!-- 円形スピナー -->
    <div style="margin-top: 1rem; ...">処理中...</div>  <!-- テキスト -->
</div>
```

- ラッパーには `text-align: center` が指定されていますが、円形スピナーは**ブロック要素**のため `text-align` では中央寄せされません（インライン要素しか効かない）。
- フレックスで中央寄せされるラッパー自体の幅は、内部の「処理中...」の**翻訳テキストの長さ**で決まります。
- 日本語（「処理中...」）は短いためラッパー幅 ≒ 円の幅となり中央に見えますが、英語・ドイツ語・ロシア語など翻訳が長い言語ではラッパーが広がり、左寄せのままの円が**左にずれて**見えていました。アラビア語（RTL）では逆に右にずれます。

## 修正

円形スピナーの要素に `margin: 0 auto` を追加し、ラッパー幅やテキスト方向に依存せず常に中央へ配置されるようにしました。

対象ファイル（同一パターンの4箇所）:
- `Group/templates/group_room_access.html`（ルーム参加・作成）
- `Group/templates/create_group_room.html`（ルーム作成）
- `Note/templates/note_room_access.html`（ルーム参加・作成）
- `Note/templates/create_note_room.html`（ルーム作成）

## 検証

各ページを `ja / en / de / ar / ru` の5言語 × PC幅(1280px)・スマホ幅(390px) で実際にレンダリングし、ヘッドレスブラウザで円形スピナーの中心座標を計測しました。

**修正前**（ビューポート中心からのずれ）:
- de: -36px、en: -33px、ru: -36px（左へ）/ ar: +23px（右へ）/ ja: 0px

**修正後**: 全ページ・全言語・両画面幅で、ずれは -7〜-8px（スクロールバー幅ぶんで日本語含め全言語共通）に収束し、中央揃いになりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)