### PR TITLE
[codex] 作成者セッション限定削除を追加

### DIFF
--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -118,14 +118,14 @@ def _get_fsqr_access(request: Request, secure_id: str):
 def _can_delete_fsqr_upload(request: Request, secure_id: str, record: dict) -> bool:
     access = _get_fsqr_access(request, secure_id)
     return bool(
-        access
-        and access.get("can_delete")
-        and access.get("id") == record.get("id")
+        access and access.get("can_delete") and access.get("id") == record.get("id")
     )
 
 
 def _forget_fsqr_access(request: Request, secure_id: str) -> None:
-    room_access.revoke_access(request.session, FSQR_UPLOAD_ACCESS_SESSION_KEY, secure_id)
+    room_access.revoke_access(
+        request.session, FSQR_UPLOAD_ACCESS_SESSION_KEY, secure_id
+    )
 
 
 def _is_valid_share_token(share_token: str) -> bool:

--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -40,7 +40,7 @@ from share_links import (
     create_share_link,
     resolve_share_link,
 )
-from web import build_url, enforce_csrf, render_template
+from web import build_url, enforce_csrf, render_template, wants_json_response
 import room_access
 from . import fsqr_data as fs_data
 
@@ -73,13 +73,21 @@ async def _get_room_by_credentials(room_id, password):
 
 
 def _remember_fsqr_access(
-    request: Request, secure_id: str, id_val: str, password: str, share_token: str = ""
+    request: Request,
+    secure_id: str,
+    id_val: str,
+    password: str,
+    share_token: str = "",
+    can_delete: bool = False,
 ) -> None:
+    payload = {"id": id_val, "password": password, "share_token": share_token}
+    if can_delete:
+        payload["can_delete"] = "1"
     room_access.grant_access(
         request.session,
         FSQR_UPLOAD_ACCESS_SESSION_KEY,
         secure_id,
-        payload={"id": id_val, "password": password, "share_token": share_token},
+        payload=payload,
     )
 
 
@@ -98,7 +106,26 @@ def _get_fsqr_access(request: Request, secure_id: str):
     password = entry.get("password", "")
     if not isinstance(password, str):
         password = ""
-    return {"id": id_val, "password": password, "share_token": share_token}
+    can_delete = entry.get("can_delete", "") == "1"
+    return {
+        "id": id_val,
+        "password": password,
+        "share_token": share_token,
+        "can_delete": can_delete,
+    }
+
+
+def _can_delete_fsqr_upload(request: Request, secure_id: str, record: dict) -> bool:
+    access = _get_fsqr_access(request, secure_id)
+    return bool(
+        access
+        and access.get("can_delete")
+        and access.get("id") == record.get("id")
+    )
+
+
+def _forget_fsqr_access(request: Request, secure_id: str) -> None:
+    room_access.revoke_access(request.session, FSQR_UPLOAD_ACCESS_SESSION_KEY, secure_id)
 
 
 def _is_valid_share_token(share_token: str) -> bool:
@@ -321,7 +348,9 @@ async def upload(  # noqa: C901
             "アップロード情報の保存に失敗しました。時間をおいて再度お試しください。",
             status_code=500,
         )
-    _remember_fsqr_access(request, secure_id, id_val, password, share_token)
+    _remember_fsqr_access(
+        request, secure_id, id_val, password, share_token, can_delete=True
+    )
 
     return api_ok_response(
         {
@@ -364,6 +393,7 @@ async def upload_complete(request: Request, secure_id: str):
         url=share_url,
         retention_days=retention_days,
         deletion_date=deletion_date,
+        can_delete=_can_delete_fsqr_upload(request, secure_id, row),
     )
 
 
@@ -394,6 +424,7 @@ async def download(request: Request, secure_id: str):
             url=build_url(request, "fsqr.download_go", secure_id=secure_id),
             retention_days=retention_days,
             deletion_date=deletion_date,
+            can_delete=_can_delete_fsqr_upload(request, secure_id, row),
         )
     raise HTTPException(status_code=404)
 
@@ -442,7 +473,29 @@ async def fs_qr_share(request: Request, token: str):
         url=build_url(request, "fsqr.share_download", token=token),
         retention_days=retention_days,
         deletion_date=deletion_date,
+        can_delete=_can_delete_fsqr_upload(request, record["secure_id"], record),
     )
