### PR TITLE
[codex] サイトマップのSEOメタ情報を最適化

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ from settings import (
     REDIS_URL,
     SESSION_MAX_AGE_SECONDS,
 )
-from i18n import DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, is_language_query_only
+from i18n import is_language_query_only
 from web import render_cached_template, render_template, wants_json_response
 from api_response import api_error_response
 from geoip_update import geoip_update_loop, update_geoip_database_async
@@ -288,6 +288,13 @@ async def ads_txt():
 
 SITEMAP_BASE_URL = "https://fs-qr.net"
 
+
+def _articles_lastmod() -> str:
+    return max(
+        (article["date"] for article in get_all_articles()), default="2025-08-31"
+    )
+
+
 SITEMAP_URLS = (
     ("/", "weekly", "1.0", "2026-04-27"),
     ("/about", "monthly", "0.8", "2026-04-26"),
@@ -296,7 +303,7 @@ SITEMAP_URLS = (
     ("/privacy-policy", "monthly", "0.6", "2026-04-26"),
     ("/terms", "monthly", "0.6", "2026-05-28"),
     ("/site-operator", "monthly", "0.5", "2026-04-26"),
-    ("/articles", "monthly", "0.8", "2025-08-31"),
+    ("/articles", "monthly", "0.8", _articles_lastmod()),
     ("/fs-qr_menu", "weekly", "0.9", "2026-04-27"),
     ("/fs-qr", "weekly", "0.9", "2026-04-27"),
     ("/group_menu", "weekly", "0.9", "2026-04-27"),
@@ -319,23 +326,12 @@ def _build_sitemap_entry(
     path: str, changefreq: str, priority: str, lastmod: str
 ) -> str:
     loc = f"{SITEMAP_BASE_URL}{path}"
-    alternates = []
-    for code in SUPPORTED_LANGUAGES:
-        href = loc if code == DEFAULT_LANGUAGE else f"{loc}?lang={code}"
-        alternates.append(
-            f'    <xhtml:link rel="alternate" hreflang="{code}" href="{href}" />'
-        )
-    alternates.append(
-        f'    <xhtml:link rel="alternate" hreflang="x-default" href="{loc}" />'
-    )
-    alt_block = "\n".join(alternates)
     return (
         "  <url>\n"
         f"    <loc>{loc}</loc>\n"
         f"    <lastmod>{lastmod}</lastmod>\n"
         f"    <changefreq>{changefreq}</changefreq>\n"
         f"    <priority>{priority}</priority>\n"
-        f"{alt_block}\n"
         "  </url>"
     )
 
@@ -343,14 +339,12 @@ def _build_sitemap_entry(
 @app.get("/sitemap.xml", name="sitemap")
 async def sitemap():
     # lastmod は該当ページのテンプレート/コードを最後に変更した日付に合わせて更新する。
-    # 各URLについて hreflang による多言語版を xhtml:link で列挙し、Google に
-    # 同一コンテンツの言語別バリアントを通知する。
+    # hreflang は各ページの HTML head で管理し、sitemap は canonical URL の列挙に絞る。
     # NOTE: /all-in-one, /search_fs-qr, /search_group, /search_note は noindex のため除外。
     entries = "\n".join(_build_sitemap_entry(*url) for url in SITEMAP_URLS)
     xml = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n'
-        '        xmlns:xhtml="http://www.w3.org/1999/xhtml">\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
         f"{entries}\n"
         "</urlset>\n"
     )

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -1,3 +1,5 @@
+import xml.etree.ElementTree as ET
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -76,6 +78,23 @@ def test_article_sitemap_entries(test_client: TestClient):
     assert response.status_code == 200
     for article in ARTICLES:
         assert f"https://fs-qr.net/{article['slug']}" in response.text
+
+
+def test_articles_index_sitemap_lastmod_tracks_newest_article(test_client: TestClient):
+    response = test_client.get("/sitemap.xml")
+    assert response.status_code == 200
+
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    root = ET.fromstring(response.text)
+    for url in root.findall("sm:url", ns):
+        loc = url.find("sm:loc", ns)
+        if loc is not None and loc.text == "https://fs-qr.net/articles":
+            lastmod = url.find("sm:lastmod", ns)
+            assert lastmod is not None
+            assert lastmod.text == max(article["date"] for article in ARTICLES)
+            break
+    else:
+        raise AssertionError("/articles entry is missing from sitemap")
 
 
 def test_get_article_by_slug():

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -1,7 +1,7 @@
 """SEO-related multilingual tests.
 
 These cover:
-- sitemap.xml exposes xhtml:link alternates for every supported language and x-default
+- sitemap.xml lists canonical URLs without sitemap-managed hreflang alternates
 - meta description / og:description / title are translated for every locale on the home page
 - geo.region and geo.placename adapt to the request locale
 - JSON-LD inLanguage matches the request locale
@@ -22,9 +22,9 @@ SITEMAP_NS = {
 }
 
 
-def test_sitemap_has_hreflang_alternates_for_every_url(test_client: TestClient):
-    from i18n import SUPPORTED_LANGUAGES
-
+def test_sitemap_lists_canonical_urls_without_hreflang_alternates(
+    test_client: TestClient,
+):
     response = test_client.get("/sitemap.xml")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/xml")
@@ -36,17 +36,8 @@ def test_sitemap_has_hreflang_alternates_for_every_url(test_client: TestClient):
     for url in urls:
         loc = url.find("sm:loc", SITEMAP_NS)
         assert loc is not None and loc.text
-
-        alternates = url.findall("xhtml:link", SITEMAP_NS)
-        hreflangs = {alt.get("hreflang") for alt in alternates}
-        # Every supported language plus x-default must be present.
-        for lang in SUPPORTED_LANGUAGES:
-            assert lang in hreflangs, f"{loc.text}: missing hreflang={lang}"
-        assert "x-default" in hreflangs
-
-        # Each alternate must point at a valid URL.
-        for alt in alternates:
-            assert alt.get("href"), f"{loc.text}: missing href"
+        assert "?" not in loc.text
+        assert not url.findall("xhtml:link", SITEMAP_NS)
 
 
 def test_sitemap_includes_terms_page(test_client: TestClient):


### PR DESCRIPTION
## 概要

サイトマップのSEO向けメタ情報を見直し、Google向けにより保守しやすい構成へ整理しました。

## 変更内容

- `sitemap.xml` から `xhtml:link` による `hreflang` 出力を削除し、canonical URL の列挙に絞りました
- `hreflang` は既存どおり各ページの HTML head 側で管理する方針にしました
- `/articles` の `lastmod` を固定値から、記事レジストリ内の最新公開日を使う自動算出に変更しました
- sitemap の方針変更と `/articles` の `lastmod` 自動更新を検証するテストを追加・更新しました

## 背景

Google の sitemap では `lastmod` の正確性が重要です。一方で `hreflang` は HTML、HTTP header、sitemap のいずれかで管理でき、複数方式を併用しても検索上の利点はありません。既存の HTML head に `hreflang` があるため、sitemap 側は canonical URL と正確な更新日に責務を絞りました。

## 確認内容

- `pytest -q tests/test_seo.py tests/test_articles.py`
  - `53 passed`
- `ast.parse` による構文確認

## 備考

未追跡の翻訳系スクリプトは今回のPR対象外として含めていません。