### PR TITLE
feat: 共有ダウンロードページのファイル名とパスワードの表示順を変更

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -157,12 +157,6 @@
                   <span class="room-info-value-text">{{ id | e }}</span>
                 </span>
               </div>
-              <div class="room-info-row">
-                <span class="room-info-label">ファイル名</span>
-                <span class="room-info-value">
-                  <span class="room-info-value-text">{{ display_filename }}</span>
-                </span>
-              </div>
               {% if password %}
               <div class="room-info-row">
                 <span class="room-info-label">パスワード</span>
@@ -181,6 +175,12 @@
                 </span>
               </div>
               {% endif %}
+              <div class="room-info-row">
+                <span class="room-info-label">ファイル名</span>
+                <span class="room-info-value">
+                  <span class="room-info-value-text">{{ display_filename }}</span>
+                </span>
+              </div>
               <div class="room-info-row">
                 <span class="room-info-label">削除予定日</span>
                 <span class="room-info-value">


### PR DESCRIPTION
## 概要
`/fs-qr/s/`（共有ダウンロード）ページのファイル情報表示において、ユーザーからの視認性・使いやすさ向上のため、ファイル名とパスワードの表示順を入れ替えました。

変更前の並び順：
1. ID
2. ファイル名
3. パスワード
4. 削除予定日

変更後の並び順：
1. ID
2. パスワード
3. ファイル名
4. 削除予定日

これにより、IDとパスワードという認証情報がまとまって上部に表示され、その後にファイル詳細（ファイル名）が続く自然なレイアウトになりました。

## 変更点
- [FSQR/templates/fs_qr_info/_content.html](file:///home/kota/fs-qr/FSQR/templates/fs_qr_info/_content.html)
  - ダウンロード情報表示部分（`else`ブロック）内の「ファイル名」と「パスワード」のHTMLブロック（`room-info-row`）の順序を入れ替えました。

## 影響範囲とテスト
- **影響範囲**: `/fs-qr/s/{token}` 経由で表示されるファイル共有のダウンロード詳細画面。
- **検証内容**:
  - `pytest` を実行し、既存のテスト（`tests/test_fsqr.py` など）がすべて正常に通過することを確認済みです。
  - クライアント側スクリプト（`_scripts.html`）等への影響がないことをコードレベルで確認済みです。

## 移行・設定上の注意点
- 特になし（スキーマ変更や設定ファイルの変更はありません）。