+
+
+@router.post("/fs-qr/delete/{secure_id}", name="fsqr.delete_upload")
+async def delete_upload(request: Request, secure_id: str):
+    await enforce_csrf(request)
+    data = await _get_active_data(secure_id)
+    if not data:
+        raise HTTPException(status_code=404)
+
+    if not _can_delete_fsqr_upload(request, secure_id, data[0]):
+        if wants_json_response(request):
+            return api_error_response("削除権限がありません。", status_code=403)
+        return msg(request, "削除権限がありません。", status_code=403)
+
+    await fs_data.remove_data(secure_id)
+    _forget_fsqr_access(request, secure_id)
+    if wants_json_response(request):
+        return api_ok_response(
+            {"redirect_url": build_url(request, "fsqr.after_remove")}
+        )
+    return RedirectResponse(build_url(request, "fsqr.after_remove"), status_code=302)
 
 
 @router.get("/fs-qr/{room_id}/{password}", name="fsqr.legacy_room")

--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -108,6 +108,20 @@
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>
+        {% if can_delete %}
+        <form
+          action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+          method="POST"
+          class="owner-delete-form"
+          data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+        >
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="modern-btn modern-btn-danger">
+            {{ icons.icon('trash', size='md', with_text=True) }}
+            ファイルを削除
+          </button>
+        </form>
+        {% endif %}
       </div>
     </div>
 
@@ -182,6 +196,20 @@
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="modern-btn modern-btn-success">ダウンロード</button>
         </form>
+        {% if can_delete %}
+        <form
+          action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+          method="POST"
+          class="owner-delete-form"
+          data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+        >
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="modern-btn modern-btn-danger">
+            {{ icons.icon('trash', size='md', with_text=True) }}
+            ファイルを削除
+          </button>
+        </form>
+        {% endif %}
 
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn">→他のファイルをアップロード</a>
@@ -192,6 +220,25 @@
     {% endif %}
   </div>
 </div>
+
+<script>
+document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
+  form.addEventListener('submit', async function(event) {
+    if (form.dataset.confirmed === 'true') {
+      return;
+    }
+    event.preventDefault();
+    var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
+      title: '削除の確認',
+      confirmLabel: '削除する'
+    });
+    if (confirmed) {
+      form.dataset.confirmed = 'true';
+      form.submit();
+    }
+  });
+});
+</script>
 
 
   <div class="spinner-container fsqr-download-overlay spinner-container--hidden" id="spinnerContainer">

