### PR TITLE
FSQRの受信者画面でもパスワードを平文表示する

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -169,16 +169,12 @@
                   <span class="room-info-value-row">
                     <span
                       id="downloadPasswordValue"
-                      class="room-info-value-text sensitive-value is-masked"
+                      class="room-info-value-text sensitive-value"
                       data-visible-value="{{ password | e }}"
-                      data-masked-value="••••••"
-                    >••••••</span>
-                    <button type="button" class="copy-inline-btn reveal-value-button"
-                      data-target="downloadPasswordValue"
-                      data-show-label='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3.53 9.47a.75.75 0 0 1 1.06 0l.97.97a9.77 9.77 0 0 1 12.88 0l.97-.97a.75.75 0 1 1 1.06 1.06l-1.03 1.03a9.72 9.72 0 0 1 0 1.88l1.03 1.03a.75.75 0 1 1-1.06 1.06l-.97-.97a9.77 9.77 0 0 1-1.88 1.27l-.37 1.38a.75.75 0 1 1-1.45-.39l.25-.93a9.83 9.83 0 0 1-2.11.23 9.83 9.83 0 0 1-2.1-.23l.24.93a.75.75 0 1 1-1.45.39l-.37-1.38a9.77 9.77 0 0 1-1.88-1.27l-.97.97a.75.75 0 1 1-1.06-1.06l1.03-1.03a9.72 9.72 0 0 1 0-1.88L3.53 10.53a.75.75 0 0 1 0-1.06ZM12 9a2.25 2.25 0 1 0 0 4.5A2.25 2.25 0 0 0 12 9Z"/></svg>'
-                      data-hide-label='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3.53 2.47a.75.75 0 0 0-1.06 1.06l17 17a.75.75 0 1 0 1.06-1.06l-2.24-2.24a10.75 10.75 0 0 0 2.74-3.68.75.75 0 0 0 0-.6C19.27 9.73 15.97 7.5 12 7.5c-1.29 0-2.5.24-3.6.68L6.7 6.48A10.4 10.4 0 0 1 12 5.25c4.4 0 8.11 2.54 9.97 6.75a.75.75 0 0 1 0 .6 11.8 11.8 0 0 1-2.62 3.67l-1.65-1.65a9.86 9.86 0 0 0 1.73-2.32C17.75 9.12 15.1 7.5 12 7.5c-.85 0-1.67.12-2.43.35l1.7 1.7a3.75 3.75 0 0 1 4.18 4.18l1.2 1.2c.38-.47.72-.98 1-1.53a.75.75 0 0 1 1.34.67 10.96 10.96 0 0 1-1.2 1.82l1.47 1.47A11.98 11.98 0 0 0 21 12.3C19.36 8.7 16.01 6.75 12 6.75c-1.67 0-3.22.34-4.58.96l-1.56-1.56A11.93 11.93 0 0 0 3 12.3a12.65 12.65 0 0 0 3.93 4.82l-1.4 1.4a.75.75 0 1 0 1.06 1.06l11.88-11.88-1.06-1.06-2.07 2.07a3.75 3.75 0 0 0-4.05-1.2L9.8 6.02A10.16 10.16 0 0 0 7.4 7.2L4.6 4.4a.75.75 0 0 0-1.06 0ZM12 10.5c.2 0 .39.04.56.1l-1.96 1.96A1.5 1.5 0 0 1 12 10.5Zm-6.86 3.63a10.7 10.7 0 0 1-.58-1.2C5.8 10.08 8.55 8.25 12 8.25c.58 0 1.14.05 1.67.16l-1.44 1.44a3 3 0 0 0-3.82 3.82L7.2 14.88a9.9 9.9 0 0 1-2.06-1.75Z"/></svg>'
-                      aria-label="パスワードを表示" title="パスワードを表示">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3.53 9.47a.75.75 0 0 1 1.06 0l.97.97a9.77 9.77 0 0 1 12.88 0l.97-.97a.75.75 0 1 1 1.06 1.06l-1.03 1.03a9.72 9.72 0 0 1 0 1.88l1.03 1.03a.75.75 0 1 1-1.06 1.06l-.97-.97a9.77 9.77 0 0 1-1.88 1.27l-.37 1.38a.75.75 0 1 1-1.45-.39l.25-.93a9.83 9.83 0 0 1-2.11.23 9.83 9.83 0 0 1-2.1-.23l.24.93a.75.75 0 1 1-1.45.39l-.37-1.38a9.77 9.77 0 0 1-1.88-1.27l-.97.97a.75.75 0 1 1-1.06-1.06l1.03-1.03a9.72 9.72 0 0 1 0-1.88L3.53 10.53a.75.75 0 0 1 0-1.06ZM12 9a2.25 2.25 0 1 0 0 4.5A2.25 2.25 0 0 0 12 9Z"/></svg>
+                    >{{ password | e }}</span>
+                    <button type="button" class="copy-inline-btn copy-url-button" data-copy-value="{{ password | e }}" data-default-label="コピー" data-copied-label="コピー済み" aria-label="パスワードをコピー">
+                      <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1Zm4 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h12v14Z"/></svg>
+                      <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>
                     </button>
                   </span>
                 </span>


### PR DESCRIPTION
## 概要
FSQR のファイル情報カードで、受信者（ダウンロード）画面のパスワード表示を、送信者（アップロード完了）画面と同じ挙動に統一します。

## 背景・課題
これまでパスワードの表示挙動が画面ごとに異なっていました。

- **アップロード完了画面（送信者）**: パスワードを最初から平文で表示
- **ダウンロード画面（受信者）**: パスワードを `••••••` でマスクし、目アイコン（表示トグル）を押さないと確認できない

受信者側も送信者側と同じようにパスワードを確認できるようにしてほしい、という要望に対応します。

## 変更内容
`FSQR/templates/fs_qr_info/_content.html` の受信者向けパスワード欄を変更:

- マスク表示（`is-masked` / `data-masked-value` / `••••••`）を廃止し、最初から `{{ password }}` を平文表示
- 表示トグルボタン（`reveal-value-button`）を、送信者画面と同じコピーボタン（`copy-url-button`）に置き換え

FSQR テンプレート内でパスワードをマスクしていたのはこの1箇所のみで、これで送信者・受信者の両画面でパスワードの見え方が揃います。

## 補足
マスク表示用の CSS（`_styles.html` の `.sensitive-value.is-masked`）と JS（`_scripts.html` の `reveal-value-button` ハンドラ）は、本変更により未使用となりました。動作上は無害なため本 PR では残していますが、別途整理可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)