### PR TITLE
[codex] 大容量ダウンロードをディスクストリーミング化

### DIFF
--- a/Admin/db_admin.py
+++ b/Admin/db_admin.py
@@ -1,13 +1,13 @@
-import io
 import os
+import tempfile
 import zipfile
 
 from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import text
+from starlette.background import BackgroundTask
 from starlette.responses import (
     FileResponse,
     RedirectResponse,
-    StreamingResponse,
 )
 from werkzeug.utils import secure_filename
 
@@ -48,6 +48,14 @@ UPLOAD_DIR = FSQR_UPLOAD_DIR
 GROUP_UPLOAD_DIR = SETTINGS_GROUP_UPLOAD_DIR
 
 router = APIRouter(prefix="/admin")
+
+
+def _remove_temp_file(path: str):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
 
 COUNT_QUERIES = {
     "fsqr": text("SELECT COUNT(*) FROM fsqr"),
@@ -356,13 +364,19 @@ async def room_download(request: Request, room_id: str):
     if not file_entries:
         raise HTTPException(status_code=404)
 
-    archive = io.BytesIO()
-    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zipf:
-        for entry in file_entries:
-            file_path = entry.get("_path") or os.path.join(folder, entry["stored_name"])
-            zipf.write(file_path, arcname=entry["display_name"])
-
-    archive.seek(0)
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as archive:
+            archive_path = archive.name
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for entry in file_entries:
+                file_path = entry.get("_path") or os.path.join(
+                    folder, entry["stored_name"]
+                )
+                zipf.write(file_path, arcname=entry["display_name"])
+    except Exception:
+        if "archive_path" in locals():
+            _remove_temp_file(archive_path)
+        raise
 
     download_name = (
         secure_filename(f"{record.get('room_id')}_files.zip") or "room_files.zip"
@@ -370,7 +384,12 @@ async def room_download(request: Request, room_id: str):
     headers = {
         "Content-Disposition": build_content_disposition_attachment(download_name)
     }
-    return StreamingResponse(archive, media_type="application/zip", headers=headers)
+    return FileResponse(
+        archive_path,
+        media_type="application/zip",
+        headers=headers,
+        background=BackgroundTask(_remove_temp_file, archive_path),
+    )
 
 
 @router.get("/db/logout", name="db_admin.logout")

--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -8,7 +8,7 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from starlette.responses import RedirectResponse, Response
+from starlette.responses import FileResponse, RedirectResponse
 
 from api_response import api_error_response, api_ok_response
 from file_validation import (
@@ -576,8 +576,7 @@ async def _send_file_response(request: Request, secure_id: str):
     safe_original_filename = sanitize_download_filename(original_filename, default="")
     if safe_original_filename:
         headers["X-Original-Filename"] = safe_original_filename
-    with open(path, "rb") as file:
-        return Response(content=file.read(), media_type=mimetype, headers=headers)
+    return FileResponse(path, media_type=mimetype, headers=headers)
 
 
 @router.get("/search_fs-qr", name="fsqr.search_fs_qr")

--- a/Group/group_routes_file.py
+++ b/Group/group_routes_file.py
@@ -1,13 +1,14 @@
-import io
 import mimetypes
 import os
 import shutil
+import tempfile
 import urllib
 import zipfile
 from typing import Optional
 
 from fastapi import APIRouter, File, Request, UploadFile
-from starlette.responses import Response, StreamingResponse
+from starlette.background import BackgroundTask
+from starlette.responses import FileResponse
 from werkzeug.utils import secure_filename
 
 from api_response import api_error_response, api_ok_response
@@ -104,6 +105,13 @@ def get_preview_metadata(filename: str) -> dict[str, str | bool]:
         "preview_type": "",
         "preview_mime_type": "",
     }
+
+
+def _remove_temp_file(path: str):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
 
 
 def register_group_upload_route(router: APIRouter):
@@ -257,22 +265,26 @@ def register_group_download_all_route(router: APIRouter):
             )
 
         try:
-            zip_stream = io.BytesIO()
-            with zipfile.ZipFile(zip_stream, "w", zipfile.ZIP_DEFLATED) as zipf:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as archive:
+                archive_path = archive.name
+            with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                 for filename, file_path in room_files.items():
-                    with open(file_path, "rb") as f:
-                        zipf.writestr(filename, f.read())
-            zip_stream.seek(0)
+                    zipf.write(file_path, arcname=filename)
             download_name = secure_filename(f"{room_id}_files.zip") or "room_files.zip"
             headers = {
                 "Content-Disposition": build_content_disposition_attachment(
                     download_name
                 )
             }
-            return StreamingResponse(
-                zip_stream, media_type="application/zip", headers=headers
+            return FileResponse(
+                archive_path,
+                media_type="application/zip",
+                headers=headers,
+                background=BackgroundTask(_remove_temp_file, archive_path),
             )
         except Exception as e:
+            if "archive_path" in locals():
+                _remove_temp_file(archive_path)
             return api_error_response(f"エラー: {str(e)}", status_code=500)
 
 
@@ -313,12 +325,11 @@ def register_group_download_file_route(router: APIRouter):
                 ),
                 "Content-Length": str(os.path.getsize(file_path)),
             }
-            with open(file_path, "rb") as file:
-                return Response(
-                    content=file.read(),
-                    media_type="application/octet-stream",
-                    headers=headers,
-                )
+            return FileResponse(
+                file_path,
+                media_type="application/octet-stream",
+                headers=headers,
+            )
         except Exception as e:
             return api_error_response(f"エラー: {str(e)}", status_code=500)
 
@@ -368,12 +379,11 @@ def register_group_preview_file_route(router: APIRouter):
                 "Content-Length": str(os.path.getsize(file_path)),
                 "X-Content-Type-Options": "nosniff",
             }
-            with open(file_path, "rb") as file:
-                return Response(
-                    content=file.read(),
-                    media_type=str(preview_metadata["preview_mime_type"]),
-                    headers=headers,
-                )
+            return FileResponse(
+                file_path,
+                media_type=str(preview_metadata["preview_mime_type"]),
+                headers=headers,
+            )
         except Exception as e:
             return api_error_response(f"エラー: {str(e)}", status_code=500)
 


### PR DESCRIPTION
## 概要
- FSQR のダウンロードレスポンスを `Response(content=file.read())` から `FileResponse` に変更しました。
- Group の単体ダウンロードとプレビューを `FileResponse` に変更しました。
- Group/Admin のzip一括ダウンロードを `BytesIO` ではなく一時ファイルへ書き出して返すようにしました。

## 背景
アップロード上限がデフォルト500MBのため、ダウンロード時にファイル全体またはzip全体をメモリに保持すると、並列アクセスでRAM枯渇DoSにつながる可能性がありました。

## 影響
- レスポンスヘッダーとダウンロード名は既存の挙動を維持しています。
- 一時zipファイルはレスポンス完了後に `BackgroundTask` で削除します。

## 確認
- `python3 -m pytest tests/test_fsqr.py tests/test_group.py -q`
- `python3 -m pytest -q`
- `git diff --check`