### PR TITLE
共有パスワードの暗号化保存とFSQR受信者画面への表示対応

### DIFF
--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -38,7 +38,9 @@ from share_links import (
     ServiceKey,
     build_share_url,
     create_share_link,
+    encrypt_share_password,
     resolve_share_link,
+    share_link_password,
 )
 from web import build_url, enforce_csrf, render_template, wants_json_response
 import room_access
@@ -321,7 +323,7 @@ async def upload(  # noqa: C901
             service_key=ServiceKey.FSQR,
             resource_id=secure_id,
             expires_at=datetime.now() + timedelta(days=retention_days_int),
-            metadata={"id": id_val},
+            metadata={"id": id_val, "password_enc": encrypt_share_password(password)},
         )
         os.replace(temp_path, final_path)
     except Exception:
@@ -460,13 +462,14 @@ async def fs_qr_share(request: Request, token: str):
     await register_success(SCOPE_QR, ip)
     record = data[0]
     retention_days, deletion_date = _calculate_deletion_context(record)
+    link_password = share_link_password(link)
 
     return render_template(
         request,
         "info.html",
         mode="download",
         id=record["id"],
-        password="",
+        password=link_password,
         secure_id=record["secure_id"],
         file_type=record.get("file_type", "multiple"),
         original_filename=record.get("original_filename", ""),

--- a/Group/group_routes_room.py
+++ b/Group/group_routes_room.py
@@ -22,8 +22,9 @@ from share_links import (
     build_room_url,
     build_share_url,
     create_share_link,
+    encrypt_share_password,
     resolve_share_link,
-    share_link_metadata,
+    share_link_password,
 )
 from web import get_or_create_csrf_token, render_template
 from web import enforce_csrf
@@ -104,7 +105,7 @@ def register_group_room_access_route(router: APIRouter):
             )
 
         await register_success(SCOPE_GROUP, ip)
-        link_password = share_link_metadata(link).get("password")
+        link_password = share_link_password(link)
         remember_group_room_access(
             request, room_id, share_token=token, password=link_password
         )
@@ -217,7 +218,10 @@ def register_group_create_room_route(router: APIRouter):
                 service_key=ServiceKey.GROUP,
                 resource_id=room_id,
                 expires_at=datetime.now() + timedelta(days=retention_days),
-                metadata={"id": room_id, "password": password},
+                metadata={
+                    "id": room_id,
+                    "password_enc": encrypt_share_password(password),
+                },
             )
         except Exception:
             logger.exception("Failed to create Group share link: room_id=%s", room_id)

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -24,8 +24,9 @@ from share_links import (
     build_room_url,
     build_share_url,
     create_share_link,
+    encrypt_share_password,
     resolve_share_link,
-    share_link_metadata,
+    share_link_password,
 )
 from web import (
     enforce_csrf,
@@ -248,7 +249,10 @@ async def create_note_room(request: Request):  # noqa: C901
             service_key=ServiceKey.NOTE,
             resource_id=room_id,
             expires_at=created.get("expires_at"),
-            metadata={"id": room_id, "password": password},
+            metadata={
+                "id": room_id,
+                "password_enc": encrypt_share_password(password),
+            },
         )
     except Exception:
         logger.exception("Failed to create Note share link: room_id=%s", room_id)
@@ -347,7 +351,7 @@ async def note_share(request: Request, token: str):
         return _gone_response(
             request, "このノートルームは期限切れ、または削除済みです。"
         )
-    link_password = share_link_metadata(link).get("password")
+    link_password = share_link_password(link)
     remember_note_room_access(
         request, room_id, share_token=token, password=link_password
     )

--- a/share_links.py
+++ b/share_links.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
@@ -8,6 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Mapping
 
+from cryptography.fernet import Fernet, InvalidToken
 from fastapi import Request
 from sqlalchemy import text
 
