### PR TITLE
Group/Noteの共有URL受信者にもパスワードを表示する

### DIFF
--- a/Group/group_routes_room.py
+++ b/Group/group_routes_room.py
@@ -23,6 +23,7 @@ from share_links import (
     build_share_url,
     create_share_link,
     resolve_share_link,
+    share_link_metadata,
 )
 from web import get_or_create_csrf_token, render_template
 from web import enforce_csrf
@@ -103,7 +104,10 @@ def register_group_room_access_route(router: APIRouter):
             )
 
         await register_success(SCOPE_GROUP, ip)
-        remember_group_room_access(request, room_id, token)
+        link_password = share_link_metadata(link).get("password")
+        remember_group_room_access(
+            request, room_id, share_token=token, password=link_password
+        )
         return _render_group_room(request, room_id, record)
 
     @router.get("/group/r/{room_id}", name="group.group_room")
@@ -213,7 +217,7 @@ def register_group_create_room_route(router: APIRouter):
                 service_key=ServiceKey.GROUP,
                 resource_id=room_id,
                 expires_at=datetime.now() + timedelta(days=retention_days),
-                metadata={"id": room_id},
+                metadata={"id": room_id, "password": password},
             )
         except Exception:
             logger.exception("Failed to create Group share link: room_id=%s", room_id)

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -25,6 +25,7 @@ from share_links import (
     build_share_url,
     create_share_link,
     resolve_share_link,
+    share_link_metadata,
 )
 from web import (
     enforce_csrf,
@@ -247,6 +248,7 @@ async def create_note_room(request: Request):  # noqa: C901
             service_key=ServiceKey.NOTE,
             resource_id=room_id,
             expires_at=created.get("expires_at"),
+            metadata={"id": room_id, "password": password},
         )
     except Exception:
         logger.exception("Failed to create Note share link: room_id=%s", room_id)
@@ -345,7 +347,10 @@ async def note_share(request: Request, token: str):
         return _gone_response(
             request, "このノートルームは期限切れ、または削除済みです。"
         )
-    remember_note_room_access(request, room_id, share_token=token)
+    link_password = share_link_metadata(link).get("password")
+    remember_note_room_access(
+        request, room_id, share_token=token, password=link_password
+    )
     return _render_note_room(request, room_id, meta)
 
 

--- a/share_links.py
+++ b/share_links.py
@@ -142,6 +142,27 @@ async def resolve_share_link(
     return row
 
 
+def share_link_metadata(link: Mapping[str, Any] | None) -> dict:
+    """Return a share link's metadata as a dict.
+
+    The ``metadata`` column is stored as JSON and may be returned by the driver
+    either as an already-decoded mapping or as a raw JSON string. Normalize both
+    cases and fall back to an empty dict when absent or malformed.
+    """
+    if not link:
+        return {}
+    raw = link.get("metadata")
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    if isinstance(raw, (str, bytes, bytearray)):
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
 async def revoke_resource_links(*, service_key: ServiceKey, resource_id: str) -> None:
     query = text("""
         UPDATE share_links

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -223,7 +223,11 @@ def test_group_share_entry_renders_room_without_redirect(test_client: TestClient
         patch(
             "Group.group_routes_room.resolve_share_link",
             new_callable=AsyncMock,
-            return_value={"service_key": "group", "resource_id": "grp999"},
+            return_value={
+                "service_key": "group",
+                "resource_id": "grp999",
+                "metadata": {"id": "grp999", "password": "024680"},
+            },
         ),
         patch(
             "Group.group_routes_room.get_room_if_active",
@@ -239,6 +243,8 @@ def test_group_share_entry_renders_room_without_redirect(test_client: TestClient
     html = response.text
     assert "グループファイル共有" in html
     assert f'data-share-url="http://testserver/group/s/{share_token}"' in html
+    # 共有URLで入った受信者にもパスワードが表示される
+    assert "024680" in html
 
 
 # --- group_upload: 認証失敗 → 400 ---

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -161,7 +161,11 @@ def test_note_share_entry_renders_room_without_redirect(test_client: TestClient)
         patch(
             "Note.note_app.resolve_share_link",
             new_callable=AsyncMock,
-            return_value={"service_key": "note", "resource_id": "not999"},
+            return_value={
+                "service_key": "note",
+                "resource_id": "not999",
+                "metadata": {"id": "not999", "password": "024680"},
+            },
         ),
         patch(
             "Note.note_app._get_room_if_valid",
@@ -180,6 +184,8 @@ def test_note_share_entry_renders_room_without_redirect(test_client: TestClient)
     html = response.text
     assert "リアルタイムノート" in html
     assert f'data-share-url="http://testserver/note/s/{share_token}"' in html
+    # 共有URLで入った受信者にもパスワードが表示される
+    assert "024680" in html
 
 
 def test_note_direct_not_found(test_client: TestClient):


### PR DESCRIPTION
## 概要
Group・Note のルームで、共有URL（QRコード）から入った受信者にも「Room情報」のパスワードが表示されるようにします。FSQR に続き、受信者側でもパスワードを確認できるようにする対応の一環です。

## 背景・課題
これまで Group/Note のパスワードは、**セッションに平文を保持しているユーザー**（ルーム作成者、または ID＋パスワードで参加したユーザー）にしか表示されませんでした。

- DB にはパスワードが**ハッシュ化**されて保存され、平文は復元できない
- キャッシュからもパスワードは除外される
- 共有URL（`/group/s/{token}` ・ `/note/s/{token}`）から入った受信者はセッションに平文を持たない

その結果、テンプレートの `{% if password %}` が偽となり、受信者の「Room情報」ではパスワード欄が表示されていませんでした。

## 変更内容
1. **ルーム作成時に共有リンクの `metadata` へ平文パスワードを保存**
   - `Group/group_routes_room.py`: `metadata={"id": room_id, "password": password}`
   - `Note/note_app.py`: 同上
2. **共有エントリで `metadata` からパスワードを取り出してセッションへ復元**
   - `group_share_entry` / `note_share` で取得し、`remember_*_room_access(..., password=...)` でセッションに保存 → テンプレートで表示
3. **`metadata` を安全に正規化する共通ヘルパー `share_link_metadata()` を追加**（`share_links.py`）
   - JSON 列は driver により文字列・辞書どちらでも返り得るため両対応

## セキュリティについて
共有トークン自体が既にルームへのアクセス権を与えるため、トークン保持者にパスワードを渡しても権限拡大にはなりません。平文パスワードはサーバー側の `share_links.metadata`（トークンのハッシュで保護）にのみ保存されます。なお既存ルームには metadata に平文が無いため、本変更の効果は新規作成ルームから適用されます。

## テスト
- `tests/test_group.py` / `tests/test_note.py` の共有エントリのテストに、metadata 由来のパスワードが HTML に表示されることのアサーションを追加
- `pytest tests/test_group.py tests/test_note.py tests/test_share_links.py tests/test_note_data_shared_links.py` 全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)