### PR TITLE
SEO: www → 非www の301リダイレクトをnginxに追加

### DIFF
--- a/fs-qr.conf
+++ b/fs-qr.conf
@@ -1,5 +1,15 @@
 server {
-    server_name fs-qr.net www.fs-qr.net;
+    listen 443 ssl;
+    server_name www.fs-qr.net;
+    ssl_certificate /etc/letsencrypt/live/fs-qr.net/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/fs-qr.net/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+    return 301 https://fs-qr.net$request_uri;
+}
+
+server {
+    server_name fs-qr.net;
 
     # Certbot実行後にリダイレクト設定がここに挿入されます。
     # 元々のif文を使ったリダイレクトは非推奨のため削除しました。


### PR DESCRIPTION
## 概要

`www.fs-qr.net` へのHTTPSアクセスを `fs-qr.net` へ301リダイレクトするサーバーブロックを追加しました。

## 背景・問題点

従来のnginx設定では、443番ポートのサーバーブロックが `fs-qr.net` と `www.fs-qr.net` の両方を同一コンテンツで返していました。

```nginx
server_name fs-qr.net www.fs-qr.net;  # 両方同じコンテンツを返す（問題）
```

これにより以下のSEO上の問題が発生していました：

- `https://fs-qr.net/` と `https://www.fs-qr.net/` が重複URLとして存在
- 外部リンクがwww/非wwwに分散した場合、評価（リンクジュース）が割れる
- Googleがどちらを正規URLとするか不定

## 修正内容

443番ポートのサーバーブロックを分割し、wwwドメイン専用のリダイレクトブロックを追加：

```nginx
# www → 非www へ301リダイレクト（新規追加）
server {
    listen 443 ssl;
    server_name www.fs-qr.net;
    # SSL証明書設定...
    return 301 https://fs-qr.net$request_uri;
}

# 本体（変更なし）
server {
    server_name fs-qr.net;
    ...
}
```

リダイレクトフロー：

| アクセスURL | 結果 |
|---|---|
| `http://www.fs-qr.net/*` | → `https://www.fs-qr.net/*` → `https://fs-qr.net/*` |
| `https://www.fs-qr.net/*` | → `https://fs-qr.net/*`（301） |
| `http://fs-qr.net/*` | → `https://fs-qr.net/*` |
| `https://fs-qr.net/*` | そのまま表示 |

## 確認済み事項

- canonical タグはすべてのページに設定済みで、`request.url` を動的に使用
- `ProxyHeadersMiddleware(trusted_hosts="*")` により、nginx修正後はFastAPIには `fs-qr.net` のリクエストのみ届くため、canonical URLも常に非wwwになる
- SSL証明書（`/etc/letsencrypt/live/fs-qr.net/`）がwwwドメインをカバーしていることを本番適用前に確認推奨

## テスト計画

- [ ] `nginx -t` で構文エラーがないことを確認
- [ ] `curl -I https://www.fs-qr.net/` で301レスポンスと `Location: https://fs-qr.net/` を確認
- [ ] `https://fs-qr.net/` が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)