--- a/Group/group_app.py
+++ b/Group/group_app.py
@@ -27,6 +27,7 @@ from .group_routes_pages import (
 )
 from .group_routes_room import (
     register_group_create_room_route,
+    register_group_delete_own_room_route,
     register_group_direct_route,
     register_group_room_access_route,
     register_group_search_process_route,
@@ -48,6 +49,7 @@ register_group_delete_file_route(router)
 register_group_files_ws_route(router)
 register_group_search_page_route(router)
 register_group_search_process_route(router)
+register_group_delete_own_room_route(router)
 register_group_direct_route(router)
 register_group_manage_page_routes(router)
 register_group_logout_management_route(router)

--- a/Group/group_common.py
+++ b/Group/group_common.py
@@ -29,12 +29,15 @@ def remember_group_room_access(
     room_id: str,
     share_token: str | None = None,
     password: str | None = None,
+    can_delete: bool = False,
 ) -> None:
     payload = {}
     if share_token:
         payload["share_token"] = share_token
     if password:
         payload["password"] = password
+    if can_delete:
+        payload["can_delete"] = "1"
     room_access.grant_access(
         request.session,
         GROUP_ROOM_ACCESS_SESSION_KEY,
@@ -59,3 +62,16 @@ def get_group_room_password(request: Request, room_id: str) -> str:
     return room_access.get_access_field(
         request.session, GROUP_ROOM_ACCESS_SESSION_KEY, room_id, "password", ""
     )
+
+
+def can_delete_group_room(request: Request, room_id: str) -> bool:
+    return (
+        room_access.get_access_field(
+            request.session, GROUP_ROOM_ACCESS_SESSION_KEY, room_id, "can_delete", ""
+        )
+        == "1"
+    )
+
+
+def forget_group_room_access(request: Request, room_id: str) -> None:
+    room_access.revoke_access(request.session, GROUP_ROOM_ACCESS_SESSION_KEY, room_id)

--- a/Group/group_routes_room.py
+++ b/Group/group_routes_room.py
@@ -30,6 +30,8 @@ from web import wants_json_response
 
 from . import group_data
 from .group_common import (
+    can_delete_group_room,
+    forget_group_room_access,
     get_group_room_password,
     get_group_room_share_token,
     get_room_if_active,
@@ -71,6 +73,7 @@ def _render_group_room(request: Request, room_id: str, record: dict):
         share_url=share_url,
         retention_days=retention_days,
         deletion_date=deletion_date,
+        can_delete=can_delete_group_room(request, room_id),
         websocket_csrf_token=get_or_create_csrf_token(request),
     )
 
@@ -223,7 +226,11 @@ def register_group_create_room_route(router: APIRouter):
                 status_code=500,
             )
         remember_group_room_access(
-            request, room_id, share_token=share_token, password=password
+            request,
+            room_id,
+            share_token=share_token,
+            password=password,
+            can_delete=True,
         )
         redirect_url = build_room_url(
             request, service_key=ServiceKey.GROUP, resource_id=room_id
@@ -280,6 +287,41 @@ def register_group_search_process_route(router: APIRouter):
             build_room_url(request, service_key=ServiceKey.GROUP, resource_id=room_id),
             status_code=302,
         )
+
+
+def register_group_delete_own_room_route(router: APIRouter):
+    @router.post("/group/r/{room_id}/delete", name="group.delete_own_room")
+    async def delete_own_room(request: Request, room_id: str):
+        await enforce_csrf(request)
+
+        record = await get_room_if_active(room_id)
+        if not record:
+            if wants_json_response(request):
+                return api_error_response("ルームが見つかりません。", status_code=404)
+            return room_msg(request, "ルームが見つかりません。", status_code=404)
+
+        if not can_delete_group_room(request, room_id):
+            if wants_json_response(request):
+                return api_error_response("削除権限がありません。", status_code=403)
+            return room_msg(request, "削除権限がありません。", status_code=403)
+
+        removed = await group_data.remove_data(room_id)
+        if not removed:
+            if wants_json_response(request):
+                return api_error_response(
+                    "ルーム削除に失敗しました。時間をおいて再度お試しください。",
+                    status_code=500,
+                )
+            return room_msg(
+                request,
+                "ルーム削除に失敗しました。時間をおいて再度お試しください。",
+                status_code=500,
+            )
+
+        forget_group_room_access(request, room_id)
+        if wants_json_response(request):
+            return api_ok_response({"redirect_url": "/remove-succes"})
+        return RedirectResponse("/remove-succes", status_code=302)
 
 
 def register_group_direct_route(router: APIRouter):

--- a/Group/templates/group_room/_content.html
+++ b/Group/templates/group_room/_content.html
@@ -69,6 +69,20 @@
                             </span>
                         </div>
                     </div>
+                    {% if can_delete %}
+                    <form
+                        action="{{ url_for('group.delete_own_room', room_id=room_id) }}"
+                        method="POST"
+                        class="owner-delete-form"
+                        data-confirm-submit="このグループルームを削除します。ルーム内のファイルもすべて削除され、この操作は元に戻せません。"
+                    >
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="modern-btn modern-btn-danger">
+                            {{ icons.icon('trash', size='md', with_text=True) }}
+                            ルームを削除
+                        </button>
+                    </form>
+                    {% endif %}
                 </div>
 
                 <div class="qr-code-container" id="groupShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
@@ -145,6 +159,25 @@
         </div>
     </div>
 </div>
+
+<script>
+document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
+    form.addEventListener('submit', async function(event) {
+        if (form.dataset.confirmed === 'true') {
+            return;
+        }
+        event.preventDefault();
+        var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
+            title: '削除の確認',
+            confirmLabel: '削除する'
+        });
+        if (confirmed) {
+            form.dataset.confirmed = 'true';
+            form.submit();
+        }
+    });
+});
+</script>
 
 <!-- Download Progress -->
 <div class="spinner-container group-download-overlay" id="downloadSpinnerContainer" style="display: none;">

--- a/Note/note_access.py
+++ b/Note/note_access.py
@@ -14,12 +14,15 @@ def remember_note_room_access(
     room_id: str,
     share_token: str | None = None,
     password: str | None = None,
+    can_delete: bool = False,
 ) -> None:
     payload = {}
     if share_token:
         payload["share_token"] = share_token
     if password:
         payload["password"] = password
