### PR TITLE
[codex] 削除ボタンのデザインを調整

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -109,18 +109,24 @@
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>
         {% if can_delete %}
-        <form
-          action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-          method="POST"
-          class="owner-delete-form"
-          data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
-        >
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="modern-btn modern-btn-danger">
-            {{ icons.icon('trash', size='md', with_text=True) }}
-            ファイルを削除
-          </button>
-        </form>
+        <div class="owner-delete-panel owner-delete-panel--standalone">
+          <div class="owner-delete-copy">
+            <span class="owner-delete-title">共有を終了する</span>
+            <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
+          </div>
+          <form
+            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+            method="POST"
+            class="owner-delete-form"
+            data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+          >
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="modern-btn modern-btn-danger">
+              {{ icons.icon('trash', size='md', with_text=True) }}
+              ファイルを削除
+            </button>
+          </form>
+        </div>
         {% endif %}
       </div>
     </div>
@@ -197,18 +203,24 @@
           <button type="submit" class="modern-btn modern-btn-success">ダウンロード</button>
         </form>
         {% if can_delete %}
-        <form
-          action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-          method="POST"
-          class="owner-delete-form"
-          data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
-        >
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="modern-btn modern-btn-danger">
-            {{ icons.icon('trash', size='md', with_text=True) }}
-            ファイルを削除
-          </button>
-        </form>
+        <div class="owner-delete-panel owner-delete-panel--standalone">
+          <div class="owner-delete-copy">
+            <span class="owner-delete-title">共有を終了する</span>
+            <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
+          </div>
+          <form
+            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+            method="POST"
+            class="owner-delete-form"
+            data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+          >
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="modern-btn modern-btn-danger">
+              {{ icons.icon('trash', size='md', with_text=True) }}
+              ファイルを削除
+            </button>
+          </form>
+        </div>
         {% endif %}
 
         <div class="text-center mt-4">

--- a/Group/templates/group_room/_content.html
+++ b/Group/templates/group_room/_content.html
@@ -70,18 +70,24 @@
                         </div>
                     </div>
                     {% if can_delete %}
-                    <form
-                        action="{{ url_for('group.delete_own_room', room_id=room_id) }}"
-                        method="POST"
-                        class="owner-delete-form"
-                        data-confirm-submit="このグループルームを削除します。ルーム内のファイルもすべて削除され、この操作は元に戻せません。"
-                    >
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="modern-btn modern-btn-danger">
-                            {{ icons.icon('trash', size='md', with_text=True) }}
-                            ルームを削除
-                        </button>
-                    </form>
+                    <div class="owner-delete-panel">
+                        <div class="owner-delete-copy">
+                            <span class="owner-delete-title">ルームを終了する</span>
+                            <span class="owner-delete-description">作成者だけが、ルームとアップロード済みファイルを削除できます。</span>
+                        </div>
+                        <form
+                            action="{{ url_for('group.delete_own_room', room_id=room_id) }}"
+                            method="POST"
+                            class="owner-delete-form"
+                            data-confirm-submit="このグループルームを削除します。ルーム内のファイルもすべて削除され、この操作は元に戻せません。"
+                        >
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="modern-btn modern-btn-danger">
+                                {{ icons.icon('trash', size='md', with_text=True) }}
+                                ルームを削除
+                            </button>
+                        </form>
+                    </div>
                     {% endif %}
                 </div>
 

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -71,18 +71,24 @@
                         </div>
                     </div>
                     {% if can_delete %}
-                    <form
-                        action="{{ url_for('note.delete_own_room', room_id=room_id) }}"
-                        method="POST"
-                        class="owner-delete-form"
-                        data-confirm-submit="このノートルームを削除します。保存済みの本文も削除され、この操作は元に戻せません。"
-                    >
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="modern-btn modern-btn-danger">
-                            {{ icons.icon('trash', size='md', with_text=True) }}
-                            ルームを削除
-                        </button>
-                    </form>
+                    <div class="owner-delete-panel">
+                        <div class="owner-delete-copy">
+                            <span class="owner-delete-title">ルームを終了する</span>
+                            <span class="owner-delete-description">作成者だけが、ルームと保存済みの本文を削除できます。</span>
+                        </div>
+                        <form
+                            action="{{ url_for('note.delete_own_room', room_id=room_id) }}"
+                            method="POST"
+                            class="owner-delete-form"
+                            data-confirm-submit="このノートルームを削除します。保存済みの本文も削除され、この操作は元に戻せません。"
+                        >
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="modern-btn modern-btn-danger">
+                                {{ icons.icon('trash', size='md', with_text=True) }}
+                                ルームを削除
+                            </button>
+                        </form>
+                    </div>
                     {% endif %}
                 </div>
 

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -418,22 +418,94 @@
   text-decoration: none;
 }
 
