### PR TITLE
[codex] 記事一覧の新着記事をページング

### DIFF
--- a/Articles/articles_app.py
+++ b/Articles/articles_app.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from starlette.responses import RedirectResponse
 
 from i18n import is_language_query_only
@@ -17,6 +17,7 @@ router = APIRouter()
 
 # 公開からこの日数以内の記事に「NEW」バッジを付ける。
 _NEW_BADGE_DAYS = 14
+ARTICLES_PER_PAGE = 9
 
 
 def _with_new_flag(articles: list[dict]) -> list[dict]:
@@ -39,18 +40,59 @@ def _canonical_redirect(request: Request):
     return None
 
 
-@router.get("/articles", name="articles.articles")
-async def articles(request: Request):
+def _paginate_articles(articles: list[dict], page_number: int) -> dict:
+    total_count = len(articles)
+    total_pages = max(1, (total_count + ARTICLES_PER_PAGE - 1) // ARTICLES_PER_PAGE)
+    if page_number < 1 or page_number > total_pages:
+        raise HTTPException(status_code=404, detail="Article page not found")
+
+    start = (page_number - 1) * ARTICLES_PER_PAGE
+    end = start + ARTICLES_PER_PAGE
+    page_articles = articles[start:end]
+    return {
+        "articles": _with_new_flag(page_articles),
+        "article_page": page_number,
+        "article_total_pages": total_pages,
+        "article_total_count": total_count,
+        "article_visible_start": start + 1 if page_articles else 0,
+        "article_visible_end": min(end, total_count),
+        "articles_per_page": ARTICLES_PER_PAGE,
+    }
+
+
+def _articles_page_response(request: Request, page_number: int):
     canonical = _canonical_redirect(request)
     if canonical:
         return canonical
+
+    guides = get_guides() if page_number == 1 else []
+    pagination = _paginate_articles(get_blog_articles_sorted(), page_number)
+    visible_categories = {
+        article["category"] for article in [*guides, *pagination["articles"]]
+    }
     return render_template(
         request,
         "articles.html",
-        guides=get_guides(),
-        articles=_with_new_flag(get_blog_articles_sorted()),
-        categories=CATEGORIES,
+        guides=guides,
+        categories=[
+            category for category in CATEGORIES if category in visible_categories
+        ],
+        **pagination,
     )
+
+
+@router.get("/articles", name="articles.articles")
+async def articles(request: Request):
+    return _articles_page_response(request, 1)
+
+
+@router.get("/articles/page/{page_number}", name="articles.articles_page")
+async def articles_page(request: Request, page_number: int):
+    if page_number == 1:
+        query = request.url.query if is_language_query_only(request) else ""
+        url = request.url.replace(path="/articles", query=query)
+        return RedirectResponse(str(url), status_code=301)
+    return _articles_page_response(request, page_number)
 
 
 def _make_article_handler(template_name: str):

--- a/Articles/articles_registry.py
+++ b/Articles/articles_registry.py
@@ -304,11 +304,18 @@ def get_guides() -> list[dict[str, Any]]:
 
 def get_blog_articles_sorted() -> list[dict[str, Any]]:
     """ブログ記事(type="article")を新しい順に並べて返す。"""
-    return sorted(
-        (a for a in ARTICLES if a.get("type", TYPE_ARTICLE) == TYPE_ARTICLE),
-        key=lambda a: a["date"],
-        reverse=True,
-    )
+    return [
+        article
+        for _, article in sorted(
+            (
+                (index, a)
+                for index, a in enumerate(ARTICLES)
+                if a.get("type", TYPE_ARTICLE) == TYPE_ARTICLE
+            ),
+            key=lambda item: (item[1]["date"], item[0]),
+            reverse=True,
+        )
+    ]
 
 
 def get_article_by_slug(slug: str) -> dict[str, Any] | None:

--- a/Articles/templates/articles.html
+++ b/Articles/templates/articles.html
@@ -337,7 +337,7 @@
     <div class="articles-toolbar">
       <div class="articles-search">
         <i class="fas fa-search"></i>
-        <input type="search" id="article-search" placeholder="このページの記事を検索…" aria-label="このページの記事を検索">
+        <input type="search" id="article-search" placeholder="{{ t('articles.search_current_page_placeholder') }}" aria-label="{{ t('articles.search_current_page_label') }}">
       </div>
       <div class="articles-filters" id="article-filters">
         <button type="button" class="filter-chip active" data-category="">すべての記事</button>
@@ -382,7 +382,7 @@
       <div class="section-header">
         <h2 class="section-title"><i class="fas fa-newspaper"></i>新着記事</h2>
         {% if article_total_count %}
-        <p class="section-status">{{ article_visible_start }}-{{ article_visible_end }} / {{ article_total_count }}件</p>
+        <p class="section-status">{{ article_visible_start }}-{{ article_visible_end }} / {{ article_total_count }}{{ t('articles.count_suffix') }}</p>
         {% endif %}
       </div>
       <div class="articles-grid">
@@ -406,12 +406,12 @@
       </div>
       {% if article_total_pages > 1 %}
       {% set page_query = '?lang=' ~ current_language if request.query_params.get('lang') else '' %}
-      <nav class="articles-pagination" aria-label="新着記事のページ送り">
+      <nav class="articles-pagination" aria-label="{{ t('articles.pagination_label') }}">
         {% if article_page > 1 %}
           {% set prev_page = article_page - 1 %}
-          <a class="pagination-link pagination-prev" href="{{ '/articles' if prev_page == 1 else '/articles/page/' ~ prev_page }}{{ page_query }}">前へ</a>
+          <a class="pagination-link pagination-prev" href="{{ '/articles' if prev_page == 1 else '/articles/page/' ~ prev_page }}{{ page_query }}">{{ t('articles.pagination_prev') }}</a>
         {% else %}
-          <span class="pagination-disabled pagination-prev" aria-disabled="true">前へ</span>
+          <span class="pagination-disabled pagination-prev" aria-disabled="true">{{ t('articles.pagination_prev') }}</span>
         {% endif %}
 
         {% for page in range(1, article_total_pages + 1) %}
@@ -428,9 +428,9 @@
 
         {% if article_page < article_total_pages %}
           {% set next_page = article_page + 1 %}
-          <a class="pagination-link pagination-next" href="/articles/page/{{ next_page }}{{ page_query }}">次へ</a>
+          <a class="pagination-link pagination-next" href="/articles/page/{{ next_page }}{{ page_query }}">{{ t('articles.pagination_next') }}</a>
         {% else %}
-          <span class="pagination-disabled pagination-next" aria-disabled="true">次へ</span>
+          <span class="pagination-disabled pagination-next" aria-disabled="true">{{ t('articles.pagination_next') }}</span>
         {% endif %}
       </nav>
       {% endif %}

--- a/Articles/templates/articles.html
+++ b/Articles/templates/articles.html
@@ -227,6 +227,70 @@
     color: var(--text-medium);
     margin: 0;
   }