+    if can_delete:
+        payload["can_delete"] = "1"
     room_access.grant_access(
         request.session,
         NOTE_ROOM_ACCESS_SESSION_KEY,
@@ -48,3 +51,16 @@ def get_note_room_password(request: Request, room_id: str) -> str:
     return room_access.get_access_field(
         request.session, NOTE_ROOM_ACCESS_SESSION_KEY, room_id, "password", ""
     )
+
+
+def can_delete_note_room(request: Request, room_id: str) -> bool:
+    return (
+        room_access.get_access_field(
+            request.session, NOTE_ROOM_ACCESS_SESSION_KEY, room_id, "can_delete", ""
+        )
+        == "1"
+    )
+
+
+def forget_note_room_access(request: Request, room_id: str) -> None:
+    room_access.revoke_access(request.session, NOTE_ROOM_ACCESS_SESSION_KEY, room_id)

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -34,11 +34,15 @@ from web import (
 )
 from . import note_data as nd
 from .note_access import (
+    can_delete_note_room,
+    forget_note_room_access,
     get_note_room_password,
     get_note_room_share_token,
     has_note_room_access,
     remember_note_room_access,
 )
+from .note_realtime import hub as note_ws_hub
+from .note_realtime import publish_room_expired
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -111,6 +115,7 @@ def _render_note_room(request: Request, room_id: str, meta: dict):
         share_url=share_url,
         retention_days=retention_days,
         deletion_date=deletion_date,
+        can_delete=can_delete_note_room(request, room_id),
         websocket_csrf_token=get_or_create_csrf_token(request),
     )
 
@@ -254,7 +259,11 @@ async def create_note_room(request: Request):  # noqa: C901
             status_code=500,
         )
     remember_note_room_access(
-        request, room_id, share_token=share_token, password=password
+        request,
+        room_id,
+        share_token=share_token,
+        password=password,
+        can_delete=True,
     )
     redirect_url = build_room_url(
         request, service_key=ServiceKey.NOTE, resource_id=room_id
@@ -372,6 +381,43 @@ async def note_room(request: Request, room_id: str):
 
     await register_success(SCOPE_NOTE, ip)
     return _render_note_room(request, room_id, meta)
+
+
+@router.post("/note/r/{room_id}/delete", name="note.delete_own_room")
+async def delete_note_room(request: Request, room_id: str):
+    await enforce_csrf(request)
+
+    meta = await _get_room_if_valid(room_id)
+    if not meta:
+        if wants_json_response(request):
+            return api_error_response("ルームが見つかりません。", status_code=404)
+        response = render_template(request, "error.html", message="ルームが見つかりません。")
+        response.status_code = 404
+        return response
+
+    if not can_delete_note_room(request, room_id):
+        if wants_json_response(request):
+            return api_error_response("削除権限がありません。", status_code=403)
+        response = render_template(request, "error.html", message="削除権限がありません。")
+        response.status_code = 403
+        return response
+
+    await nd.remove_room(room_id)
+    forget_note_room_access(request, room_id)
+
+    expired_payload = {
+        "type": "room_expired",
+        "status": "error",
+        "data": {},
+        "error": "Room has expired or was deleted.",
+    }
+    await note_ws_hub.broadcast(room_id, expired_payload)
+    await publish_room_expired(room_id)
+    await note_ws_hub.close_room(room_id)
+
+    if wants_json_response(request):
+        return api_ok_response({"redirect_url": "/remove-succes"})
+    return RedirectResponse("/remove-succes", status_code=302)
 
 
 @router.get("/note/{room_id}/{password}", name="note.note_legacy_room")

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -391,14 +391,18 @@ async def delete_note_room(request: Request, room_id: str):
     if not meta:
         if wants_json_response(request):
             return api_error_response("ルームが見つかりません。", status_code=404)
-        response = render_template(request, "error.html", message="ルームが見つかりません。")
+        response = render_template(
+            request, "error.html", message="ルームが見つかりません。"
+        )
         response.status_code = 404
         return response
 
     if not can_delete_note_room(request, room_id):
         if wants_json_response(request):
             return api_error_response("削除権限がありません。", status_code=403)
-        response = render_template(request, "error.html", message="削除権限がありません。")
+        response = render_template(
+            request, "error.html", message="削除権限がありません。"
+        )
         response.status_code = 403
         return response
 

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -70,6 +70,20 @@
                             </span>
                         </div>
                     </div>
+                    {% if can_delete %}
+                    <form
+                        action="{{ url_for('note.delete_own_room', room_id=room_id) }}"
+                        method="POST"
+                        class="owner-delete-form"
+                        data-confirm-submit="このノートルームを削除します。保存済みの本文も削除され、この操作は元に戻せません。"
+                    >
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="modern-btn modern-btn-danger">
+                            {{ icons.icon('trash', size='md', with_text=True) }}
+                            ルームを削除
+                        </button>
+                    </form>
+                    {% endif %}
                 </div>
 
                 <div class="qr-code-container" id="noteShareQrCode" data-share-url="{{ share_url | e }}" aria-label="共有用QRコード">
@@ -99,6 +113,25 @@
         </div>
     </div>
 </div>
+
+<script>
+document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
+    form.addEventListener('submit', async function(event) {
+        if (form.dataset.confirmed === 'true') {
+            return;
+        }
+        event.preventDefault();
+        var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
+            title: '削除の確認',
+            confirmLabel: '削除する'
+        });
+        if (confirmed) {
+            form.dataset.confirmed = 'true';
+            form.submit();
+        }
+    });
+});
+</script>
 
 
 <div class="usage-section">

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -418,6 +418,24 @@
   text-decoration: none;
 }
 