-.modern-btn-danger {
-  background: linear-gradient(135deg, var(--btn-danger) 0%, #ef4444 100%);
-  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.28);
+.modern-btn.modern-btn-danger {
+  min-height: 2.65rem;
+  padding: 0.72rem 1rem;
+  border: 1px solid rgba(220, 38, 38, 0.28);
+  border-radius: var(--radius-pill, 999px);
+  background: linear-gradient(135deg, #ffffff 0%, #fff5f5 100%);
+  color: var(--btn-danger-hover);
+  box-shadow: 0 10px 22px -16px rgba(185, 28, 28, 0.7);
 }
 
-.modern-btn-danger:hover {
-  background: linear-gradient(135deg, var(--btn-danger-hover) 0%, var(--btn-danger) 100%);
-  box-shadow: 0 6px 20px rgba(220, 38, 38, 0.38);
+.modern-btn.modern-btn-danger:hover,
+.modern-btn.modern-btn-danger:focus-visible {
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--btn-danger-hover) 0%, #ef4444 100%);
+  box-shadow: 0 14px 28px -18px rgba(185, 28, 28, 0.78);
   color: white;
   text-decoration: none;
 }
 
+.modern-btn.modern-btn-danger .svg-icon,
+.modern-btn.modern-btn-danger .svg-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.owner-delete-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  padding: 1rem 1.25rem 1.1rem;
+  border-top: 1px solid rgba(220, 38, 38, 0.12);
+  background:
+    linear-gradient(135deg, rgba(254, 242, 242, 0.82) 0%, rgba(255, 255, 255, 0.96) 100%);
+  text-align: left;
+}
+
+.owner-delete-panel--standalone {
+  width: min(100%, 520px);
+  margin: 1.1rem auto 0;
+  border: 1px solid rgba(220, 38, 38, 0.14);
+  border-radius: 16px;
+  box-shadow: 0 18px 34px -28px rgba(127, 29, 29, 0.42);
+}
+
+.owner-delete-copy {
+  min-width: 0;
+}
+
+.owner-delete-title {
+  display: block;
+  color: #7f1d1d;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.owner-delete-description {
+  display: block;
+  margin-top: 0.18rem;
+  color: #991b1b;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  opacity: 0.78;
+}
+
 .owner-delete-form {
   display: flex;
-  justify-content: center;
-  margin-top: 1rem;
+  justify-content: flex-end;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+@media (max-width: 575.98px) {
+  .owner-delete-panel {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 0.95rem 1rem 1rem;
+  }
+
+  .owner-delete-form,
+  .owner-delete-form .modern-btn-danger {
+    width: 100%;
+  }
+
+  .owner-delete-form .modern-btn-danger {
+    justify-content: center;
+  }
 }
 
 /* ===============================================


### PR DESCRIPTION
## 概要
- FSQRの「ファイルを削除」ボタンを、主要CTAから独立した淡い削除アクション帯に変更しました。
- Group Noteの「ルームを削除」ボタンをRoom情報カード下部のアクション帯として配置し、余白と背景をカード内レイアウトに合わせました。
- 削除ボタンのCSS優先度を調整し、各ページテーマの汎用ボタン色に上書きされない危険色デザインにしました。

## 影響
- 削除権限や削除処理のロジックは変更していません。
- 表示対象は作成者/アップロード者セッションで表示される削除操作のみです。

## 確認
- `python3 -m ruff check $(git ls-files '*.py')`\n- `python3 -m ruff format --check $(git ls-files '*.py')`\n- `python3 -m pytest tests/test_fsqr.py tests/test_group.py tests/test_note.py tests/test_room_access.py`\n- `git diff --check`