### PR TITLE
[codex] トップページフッターの視認性を改善

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -472,6 +472,37 @@
         grid-template-columns: 1fr;
       }
     }
+
+    .top-footer {
+      width: min(calc(100% - 32px), 1100px);
+      margin: 32px auto calc(32px + env(safe-area-inset-bottom));
+      padding: 22px clamp(18px, 4vw, 36px);
+      background: #132238;
+      border: 1px solid rgba(19, 34, 56, 0.18);
+      color: #ffffff;
+      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.16);
+    }
+
+    .top-footer nav {
+      gap: 10px 18px;
+    }
+
+    .top-footer a,
+    .top-footer .footer-link-button {
+      color: #ffffff;
+    }
+
+    .top-footer small {
+      color: rgba(255, 255, 255, 0.82);
+    }
+
+    @media (max-width: 575.98px) {
+      .top-footer {
+        width: min(calc(100% - 24px), 1100px);
+        margin-top: 24px;
+        margin-bottom: calc(24px + env(safe-area-inset-bottom));
+      }
+    }
   </style>
 </head>
 <body>
@@ -615,7 +646,7 @@
     </div>
   </section>
 
-  <footer class="simple-footer service-footer">
+  <footer class="simple-footer service-footer top-footer">
     <nav aria-label="フッターナビゲーション">
       <a href="/">ホーム</a>
       <a href="/about">サイト概要</a>


### PR DESCRIPTION
## 概要
- トップページのフッターに専用クラス `.top-footer` を追加しました。
- 白背景のSEOコンテンツ下でも読みやすいよう、濃いネイビー背景と白文字に変更しました。
- PC・スマホともに左右の余白が確保されるよう、フッター幅と余白を調整しました。

## 変更理由
トップページ下部のフッターが背景とのコントラストや左右余白の面で見えにくく、リンクが読みづらい状態だったためです。

## 影響範囲
- `templates/index.html`
- トップページのフッター表示のみ

## 確認内容
- `python3 -m pytest tests/test_basic_routes.py`
- 結果: 30 passed, 4 warnings

## 補足
警告は既存の FastAPI `on_event` 非推奨警告で、今回の変更とは無関係です。