+.modern-btn-danger {
+  background: linear-gradient(135deg, var(--btn-danger) 0%, #ef4444 100%);
+  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.28);
+}
+
+.modern-btn-danger:hover {
+  background: linear-gradient(135deg, var(--btn-danger-hover) 0%, var(--btn-danger) 100%);
+  box-shadow: 0 6px 20px rgba(220, 38, 38, 0.38);
+  color: white;
+  text-decoration: none;
+}
+
+.owner-delete-form {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
 /* ===============================================
    Modern File List System
    =============================================== */

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -217,6 +217,75 @@ def test_upload_single_filename_with_enc_keeps_download_path_consistent(
     assert "share_token" not in save_mock.await_args.kwargs
 
 
+def test_fsqr_owner_session_can_delete_uploaded_file(test_client: TestClient, tmp_path):
+    """アップロード直後の同一セッションだけFSQRファイルを削除できる"""
+    secure_id = "own123-1234567890-report.pdf"
+    record = {
+        "id": "own123",
+        "secure_id": secure_id,
+        "time": None,
+        "retention_days": 7,
+        "file_type": "single",
+        "original_filename": "report.pdf",
+    }
+    remove_mock = AsyncMock()
+    with (
+        patch("FSQR.fsqr_app.STATIC", str(tmp_path)),
+        patch("FSQR.fsqr_app.uuid.uuid4", return_value="1234567890abcdef"),
+        patch("FSQR.fsqr_data.save_file", new_callable=AsyncMock),
+        patch("FSQR.fsqr_data.get_data", new_callable=AsyncMock, return_value=[record]),
+        patch("FSQR.fsqr_data.remove_data", remove_mock),
+    ):
+        upload_response = test_client.post(
+            "/upload",
+            files={
+                "upfile": (
+                    "report.pdf.enc",
+                    b"encrypted-by-browser",
+                    "application/octet-stream",
+                )
+            },
+            data={
+                "name": "own123",
+                "download_password": "123456",
+                "file_type": "single",
+                "original_filename": "report.pdf",
+                "retention_days": "7",
+            },
+            headers={
+                "X-Requested-With": "XMLHttpRequest",
+                "Accept": "application/json",
+            },
+        )
+        page_response = test_client.get(f"/upload_complete/{secure_id}")
+        delete_response = test_client.post(f"/fs-qr/delete/{secure_id}")
+
+    assert upload_response.status_code == 200
+    assert "ファイルを削除" in page_response.text
+    assert delete_response.status_code == 302
+    assert delete_response.headers["location"] == "/remove-succes"
+    remove_mock.assert_awaited_once_with(secure_id)
+
+
+def test_fsqr_delete_requires_owner_session(test_client: TestClient):
+    """FSQR削除は作成セッションなしでは実行できない"""
+    secure_id = "noown1-1234567890-report.pdf"
+    record = {
+        "id": "noown1",
+        "secure_id": secure_id,
+        "time": None,
+        "retention_days": 7,
+    }
+    with (
+        patch("FSQR.fsqr_data.get_data", new_callable=AsyncMock, return_value=[record]),
+        patch("FSQR.fsqr_data.remove_data", new_callable=AsyncMock) as remove_mock,
+    ):
+        response = test_client.post(f"/fs-qr/delete/{secure_id}")
+
+    assert response.status_code == 403
+    remove_mock.assert_not_awaited()
+
+
 def test_upload_metadata_failure_removes_staged_file(test_client: TestClient, tmp_path):
     """DB保存に失敗した場合は一時ファイルも正式ファイルも残さない"""
     save_mock = AsyncMock(side_effect=RuntimeError("db down"))

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -416,8 +416,9 @@ def test_group_delete_room_requires_owner_session(test_client: TestClient):
             new_callable=AsyncMock,
             return_value=[active_room],
         ),
-        patch("Group.group_routes_room.group_data.remove_data", new_callable=AsyncMock)
-        as remove_mock,
+        patch(
+            "Group.group_routes_room.group_data.remove_data", new_callable=AsyncMock
+        ) as remove_mock,
     ):
         response = test_client.post(f"/group/r/{room_id}/delete")
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -378,6 +378,53 @@ def test_create_group_room_generates_numeric_password(test_client: TestClient):
     assert create_mock.await_args.kwargs["password"] == "000042"
 
 