@@ -52,6 +54,35 @@ def hash_token(token: str) -> str:
     if secret:
         return hmac.new(secret, token.encode("utf-8"), hashlib.sha256).hexdigest()
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+_fernet: Fernet | None = None
+
+
+def _get_fernet() -> Fernet:
+    """Return a process-wide Fernet derived from SECRET_KEY."""
+    global _fernet
+    if _fernet is None:
+        digest = hashlib.sha256((SECRET_KEY or "").encode("utf-8")).digest()
+        _fernet = Fernet(base64.urlsafe_b64encode(digest))
+    return _fernet
+
+
+def encrypt_share_password(password: str) -> str:
+    """Encrypt a room password for at-rest storage in share link metadata."""
+    if not password:
+        return ""
+    return _get_fernet().encrypt(password.encode("utf-8")).decode("ascii")
+
+
+def decrypt_share_password(token: str) -> str:
+    """Decrypt a password produced by :func:`encrypt_share_password`."""
+    if not token:
+        return ""
+    try:
+        return _get_fernet().decrypt(token.encode("utf-8")).decode("utf-8")
+    except (InvalidToken, ValueError, TypeError):
+        return ""
 
 
 def build_share_url(
@@ -161,6 +192,16 @@ def share_link_metadata(link: Mapping[str, Any] | None) -> dict:
             return {}
         return parsed if isinstance(parsed, dict) else {}
     return {}
+
+
+def share_link_password(link: Mapping[str, Any] | None) -> str:
+    """Return the decrypted room password stored in a share link's metadata.
+
+    The password is persisted encrypted under ``password_enc``; only holders of
+    the share token (who already have room access) can have it resolved here.
+    """
+    enc = share_link_metadata(link).get("password_enc")
+    return decrypt_share_password(enc) if isinstance(enc, str) else ""
 
 
 async def revoke_resource_links(*, service_key: ServiceKey, resource_id: str) -> None:

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -465,6 +465,55 @@ def test_upload_complete_hides_password_for_token_url(
     assert f"/fs-qr/s/{share_token}" in response.text
 
 
+def test_share_entry_shows_password_to_receiver(test_client: TestClient):
+    """共有URLで入った受信者にも暗号化保存したパスワードを復号して表示する"""
+    from share_links import encrypt_share_password
+
+    share_token = "share-token-receiver-pw-1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    secure_id = "abc123-1234567890-report.pdf"
+    mock_data = [
+        {
+            "id": "abc123",
+            "password": "scrypt:hashed-password",
+            "secure_id": secure_id,
+            "file_type": "single",
+            "original_filename": "report.pdf",
+            "retention_days": 7,
+            "time": None,
+        }
+    ]
+    with (
+        patch(
+            "FSQR.fsqr_app.check_rate_limit",
+            new_callable=AsyncMock,
+            return_value=(True, None, None),
+        ),
+        patch(
+            "FSQR.fsqr_app.resolve_share_link",
+            new_callable=AsyncMock,
+            return_value={
+                "service_key": "fsqr",
+                "resource_id": secure_id,
+                "metadata": {
+                    "id": "abc123",
+                    "password_enc": encrypt_share_password("123456"),
+                },
+            },
+        ),
+        patch(
+            "FSQR.fsqr_data.get_data", new_callable=AsyncMock, return_value=mock_data
+        ),
+        patch("FSQR.fsqr_app.register_success", new_callable=AsyncMock),
+    ):
+        response = test_client.get(f"/fs-qr/s/{share_token}")
+
+    assert response.status_code == 200
+    html = response.text
+    # 復号した平文パスワードが表示される（ハッシュは出ない）
+    assert "123456" in html
+    assert "scrypt:hashed-password" not in html
+
+
 def test_upload_rejects_plain_single_file(test_client: TestClient, tmp_path):
     """暗号化されていない単一ファイルはアップロード処理として拒否する"""
     with patch("FSQR.fsqr_app.STATIC", str(tmp_path)):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, mock_open, patch
 from starlette.testclient import TestClient
 
 from Group import group_data
+from share_links import encrypt_share_password
 
 
 def test_group_menu(test_client: TestClient):
@@ -226,7 +227,10 @@ def test_group_share_entry_renders_room_without_redirect(test_client: TestClient
             return_value={
                 "service_key": "group",
                 "resource_id": "grp999",
-                "metadata": {"id": "grp999", "password": "024680"},
+                "metadata": {
+                    "id": "grp999",
+                    "password_enc": encrypt_share_password("024680"),
+                },
             },
         ),
         patch(

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock, patch
 
 from starlette.testclient import TestClient
 
+from share_links import encrypt_share_password
+
 
 def test_note_menu(test_client: TestClient):
     response = test_client.get("/note_menu")
@@ -164,7 +166,10 @@ def test_note_share_entry_renders_room_without_redirect(test_client: TestClient)
             return_value={
                 "service_key": "note",
                 "resource_id": "not999",
-                "metadata": {"id": "not999", "password": "024680"},
+                "metadata": {
+                    "id": "not999",
+                    "password_enc": encrypt_share_password("024680"),
+                },
             },
         ),
         patch(

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -40,6 +40,40 @@ def test_hash_token_without_secret_uses_plain_sha256():
         assert share_links.hash_token("token") == hashlib.sha256(b"token").hexdigest()
 
 
+def test_share_password_round_trip_and_not_cleartext():
+    enc = share_links.encrypt_share_password("024680")
+    # 暗号文には平文が含まれない（at-rest で読めない）
+    assert "024680" not in enc
+    assert enc != "024680"
+    assert share_links.decrypt_share_password(enc) == "024680"
+
+
+def test_share_link_password_decrypts_metadata():
+    enc = share_links.encrypt_share_password("135790")
+    link = {"resource_id": "r1", "metadata": {"password_enc": enc}}
+    assert share_links.share_link_password(link) == "135790"
+
+
+def test_share_link_password_absent_or_invalid_returns_empty():
+    assert share_links.share_link_password(None) == ""
+    assert share_links.share_link_password({"metadata": {}}) == ""
+    assert (
+        share_links.share_link_password({"metadata": {"password_enc": "not-a-token"}})
+        == ""
+    )
+
+
+def test_decrypt_with_wrong_key_returns_empty():
+    # 鍵（SECRET_KEY）が異なると復号できない
+    share_links._fernet = None
+    with patch("share_links.SECRET_KEY", "key-a"):
+        enc = share_links.encrypt_share_password("024680")
+    share_links._fernet = None
+    with patch("share_links.SECRET_KEY", "key-b"):
+        assert share_links.decrypt_share_password(enc) == ""
+    share_links._fernet = None
+
+
 def test_build_share_url_and_room_url():
     request = FakeRequest()
 


### PR DESCRIPTION
## 概要
2点を対応します。

1. **FSQR のダウンロード画面（共有URL受信者）でパスワードが表示されない問題の修正**
2. **セキュリティレビュー指摘への対応**（PR #189 で共有リンク metadata に保存していた平文パスワードを暗号化）

## 背景
- PR #189 で Group/Note の共有URL受信者にパスワードを表示するようにしたが、**FSQR は同じ対応が漏れていた**。`/fs-qr/s/{token}`（`fs_qr_share`）が `password=""` で描画しており、受信者の「ファイル情報」にパスワード欄が出ていなかった。
- PR #189 では平文パスワードを `share_links.metadata` に保存していたため、自動セキュリティレビューで以下が指摘された:
  - [HIGH] 平文資格情報の at-rest 保存（DBダンプ/SQLi時に読める）
  - [HIGH] 失効バイパス（受信者がパスワードを知ると、共有リンク失効後も ID＋パスワードで再入室できる）

## 変更内容
### 暗号化保存（`share_links.py`）
- `encrypt_share_password()` / `decrypt_share_password()` を追加。`SECRET_KEY` から導出した鍵で **Fernet 暗号化**。
- metadata には平文 `password` ではなく暗号文 `password_enc` を保存。
- `share_link_password(link)` で復号して取り出す共通ヘルパーを追加。
- Group / Note / FSQR の作成フローを `password_enc`（暗号化）に統一。

### FSQR 受信者表示（`FSQR/fsqr_app.py`）
- アップロード時に metadata へ `password_enc` を保存。
- `fs_qr_share` で metadata から復号し、ダウンロード画面に `password` を渡す（従来は `""`）。
- これで **FSQR・Group・Note の3サービスすべて**で受信者にパスワードが表示される。

## セキュリティ上の判断
- **at-rest 平文（指摘1）**: 暗号化保存で解消。平文はサーバーメモリ上で復号時のみ存在。
- **失効バイパス（指摘2・3）**: Group/Note は複数人で ID＋パスワードを共有する共同ルーム、FSQR は共有を前提とした受け渡しという製品特性上、受信者へのパスワード開示は意図された挙動。共有トークン自体が既にアクセス権を与えるため、開示による即時の権限拡大はない。この点は**ユーザーと確認のうえ「表示する＋暗号化保存」を選択**。

## テスト
- `share_links`: 暗号化ラウンドトリップ / 鍵不一致で復号不可 / metadata 復号 / 不正値で空文字 を追加
- `Group` / `Note` / `FSQR`: 共有エントリで受信者にパスワードが表示され、ハッシュ値は出ないことを検証
- 全 370 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)