### PR TITLE
[codex] 閲覧ユーザー数表示のリアルタイム性を改善

### DIFF
--- a/presence.py
+++ b/presence.py
@@ -19,11 +19,12 @@ from cache_utils import redis_client
 
 logger = logging.getLogger(__name__)
 
-# ハートビートが途切れてからこの秒数を過ぎた閲覧者は「離脱」とみなす。
-# フロント側のハートビート間隔（PRESENCE_HEARTBEAT_INTERVAL_MS）より十分長くする。
-PRESENCE_WINDOW_SECONDS = 30
+# ハートビートが途切れてからこの秒数で閲覧者を「離脱」とみなす。
+# フロント側は 4 秒間隔で送るため、1 回失敗しても継続閲覧者を残しつつ、
+# 離脱通知が届かなかった場合の表示遅延を 10 秒以内に抑える。
+PRESENCE_WINDOW_SECONDS = 10
 # Redis キー自体の TTL。全員が離脱すればキーを残さず自動消滅させる。
-PRESENCE_KEY_TTL_SECONDS = 120
+PRESENCE_KEY_TTL_SECONDS = 60
 
 # 不特定多数のページから呼ばれる公開 API のため、scope は許可リストで限定する。
 ALLOWED_SCOPES = frozenset(
@@ -63,7 +64,7 @@ def _redis_key(scope: str, key: str) -> str:
 
 def _local_prune(viewers: dict[str, float], now: float) -> None:
     threshold = now - PRESENCE_WINDOW_SECONDS
-    for viewer_id in [vid for vid, seen in viewers.items() if seen < threshold]:
+    for viewer_id in [vid for vid, seen in viewers.items() if seen <= threshold]:
         viewers.pop(viewer_id, None)
 
 

--- a/static/presence.js
+++ b/static/presence.js
@@ -8,7 +8,7 @@
 (function () {
   "use strict";
 
-  var HEARTBEAT_INTERVAL_MS = 10000;
+  var HEARTBEAT_INTERVAL_MS = 4000;
   var STORAGE_KEY = "fsqr_presence_viewer_id";
 
   function t(key, fallback) {

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -50,6 +50,21 @@ def test_stale_viewers_are_pruned(monkeypatch):
     assert _run(presence.count(scope, key)) == 0
 
 
+def test_stale_viewers_expire_at_window_boundary(monkeypatch):
+    scope, key = "fsqr-share", "token-boundary"
+    base = 1_000_000.0
+    monkeypatch.setattr(presence.time, "time", lambda: base)
+    assert _run(presence.heartbeat(scope, key, "viewer-old")) == 1
+    monkeypatch.setattr(
+        presence.time, "time", lambda: base + presence.PRESENCE_WINDOW_SECONDS
+    )
+    assert _run(presence.count(scope, key)) == 0
+
+
+def test_presence_window_matches_realtime_requirement():
+    assert presence.PRESENCE_WINDOW_SECONDS <= 10
+
+
 def test_validators():
     assert presence.is_valid_scope("group")
     assert not presence.is_valid_scope("unknown-scope")


### PR DESCRIPTION
## 概要

全ページで表示している「現在の閲覧ユーザー数」のリアルタイム性を改善しました。

## 変更内容

- フロントエンドの presence ハートビート間隔を 10 秒から 4 秒に短縮
- サーバ側の閲覧中判定ウィンドウを 30 秒から 10 秒に短縮
- Redis キー TTL を 120 秒から 60 秒に短縮
- Redis 不在時のメモリフォールバックでも、10 秒境界で失効するよう調整
- 10 秒以内の失効要件を確認するテストを追加

## 背景・原因

従来はブラウザ終了時の `sendBeacon` が届けば即時に人数が減りますが、通知が失敗した場合はサーバ側の 30 秒ウィンドウが切れるまで閲覧中として残る可能性がありました。要件では遅延は 10 秒まで許容のため、サーバ側の失効判定を 10 秒に短縮し、継続閲覧中のユーザーが落ちにくいようフロント側は 4 秒間隔でハートビートを送るようにしています。

## 影響

- 対象ページ: FSQR 共有/アップロード完了、Group ルーム、Note ルーム
- 離脱通知が届かない場合でも、最大 10 秒程度で閲覧ユーザー数から除外されます
- ハートビート頻度は上がるため、presence API のリクエスト数は増えます

## 検証

- `pytest tests/test_presence.py`
- `pytest tests/test_basic_routes.py`
- `ruff check presence.py tests/test_presence.py`