+def test_group_owner_session_can_delete_room(test_client: TestClient):
+    """ルーム作成直後の同一セッションだけGroupルームを削除できる"""
+    room_id = "gdel01"
+    active_room = {"id": room_id, "room_id": room_id, "retention_days": 7, "time": None}
+    remove_mock = AsyncMock(return_value=True)
+    with (
+        patch("Group.group_routes_room.generate_room_password", return_value="000042"),
+        patch(
+            "Group.group_routes_room.group_data.get_data",
+            new_callable=AsyncMock,
+            side_effect=[None, [active_room]],
+        ),
+        patch("Group.group_routes_room.group_data.create_room", new_callable=AsyncMock),
+        patch("Group.group_routes_room.group_data.remove_data", remove_mock),
+        patch("Group.group_routes_room.os.makedirs"),
+    ):
+        create_response = test_client.post(
+            "/create_group_room",
+            json={"id": room_id, "idMode": "manual"},
+        )
+        delete_response = test_client.post(f"/group/r/{room_id}/delete")
+
+    assert create_response.status_code == 302
+    assert delete_response.status_code == 302
+    assert delete_response.headers["location"] == "/remove-succes"
+    remove_mock.assert_awaited_once_with(room_id)
+
+
+def test_group_delete_room_requires_owner_session(test_client: TestClient):
+    """作成セッションがないGroupルーム削除は403を返す"""
+    room_id = "gfor01"
+    active_room = {"id": room_id, "room_id": room_id, "retention_days": 7, "time": None}
+    with (
+        patch(
+            "Group.group_routes_room.group_data.get_data",
+            new_callable=AsyncMock,
+            return_value=[active_room],
+        ),
+        patch("Group.group_routes_room.group_data.remove_data", new_callable=AsyncMock)
+        as remove_mock,
+    ):
+        response = test_client.post(f"/group/r/{room_id}/delete")
+
+    assert response.status_code == 403
+    remove_mock.assert_not_awaited()
+
+
 def test_delete_all_rooms_requires_management_auth(test_client: TestClient):
     with patch("Group.group_data.all_remove", new_callable=AsyncMock) as remove_mock:
         response = test_client.post("/delete_all_rooms")

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -233,6 +233,75 @@ def test_create_note_room_generates_numeric_password(test_client: TestClient):
     create_mock.assert_awaited_once_with("abc123", "000042", "abc123", retention_days=7)
 
 
