### PR TITLE
削除完了画面から「管理画面へ」ボタンを削除

### DIFF
--- a/FSQR/templates/after-remove.html
+++ b/FSQR/templates/after-remove.html
@@ -18,7 +18,6 @@
           対象のルームまたはファイルは正常に削除されました。
         </p>
         <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-          <a href="/admin/list" class="btn btn-outline-primary px-4 py-2 rounded-pill">管理画面へ</a>
           <a href="/" class="btn btn-primary px-4 py-2 rounded-pill">ホームへ</a>
         </div>
       </div>


### PR DESCRIPTION
## 概要

ルーム・ファイルを削除したあとに表示される削除完了画面（`after-remove.html`）に表示されていた「管理画面へ」ボタンを削除しました。

## 変更内容

- `FSQR/templates/after-remove.html` から `/admin/list` へのリンクボタン（「管理画面へ」）を削除
- 「ホームへ」ボタンのみを残す

## テスト観点

- [ ] ファイルまたはルームを削除後、削除完了画面に「管理画面へ」ボタンが表示されないこと
- [ ] 「ホームへ」ボタンが表示され、トップページへ遷移できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)