### PR TITLE
グループページのファイル行の高さを揃えて整列の違和感を解消

### DIFF
--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -456,6 +456,8 @@
   align-items: center;
   gap: 0.75rem;
   min-width: 0; /* Allow shrinking */
+  min-height: 2.5rem;
+  line-height: 1.4;
 }
 
 .modern-file-name-text {
@@ -472,6 +474,7 @@
 
 .modern-file-actions {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
 }
 
@@ -486,6 +489,10 @@
   padding: 0.5rem;
   border-radius: 6px;
   transition: all 0.2s ease;
+  width: 2.5rem;
+  height: 2.5rem;
+  line-height: 1;
+  flex: 0 0 auto;
 }
 
 .modern-file-action-btn:hover {


### PR DESCRIPTION
## 概要
グループルームのファイル一覧で、ファイル名のテキストとプレビュー／ダウンロード／削除アイコンボタンの高さが揃わず、視覚的にずれて見える問題を修正しました。

## 原因
- `.modern-file-name` は内部のファイルアイコン (1.5em) ＋ テキストの自然な高さのみで構成されており、約 24px だった
- 一方 `.modern-file-action-btn` は `padding: 0.5rem` ＋ 1.5em アイコンで合計約 40px となっていた
- 親要素 `.modern-file-item` が `align-items: center` で揃えてはいたものの、ファイル名側の領域に比べてアイコンボタン側が大きく、上下のスペース感が一致しないため違和感が生じていた

## 修正内容（`static/css/07-modern-components.css`）
- `.modern-file-name` に `min-height: 2.5rem` と `line-height: 1.4` を設定し、ボタン側と同等の縦サイズを確保
- `.modern-file-action-btn` に `width: 2.5rem; height: 2.5rem; line-height: 1; flex: 0 0 auto` を追加し、すべてのアイコンボタンを 40px × 40px の正方形に統一
- `.modern-file-actions` に `align-items: center` を明示し、ボタンを縦中央に配置

これにより、ファイル名行と各操作アイコンの高さが揃い、視覚的な統一感が得られます。グループルームの「アップロード待ちファイル」と「グループメンバーのファイル」の両方、および同じ CSS クラスを利用している FS!QR アップロードページのファイル一覧にも同じ整列が適用されます。

## テスト計画
- [ ] グループルームページでファイルをアップロードし、「アップロード待ちファイル」のファイル名と削除アイコンが同じ高さで整列していることを確認
- [ ] 他のメンバーがアップロードしたファイルで、ファイル名とプレビュー／ダウンロード／削除アイコンが揃っていることを確認
- [ ] FS!QR アップロードページのファイル一覧でも高さが揃っていることを確認（同じ CSS クラスを共有しているため）
- [ ] モバイル幅（767px 以下／575px 以下）でレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)