### PR TITLE
[codex] FS!QRの削除ボタンをカード内に配置

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -98,6 +98,26 @@
                 </span>
               </div>
             </div>
+            {% if can_delete %}
+            <div class="owner-delete-panel">
+              <div class="owner-delete-copy">
+                <span class="owner-delete-title">{{ t('fsqr.delete_sharing_title') }}</span>
+                <span class="owner-delete-description">{{ t('fsqr.delete_sharing_description') }}</span>
+              </div>
+              <form
+                action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+                method="POST"
+                class="owner-delete-form"
+                data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="modern-btn modern-btn-danger">
+                  {{ icons.icon('trash', size='md', with_text=True) }}
+                  {{ t('fsqr.delete_file_button') }}
+                </button>
+              </form>
+            </div>
+            {% endif %}
           </div>
 
           <div class="qr-code-container" id="shareQrCode" data-share-url="{{ url | e }}" aria-label="共有用QRコード">
@@ -108,26 +128,6 @@
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn modern-btn-success">→他のファイルをアップロード</a>
         </div>
-        {% if can_delete %}
-        <div class="owner-delete-panel owner-delete-panel--standalone">
-          <div class="owner-delete-copy">
-            <span class="owner-delete-title">{{ t('fsqr.delete_sharing_title') }}</span>
-            <span class="owner-delete-description">{{ t('fsqr.delete_sharing_description') }}</span>
-          </div>
-          <form
-            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-            method="POST"
-            class="owner-delete-form"
-            data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
-          >
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="modern-btn modern-btn-danger">
-              {{ icons.icon('trash', size='md', with_text=True) }}
-              {{ t('fsqr.delete_file_button') }}
-            </button>
-          </form>
-        </div>
-        {% endif %}
       </div>
     </div>
 
@@ -195,6 +195,26 @@
                 </span>
               </div>
             </div>
+            {% if can_delete %}
+            <div class="owner-delete-panel">
+              <div class="owner-delete-copy">
+                <span class="owner-delete-title">{{ t('fsqr.delete_sharing_title') }}</span>
+                <span class="owner-delete-description">{{ t('fsqr.delete_sharing_description') }}</span>
+              </div>
+              <form
+                action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
+                method="POST"
+                class="owner-delete-form"
+                data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="modern-btn modern-btn-danger">
+                  {{ icons.icon('trash', size='md', with_text=True) }}
+                  {{ t('fsqr.delete_file_button') }}
+                </button>
+              </form>
+            </div>
+            {% endif %}
           </div>
         </div>
 
@@ -202,26 +222,6 @@
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="modern-btn modern-btn-success">ダウンロード</button>
         </form>
-        {% if can_delete %}
-        <div class="owner-delete-panel owner-delete-panel--standalone">
-          <div class="owner-delete-copy">
-            <span class="owner-delete-title">{{ t('fsqr.delete_sharing_title') }}</span>
-            <span class="owner-delete-description">{{ t('fsqr.delete_sharing_description') }}</span>
-          </div>
-          <form
-            action="{{ url_for('fsqr.delete_upload', secure_id=secure_id) }}"
-            method="POST"
-            class="owner-delete-form"
-            data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
-          >
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="modern-btn modern-btn-danger">
-              {{ icons.icon('trash', size='md', with_text=True) }}
-              {{ t('fsqr.delete_file_button') }}
-            </button>
-          </form>
-        </div>
-        {% endif %}
 
         <div class="text-center mt-4">
           <a href="/fs-qr" class="modern-btn">→他のファイルをアップロード</a>

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -423,18 +423,18 @@
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 12px;
-  background: #fef2f2;
-  color: #dc2626;
+  background: #dc2626;
+  color: #fff;
   font-weight: 600;
-  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.08);
+  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.24);
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .modern-btn.modern-btn-danger:hover,
 .modern-btn.modern-btn-danger:focus-visible {
   border-color: transparent;
-  background: #ef4444;
-  box-shadow: 0 6px 16px rgba(220, 38, 38, 0.25);
+  background: #b91c1c;
+  box-shadow: 0 6px 16px rgba(220, 38, 38, 0.34);
   transform: translateY(-2px);
   color: white;
   text-decoration: none;

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -20,8 +20,7 @@ class OwnerDeletePanelScanner(HTMLParser):
                 break
 
         if "owner-delete-panel" in classes and any(
-            "room-info-card" in parent_classes
-            for parent_classes in self._class_stack
+            "room-info-card" in parent_classes for parent_classes in self._class_stack
         ):
             self.has_owner_delete_panel_inside_room_info_card = True
 

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -1,8 +1,36 @@
 import os
+from html.parser import HTMLParser
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from starlette.testclient import TestClient
+
+
+class OwnerDeletePanelScanner(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._class_stack = []
+        self.has_owner_delete_panel_inside_room_info_card = False
+
+    def handle_starttag(self, tag, attrs):
+        classes = set()
+        for name, value in attrs:
+            if name == "class" and value:
+                classes = set(value.split())
+                break
+
+        if "owner-delete-panel" in classes and any(
+            "room-info-card" in parent_classes
+            for parent_classes in self._class_stack
+        ):
+            self.has_owner_delete_panel_inside_room_info_card = True
+
+        if tag not in {"br", "hr", "img", "input", "link", "meta"}:
+            self._class_stack.append(classes)
+
+    def handle_endtag(self, tag):
+        if self._class_stack:
+            self._class_stack.pop()
 
 
 def test_fsqr_menu(test_client: TestClient):
@@ -262,6 +290,10 @@ def test_fsqr_owner_session_can_delete_uploaded_file(test_client: TestClient, tm
 
     assert upload_response.status_code == 200
     assert "ファイルを削除" in page_response.text
+    scanner = OwnerDeletePanelScanner()
+    scanner.feed(page_response.text)
+    assert scanner.has_owner_delete_panel_inside_room_info_card
+    assert "owner-delete-panel--standalone" not in page_response.text
     assert delete_response.status_code == 302
     assert delete_response.headers["location"] == "/remove-succes"
     remove_mock.assert_awaited_once_with(secure_id)


### PR DESCRIPTION
## 概要
- FS!QRの「ファイルを削除」パネルを、アップロード完了画面の「ダウンロード先の情報」カード内に配置しました。
- ダウンロード画面の「ファイル情報」カード内にも同じ削除パネルを配置し、note/group と同じ構造に揃えました。
- 削除ボタンの通常状態を濃い赤背景に変更し、ホバー前でも危険操作として視認しやすくしました。

## 影響
- FS!QRの削除導線の見た目と配置が変わります。
- `modern-btn-danger` の通常/ホバー配色が濃くなるため、同じ共通クラスを使う note/group の削除ボタンも濃い赤基調になります。

## 検証
- `python3 -m pytest tests/test_fsqr.py`