### PR TITLE
ノートエディタのペースト・全文コピーボタンをアイコン表示に変更

### DIFF
--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -107,8 +107,12 @@
                 <div class="note-editor-toolbar">
                     <span id="charCount" class="note-char-count" aria-live="polite">0 / {{ note_max_content_length }}文字</span>
                     <div class="note-editor-actions">
-                        <button type="button" id="pasteButton" class="note-action-button">ペースト</button>
-                        <button type="button" id="copyAllButton" class="note-action-button">全文コピー</button>
+                        <button type="button" id="pasteButton" class="note-action-button" aria-label="ペースト" data-tooltip="ペースト">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                        </button>
+                        <button type="button" id="copyAllButton" class="note-action-button" aria-label="全文コピー" data-tooltip="全文コピー">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                        </button>
                     </div>
                 </div>
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 0.5rem;">

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -295,19 +295,43 @@ footer.simple-footer {
 }
 
 .note-action-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--theme-note-action-border);
   border-radius: var(--radius-md);
-  padding: 0.45rem 0.85rem;
+  padding: 0.45rem;
+  width: 2.2rem;
+  height: 2.2rem;
   background: var(--theme-note-action-background);
   color: var(--theme-note-char-count-text);
-  font-size: 0.88rem;
-  font-weight: 700;
   line-height: 1;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.note-action-button::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 0.25rem 0.55rem;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.note-action-button:hover::after,
+.note-action-button:focus-visible::after {
+  opacity: 1;
 }
 
 .note-action-button:hover,


### PR DESCRIPTION
## 概要

ノートエディタツールバーの「ペースト」「全文コピー」ボタンを、テキストラベルからアイコンのみのボタンに変更しました。

## 変更内容

- ボタンをアイコンのみの正方形ボタン（2.2rem × 2.2rem）に変更
  - ペースト：クリップボード貼り付けアイコン
  - 全文コピー：コピーアイコン
- ホバー・フォーカス時に CSS `::after` 疑似要素でツールチップを表示
- `aria-label` を設定し、スクリーンリーダー対応を維持

## テスト方法

- [ ] ノートページを開き、エディタツールバーにアイコンボタンが表示されることを確認
- [ ] 各ボタンにホバーしてツールチップ（「ペースト」「全文コピー」）が表示されることを確認
- [x] ペーストボタンでクリップボードの内容が貼り付けられることを確認
- [x] 全文コピーボタンでテキスト全体がコピーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)