+  .section-status {
+    margin-left: auto;
+    font-size: 0.85rem;
+    color: var(--text-medium);
+    white-space: nowrap;
+  }
+
+  .articles-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 2rem 0 0;
+  }
+  .pagination-link,
+  .pagination-current,
+  .pagination-disabled,
+  .pagination-gap {
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0.55rem 0.8rem;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.92rem;
+    line-height: 1;
+    text-decoration: none;
+  }
+  .pagination-link {
+    background: var(--bg-white);
+    color: var(--text-dark);
+    border: 1px solid var(--border-light);
+    box-shadow: var(--shadow-sm, 0 1px 3px rgba(0,0,0,0.08));
+    transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+  .pagination-link:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  .pagination-current {
+    background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+    color: white;
+    border: 1px solid transparent;
+    font-weight: 700;
+  }
+  .pagination-disabled {
+    color: var(--text-medium);
+    background: rgba(255,255,255,0.65);
+    border: 1px solid var(--border-light);
+    opacity: 0.55;
+  }
+  .pagination-gap {
+    color: var(--text-medium);
+    min-width: 1.5rem;
+    padding-inline: 0.2rem;
+  }
+  .pagination-prev,
+  .pagination-next {
+    min-width: 5.5rem;
+  }
 
   .articles-empty {
     display: none;
@@ -238,6 +302,7 @@
 
   @media (max-width: 768px) {
     .section-header { flex-direction: column; gap: 0.25rem; }
+    .section-status { margin-left: 0; }
     .section-title { font-size: 1.25rem; }
     .articles-page { padding: 1rem 0.5rem; }
     .articles-header { padding: 2rem 1rem; margin-bottom: 1.5rem; }
@@ -245,6 +310,20 @@
     .articles-subtitle { font-size: 1rem; }
     .articles-grid { grid-template-columns: 1fr; gap: 18px; }
     .article-card { padding: 1.5rem; }
+    .articles-pagination { gap: 0.4rem; }
+    .pagination-link,
+    .pagination-current,
+    .pagination-disabled,
+    .pagination-gap {
+      min-width: 2.25rem;
+      min-height: 2.25rem;
+      padding: 0.5rem 0.65rem;
+      font-size: 0.86rem;
+    }
+    .pagination-prev,
+    .pagination-next {
+      min-width: 4.5rem;
+    }
   }
 </style>
 
@@ -258,7 +337,7 @@
     <div class="articles-toolbar">
       <div class="articles-search">
         <i class="fas fa-search"></i>
-        <input type="search" id="article-search" placeholder="記事を検索…" aria-label="記事を検索">
+        <input type="search" id="article-search" placeholder="このページの記事を検索…" aria-label="このページの記事を検索">
       </div>
       <div class="articles-filters" id="article-filters">
         <button type="button" class="filter-chip active" data-category="">すべての記事</button>
@@ -302,6 +381,9 @@
     <section class="articles-section" data-section="articles">
       <div class="section-header">
         <h2 class="section-title"><i class="fas fa-newspaper"></i>新着記事</h2>
+        {% if article_total_count %}
+        <p class="section-status">{{ article_visible_start }}-{{ article_visible_end }} / {{ article_total_count }}件</p>
+        {% endif %}
       </div>
       <div class="articles-grid">
         {% for art in articles %}
@@ -322,6 +404,36 @@
         </a>
         {% endfor %}
       </div>
+      {% if article_total_pages > 1 %}
+      {% set page_query = '?lang=' ~ current_language if request.query_params.get('lang') else '' %}
+      <nav class="articles-pagination" aria-label="新着記事のページ送り">
+        {% if article_page > 1 %}
+          {% set prev_page = article_page - 1 %}
+          <a class="pagination-link pagination-prev" href="{{ '/articles' if prev_page == 1 else '/articles/page/' ~ prev_page }}{{ page_query }}">前へ</a>
+        {% else %}
+          <span class="pagination-disabled pagination-prev" aria-disabled="true">前へ</span>
+        {% endif %}
+
+        {% for page in range(1, article_total_pages + 1) %}
+          {% if article_total_pages <= 7 or page == 1 or page == article_total_pages or (page >= article_page - 1 and page <= article_page + 1) %}
+            {% if page == article_page %}
+              <span class="pagination-current" aria-current="page">{{ page }}</span>
+            {% else %}
+              <a class="pagination-link" href="{{ '/articles' if page == 1 else '/articles/page/' ~ page }}{{ page_query }}">{{ page }}</a>
+            {% endif %}
+          {% elif page == 2 or page == article_total_pages - 1 %}
+            <span class="pagination-gap" aria-hidden="true">…</span>
+          {% endif %}
+        {% endfor %}
+
+        {% if article_page < article_total_pages %}
+          {% set next_page = article_page + 1 %}
+          <a class="pagination-link pagination-next" href="/articles/page/{{ next_page }}{{ page_query }}">次へ</a>
+        {% else %}
+          <span class="pagination-disabled pagination-next" aria-disabled="true">次へ</span>
+        {% endif %}
+      </nav>
+      {% endif %}
     </section>
     {% endif %}
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -39,7 +39,13 @@
     "group.delete_room_confirm_message": "This will delete the group room. All files in the room will also be deleted, and this action cannot be undone.",
     "group.delete_room_button": "Delete Room",
     "alert.confirm_delete": "Confirm Delete",
-    "alert.delete_action": "Delete"
+    "alert.delete_action": "Delete",
+    "articles.search_current_page_placeholder": "Search articles on this page...",
+    "articles.search_current_page_label": "Search articles on this page",
+    "articles.count_suffix": " items",
+    "articles.pagination_label": "Latest articles pagination",
+    "articles.pagination_prev": "Previous",
+    "articles.pagination_next": "Next"
   },
   "js": {
     "alert.notice": "Notice",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -39,7 +39,13 @@
     "group.delete_room_confirm_message": "このグループルームを削除します。ルーム内のファイルもすべて削除され、この操作は元に戻せません。",
     "group.delete_room_button": "ルームを削除",
     "alert.confirm_delete": "削除の確認",
-    "alert.delete_action": "削除する"
+    "alert.delete_action": "削除する",
+    "articles.search_current_page_placeholder": "このページの記事を検索…",
+    "articles.search_current_page_label": "このページの記事を検索",
+    "articles.count_suffix": "件",
+    "articles.pagination_label": "新着記事のページ送り",
+    "articles.pagination_prev": "前へ",
+    "articles.pagination_next": "次へ"
   },
   "js": {
     "alert.notice": "お知らせ",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -39,7 +39,13 @@
     "group.delete_room_confirm_message": "이 그룹 룸을 삭제합니다. 룸 안의 모든 파일도 삭제되며, 이 작업은 되돌릴 수 없습니다.",
     "group.delete_room_button": "룸 삭제",
     "alert.confirm_delete": "삭제 확인",
-    "alert.delete_action": "삭제"
+    "alert.delete_action": "삭제",
+    "articles.search_current_page_placeholder": "이 페이지의 기사 검색...",
+    "articles.search_current_page_label": "이 페이지의 기사 검색",
+    "articles.count_suffix": "건",
+    "articles.pagination_label": "최신 기사 페이지 이동",
+    "articles.pagination_prev": "이전",
+    "articles.pagination_next": "다음"
   },
   "js": {
     "alert.notice": "알림",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -39,7 +39,13 @@
     "group.delete_room_confirm_message": "此操作将删除该群组房间。房间内的所有文件也将被删除，且无法撤销。",
     "group.delete_room_button": "删除房间",
     "alert.confirm_delete": "确认删除",
-    "alert.delete_action": "删除"
+    "alert.delete_action": "删除",
+    "articles.search_current_page_placeholder": "搜索此页面的文章...",
+    "articles.search_current_page_label": "搜索此页面的文章",
+    "articles.count_suffix": "篇",
+    "articles.pagination_label": "最新文章分页",
+    "articles.pagination_prev": "上一页",
+    "articles.pagination_next": "下一页"
   },
   "js": {
     "alert.notice": "通知",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -39,7 +39,13 @@
     "group.delete_room_confirm_message": "此操作將刪除該群組房間。房間內的所有檔案也將被刪除，且無法復原。",
     "group.delete_room_button": "刪除房間",
     "alert.confirm_delete": "確認刪除",
-    "alert.delete_action": "刪除"
+    "alert.delete_action": "刪除",
+    "articles.search_current_page_placeholder": "搜尋此頁面的文章...",
+    "articles.search_current_page_label": "搜尋此頁面的文章",
+    "articles.count_suffix": "篇",
+    "articles.pagination_label": "最新文章分頁",
+    "articles.pagination_prev": "上一頁",
+    "articles.pagination_next": "下一頁"
   },
   "js": {
     "alert.notice": "通知",

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -3,6 +3,7 @@ import xml.etree.ElementTree as ET
 import pytest
 from starlette.testclient import TestClient
 
+from Articles.articles_app import ARTICLES_PER_PAGE
 from Articles.articles_registry import (
     ARTICLES,
     TYPE_ARTICLE,
@@ -22,9 +23,38 @@ def test_articles_index_lists_all_articles(test_client: TestClient):
     response = test_client.get("/articles")
     assert response.status_code == 200
     body = response.text
-    for article in ARTICLES:
+    for article in get_guides():
         assert f"/{article['slug']}" in body
         assert article["title"] in body
+    for article in get_blog_articles_sorted()[:ARTICLES_PER_PAGE]:
+        assert f"/{article['slug']}" in body
+        assert article["title"] in body
+    for article in get_blog_articles_sorted()[ARTICLES_PER_PAGE:]:
+        assert f"/{article['slug']}" not in body
+
+
+def test_articles_second_page_lists_remaining_articles(test_client: TestClient):
+    response = test_client.get("/articles/page/2")
+    assert response.status_code == 200
+    body = response.text
+    for article in get_guides():
+        assert f"/{article['slug']}" not in body
+    for article in get_blog_articles_sorted()[:ARTICLES_PER_PAGE]:
+        assert f"/{article['slug']}" not in body
+    for article in get_blog_articles_sorted()[ARTICLES_PER_PAGE:]:
+        assert f"/{article['slug']}" in body
+        assert article["title"] in body
+
+
+def test_articles_page_one_redirects_to_canonical_index(test_client: TestClient):
+    response = test_client.get("/articles/page/1")
+    assert response.status_code == 301
+    assert response.headers["location"] == "http://testserver/articles"
+
+
+def test_articles_out_of_range_page_returns_404(test_client: TestClient):
+    response = test_client.get("/articles/page/999")
+    assert response.status_code == 404
 
 
 @pytest.mark.parametrize("article", ARTICLES, ids=lambda a: a["slug"])
@@ -120,6 +150,14 @@ def test_blog_articles_sorted_newest_first():
     assert all(a["type"] == TYPE_ARTICLE for a in blog)
     dates = [a["date"] for a in blog]
     assert dates == sorted(dates, reverse=True)
+
+
+def test_blog_articles_sorted_uses_later_registry_order_for_same_day():
+    blog = get_blog_articles_sorted()
+    indexes = {article["slug"]: index for index, article in enumerate(ARTICLES)}
+    for previous, current in zip(blog, blog[1:]):
+        if previous["date"] == current["date"]:
+            assert indexes[previous["slug"]] > indexes[current["slug"]]
 
 
 def test_articles_index_renders_both_sections(test_client: TestClient):


### PR DESCRIPTION
## 概要

記事一覧ページの「新着記事」セクションにページングを追加しました。

## 変更内容

- `/articles` を1ページ目として、新着記事を9件ずつ表示
- `/articles/page/{page_number}` を追加し、2ページ目以降を表示
- `/articles/page/1` は `/articles` へ301リダイレクト
- 範囲外ページは404を返す
- 1ページ目のみサービス解説ガイドを表示
- 一覧下部に表示範囲とページ送りUIを追加
- 同日公開の記事は、レジストリで後から追加した記事が上に出るように整理

## 確認したこと

- `pytest tests/test_articles.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_articles.py tests/test_seo.py`
- `python3` によるAST構文チェック

## 補足

`python3 -m py_compile` は既存の `Articles/__pycache__` 配下に権限のないpycがあり失敗したため、バイトコードを書かないASTチェックで代替しました。