+def test_note_owner_session_can_delete_room(test_client: TestClient):
+    """ルーム作成直後の同一セッションだけNoteルームを削除できる"""
+    from datetime import datetime
+
+    room_id = "ndel01"
+    meta = {
+        "id": room_id,
+        "retention_days": 7,
+        "expires_at": datetime(2026, 1, 8, 0, 0, 0),
+    }
+    remove_mock = AsyncMock()
+    with (
+        patch("Note.note_app.generate_room_password", return_value="000042"),
+        patch(
+            "Note.note_app._room_id_exists", new_callable=AsyncMock, return_value=False
+        ),
+        patch("Note.note_app.nd.create_room", new_callable=AsyncMock),
+        patch(
+            "Note.note_app._get_room_if_valid",
+            new_callable=AsyncMock,
+            side_effect=[meta, meta],
+        ),
+        patch("Note.note_app.nd.remove_room", remove_mock),
+        patch("Note.note_app.note_ws_hub.broadcast", new_callable=AsyncMock)
+        as broadcast_mock,
+        patch("Note.note_app.publish_room_expired", new_callable=AsyncMock)
+        as publish_mock,
+        patch("Note.note_app.note_ws_hub.close_room", new_callable=AsyncMock)
+        as close_mock,
+    ):
+        create_response = test_client.post(
+            "/create_note_room",
+            json={"id": room_id, "idMode": "manual"},
+        )
+        delete_response = test_client.post(f"/note/r/{room_id}/delete")
+
+    assert create_response.status_code == 302
+    assert delete_response.status_code == 302
+    assert delete_response.headers["location"] == "/remove-succes"
+    remove_mock.assert_awaited_once_with(room_id)
+    broadcast_mock.assert_awaited_once()
+    publish_mock.assert_awaited_once_with(room_id)
+    close_mock.assert_awaited_once_with(room_id)
+
+
+def test_note_delete_room_requires_owner_session(test_client: TestClient):
+    """作成セッションがないNoteルーム削除は403を返す"""
+    from datetime import datetime
+
+    room_id = "nfor01"
+    meta = {
+        "id": room_id,
+        "retention_days": 7,
+        "expires_at": datetime(2026, 1, 8, 0, 0, 0),
+    }
+    with (
+        patch(
+            "Note.note_app._get_room_if_valid",
+            new_callable=AsyncMock,
+            return_value=meta,
+        ),
+        patch("Note.note_app.nd.remove_room", new_callable=AsyncMock) as remove_mock,
+    ):
+        response = test_client.post(f"/note/r/{room_id}/delete")
+
+    assert response.status_code == 403
+    remove_mock.assert_not_awaited()
+
+
 def test_create_note_room_fetch_returns_redirect_url(test_client: TestClient):
     """fetch からの作成は画面遷移先を JSON で返す"""
     create_mock = AsyncMock()

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -256,12 +256,15 @@ def test_note_owner_session_can_delete_room(test_client: TestClient):
             side_effect=[meta, meta],
         ),
         patch("Note.note_app.nd.remove_room", remove_mock),
-        patch("Note.note_app.note_ws_hub.broadcast", new_callable=AsyncMock)
-        as broadcast_mock,
-        patch("Note.note_app.publish_room_expired", new_callable=AsyncMock)
-        as publish_mock,
-        patch("Note.note_app.note_ws_hub.close_room", new_callable=AsyncMock)
-        as close_mock,
+        patch(
+            "Note.note_app.note_ws_hub.broadcast", new_callable=AsyncMock
+        ) as broadcast_mock,
+        patch(
+            "Note.note_app.publish_room_expired", new_callable=AsyncMock
+        ) as publish_mock,
+        patch(
+            "Note.note_app.note_ws_hub.close_room", new_callable=AsyncMock
+        ) as close_mock,
     ):
         create_response = test_client.post(
             "/create_note_room",


### PR DESCRIPTION
## 概要

Group / Note のルームと FSQR のアップロード済みファイルについて、作成・アップロードした同一ブラウザセッションだけが手動削除できるようにしました。

## 変更内容

- FSQR / Group / Note の既存セッションアクセス情報に `can_delete` フラグを追加
- 作成・アップロード直後のセッションだけに削除権限を付与
- 共有URLアクセスやID+パスワード検索では削除権限を付与しないよう維持
- FSQRファイル、Groupルーム、Noteルーム用のユーザー向け削除エンドポイントを追加
- 削除権限がある画面だけに削除ボタンを表示
- Noteルーム削除時にWebSocketへ期限切れ相当の通知を送り、接続を閉じる処理を追加
- 作成者セッションで削除できるケースと、権限なしで403になるケースのテストを追加

## 影響

- 作成者が同じブラウザセッションを保持している場合、保存期間を待たずに対象を削除できます。
- 共有相手や検索ログインした参加者は削除できません。
- セッションを失った場合は、従来通り管理者削除または自動削除で対応します。

## 確認

- `python3 -m pytest tests/test_fsqr.py tests/test_group.py tests/test_note.py tests/test_room_access.py`
  - `120 passed`
- `git diff --check`