### PR TITLE
UI改善: ボタン色とパネル配置の調整

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -98,6 +98,26 @@
                 </span>
               </div>
             </div>
+            {% if can_delete %}
+            <div class="owner-delete-panel">
+              <div class="owner-delete-copy">
+                <span class="owner-delete-title">共有を終了する</span>
+                <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
+              </div>
+              <form
+                action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+                method="POST"
+                class="owner-delete-form"
+                data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="modern-btn modern-btn-danger">
+                  {{ icons.icon('trash', size='md', with_text=True) }}
+                  ファイルを削除
+                </button>
+              </form>
+            </div>
+            {% endif %}
           </div>
 
           <div class="qr-code-container" id="shareQrCode" data-share-url="{{ url | e }}" aria-label="共有用QRコード">
@@ -108,26 +128,6 @@
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>
-        {% if can_delete %}
-        <div class="owner-delete-panel owner-delete-panel--standalone">
-          <div class="owner-delete-copy">
-            <span class="owner-delete-title">共有を終了する</span>
-            <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
-          </div>
-          <form
-            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-            method="POST"
-            class="owner-delete-form"
-            data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
-          >
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="modern-btn modern-btn-danger">
-              {{ icons.icon('trash', size='md', with_text=True) }}
-              ファイルを削除
-            </button>
-          </form>
-        </div>
-        {% endif %}
       </div>
     </div>
 
@@ -195,6 +195,26 @@
                 </span>
               </div>
             </div>
+            {% if can_delete %}
+            <div class="owner-delete-panel">
+              <div class="owner-delete-copy">
+                <span class="owner-delete-title">共有を終了する</span>
+                <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
+              </div>
+              <form
+                action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+                method="POST"
+                class="owner-delete-form"
+                data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="modern-btn modern-btn-danger">
+                  {{ icons.icon('trash', size='md', with_text=True) }}
+                  ファイルを削除
+                </button>
+              </form>
+            </div>
+            {% endif %}
           </div>
         </div>
 
@@ -202,26 +222,6 @@
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="modern-btn modern-btn-success">ダウンロード</button>
         </form>
-        {% if can_delete %}
-        <div class="owner-delete-panel owner-delete-panel--standalone">
-          <div class="owner-delete-copy">
-            <span class="owner-delete-title">共有を終了する</span>
-            <span class="owner-delete-description">アップロードした本人だけが、このファイルを削除できます。</span>
-          </div>
-          <form
-            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-            method="POST"
-            class="owner-delete-form"
-            data-confirm-submit="このファイルを削除します。この操作は元に戻せません。"
-          >
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="modern-btn modern-btn-danger">
-              {{ icons.icon('trash', size='md', with_text=True) }}
-              ファイルを削除
-            </button>
-          </form>
-        </div>
-        {% endif %}
 
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn">→他のファイルをアップロード</a>

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -423,18 +423,18 @@
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 12px;
-  background: #fef2f2;
-  color: #dc2626;
+  background: #ef4444;
+  color: white;
   font-weight: 600;
-  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.08);
+  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.15);
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .modern-btn.modern-btn-danger:hover,
 .modern-btn.modern-btn-danger:focus-visible {
   border-color: transparent;
-  background: #ef4444;
-  box-shadow: 0 6px 16px rgba(220, 38, 38, 0.25);
+  background: #dc2626;
+  box-shadow: 0 6px 16px rgba(220, 38, 38, 0.3);
   transform: translateY(-2px);
   color: white;
   text-decoration: none;


### PR DESCRIPTION
「ファイルを削除」ボタンの通常時の色を濃い赤に変更し、視認性を高めました。また、fsqrの削除パネルを「ダウンロード先の情報」カード内に移動し、noteやgroup画面とレイアウトの統一を図りました。