### PR TITLE
Cookie同意モーダルを下からスライドする折り畳み式バナーに変更

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -23,6 +23,8 @@
     "settings.privacy": "سياسة الخصوصية",
     "settings.back": "رجوع",
     "settings.close": "إغلاق",
+    "settings.collapse": "طيّ",
+    "settings.expand": "توسيع",
     "settings.optional": "اختياري",
     "settings.save": "حفظ وإغلاق",
     "note.editor.label": "ملاحظة مشتركة (بحد أقصى {max_length} حرفاً)",

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -23,6 +23,8 @@
     "settings.privacy": "গোপনীয়তা নীতি",
     "settings.back": "ফিরে যান",
     "settings.close": "বন্ধ করুন",
+    "settings.collapse": "সংকুচিত করুন",
+    "settings.expand": "প্রসারিত করুন",
     "settings.optional": "ঐচ্ছিক",
     "settings.save": "সংরক্ষণ করুন এবং বন্ধ করুন",
     "note.editor.label": "শেয়ার্ড নোট ({max_length} অক্ষর পর্যন্ত)",

--- a/locales/de.json
+++ b/locales/de.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Datenschutzerklärung",
     "settings.back": "Zurück",
     "settings.close": "Schließen",
+    "settings.collapse": "Einklappen",
+    "settings.expand": "Ausklappen",
     "settings.optional": "Optional",
     "settings.save": "Speichern und schließen",
     "note.editor.label": "Gemeinsame Notiz (bis zu {max_length} Zeichen)",

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Privacy Policy",
     "settings.back": "Back",
     "settings.close": "Close",
+    "settings.collapse": "Collapse",
+    "settings.expand": "Expand",
     "settings.optional": "Optional",
     "settings.save": "Save and Close",
     "note.editor.label": "Shared note (up to {max_length} characters)",

--- a/locales/es.json
+++ b/locales/es.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Política de privacidad",
     "settings.back": "Volver",
     "settings.close": "Cerrar",
+    "settings.collapse": "Contraer",
+    "settings.expand": "Expandir",
     "settings.optional": "Opcional",
     "settings.save": "Guardar y cerrar",
     "note.editor.label": "Nota compartida (hasta {max_length} caracteres)",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Politique de confidentialité",
     "settings.back": "Retour",
     "settings.close": "Fermer",
+    "settings.collapse": "Réduire",
+    "settings.expand": "Développer",
     "settings.optional": "Facultatif",
     "settings.save": "Enregistrer et fermer",
     "note.editor.label": "Note partagée (jusqu'à {max_length} caractères)",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -23,6 +23,8 @@
     "settings.privacy": "गोपनीयता नीति",
     "settings.back": "वापस",
     "settings.close": "बंद करें",
+    "settings.collapse": "संक्षिप्त करें",
+    "settings.expand": "विस्तृत करें",
     "settings.optional": "वैकल्पिक",
     "settings.save": "सहेजें और बंद करें",
     "note.editor.label": "साझा नोट (अधिकतम {max_length} वर्ण)",

--- a/locales/id.json
+++ b/locales/id.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Kebijakan Privasi",
     "settings.back": "Kembali",
     "settings.close": "Tutup",
+    "settings.collapse": "Ciutkan",
+    "settings.expand": "Perluas",
     "settings.optional": "Opsional",
     "settings.save": "Simpan dan Tutup",
     "note.editor.label": "Catatan Bersama (maksimal {max_length} karakter)",

--- a/locales/it.json
+++ b/locales/it.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Informativa sulla privacy",
     "settings.back": "Indietro",
     "settings.close": "Chiudi",
+    "settings.collapse": "Comprimi",
+    "settings.expand": "Espandi",
     "settings.optional": "Opzionale",
     "settings.save": "Salva e chiudi",
     "note.editor.label": "Nota condivisa (fino a {max_length} caratteri)",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -23,6 +23,8 @@
     "settings.privacy": "プライバシーポリシー",
     "settings.back": "戻る",
     "settings.close": "閉じる",
+    "settings.collapse": "折りたたむ",
+    "settings.expand": "開く",
     "settings.optional": "任意",
     "settings.save": "保存して閉じる",
     "note.editor.label": "共有ノート（最大{max_length}文字）",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -23,6 +23,8 @@
     "settings.privacy": "개인정보처리방침",
     "settings.back": "뒤로",
     "settings.close": "닫기",
+    "settings.collapse": "접기",
+    "settings.expand": "펼치기",
     "settings.optional": "선택",
     "settings.save": "저장 후 닫기",
     "note.editor.label": "공유 노트(최대 {max_length}자)",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Privacybeleid",
     "settings.back": "Terug",
     "settings.close": "Sluiten",
+    "settings.collapse": "Inklappen",
+    "settings.expand": "Uitklappen",
     "settings.optional": "Optioneel",
     "settings.save": "Opslaan en sluiten",
     "note.editor.label": "Gedeelde notitie (maximaal {max_length} tekens)",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Polityka prywatności",
     "settings.back": "Powrót",
     "settings.close": "Zamknij",
+    "settings.collapse": "Zwiń",
+    "settings.expand": "Rozwiń",
     "settings.optional": "Opcjonalne",
     "settings.save": "Zapisz i zamknij",
     "note.editor.label": "Wspólna notatka (maksymalnie {max_length} znaków)",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Política de Privacidade",
     "settings.back": "Voltar",
     "settings.close": "Fechar",
+    "settings.collapse": "Recolher",
+    "settings.expand": "Expandir",
     "settings.optional": "Opcional",
     "settings.save": "Guardar e fechar",
     "note.editor.label": "Nota partilhada (até {max_length} caracteres)",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Политика конфиденциальности",
     "settings.back": "Назад",
     "settings.close": "Закрыть",
+    "settings.collapse": "Свернуть",
+    "settings.expand": "Развернуть",
     "settings.optional": "Дополнительно",
     "settings.save": "Сохранить и закрыть",
     "note.editor.label": "Общая заметка (до {max_length} символов)",

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Sera ya Faragha",
     "settings.back": "Nyuma",
     "settings.close": "Funga",
+    "settings.collapse": "Kunja",
+    "settings.expand": "Panua",
     "settings.optional": "Hiari",
     "settings.save": "Hifadhi na ufunge",
     "note.editor.label": "Kumbukumbu iliyoshirikiwa (hadi herufi {max_length})",

--- a/locales/th.json
+++ b/locales/th.json
@@ -23,6 +23,8 @@
     "settings.privacy": "นโยบายความเป็นส่วนตัว",
     "settings.back": "ย้อนกลับ",
     "settings.close": "ปิด",
+    "settings.collapse": "ย่อ",
+    "settings.expand": "ขยาย",
     "settings.optional": "ไม่บังคับ",
     "settings.save": "บันทึกและปิด",
     "note.editor.label": "โน้ตที่แชร์ (สูงสุด {max_length} ตัวอักษร)",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Gizlilik Politikası",
     "settings.back": "Geri",
     "settings.close": "Kapat",
+    "settings.collapse": "Daralt",
+    "settings.expand": "Genişlet",
     "settings.optional": "İsteğe Bağlı",
     "settings.save": "Kaydet ve Kapat",
     "note.editor.label": "Paylaşılan Not (En fazla {max_length} karakter)",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Політика конфіденційності",
     "settings.back": "Назад",
     "settings.close": "Закрити",
+    "settings.collapse": "Згорнути",
+    "settings.expand": "Розгорнути",
     "settings.optional": "Необов'язково",
     "settings.save": "Зберегти та закрити",
     "note.editor.label": "Спільна замітка (до {max_length} символів)",

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -23,6 +23,8 @@
     "settings.privacy": "Chính sách bảo mật",
     "settings.back": "Quay lại",
     "settings.close": "Đóng",
+    "settings.collapse": "Thu gọn",
+    "settings.expand": "Mở rộng",
     "settings.optional": "Không bắt buộc",
     "settings.save": "Lưu và đóng",
     "note.editor.label": "Ghi chú chia sẻ (tối đa {max_length} ký tự)",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -23,6 +23,8 @@
     "settings.privacy": "隐私政策",
     "settings.back": "返回",
     "settings.close": "关闭",
+    "settings.collapse": "收起",
+    "settings.expand": "展开",
     "settings.optional": "可选",
     "settings.save": "保存并关闭",
     "note.editor.label": "共享笔记（最多 {max_length} 个字符）",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -23,6 +23,8 @@
     "settings.privacy": "隱私權政策",
     "settings.back": "返回",
     "settings.close": "關閉",
+    "settings.collapse": "收合",
+    "settings.expand": "展開",
     "settings.optional": "選用",
     "settings.save": "儲存並關閉",
     "note.editor.label": "共用筆記（最多 {max_length} 個字）",

--- a/static/cookie-consent.css
+++ b/static/cookie-consent.css
@@ -1,31 +1,26 @@
-/* ─── Overlay ─────────────────────────────────────── */
+/* ─── Bottom sheet container (non-modal) ──────────── */
 .cookie-consent-overlay {
   position: fixed;
-  inset: 0;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(14, 165, 233, 0.2), transparent 34rem),
-    rgba(15, 23, 42, 0.62);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
-  align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  padding: 1.25rem;
   z-index: 1100;
   z-index: var(--z-modal, 1100);
-  /* visibility transition: fade out then hide; fade in immediately */
-  visibility: hidden;
+  /* Non-modal: the page underneath stays scrollable and clickable. */
   pointer-events: none;
-  opacity: 0;
-  overscroll-behavior: contain;
-  transition: opacity 0.28s ease, visibility 0s linear 0.28s;
+  visibility: hidden;
+  transition: visibility 0s linear 0.5s;
 }
 
-/* Keep the consent modal anchored to the viewport across all layouts. */
+/* Keep the consent sheet anchored to the bottom across all layouts. */
 body > #cookieConsent.cookie-consent-overlay {
   position: fixed;
-  inset: 0;
-  width: 100%;
+  left: 0;
+  right: 0;
+  bottom: 0;
   margin: 0;
   z-index: 1100;
   z-index: var(--z-modal, 1100);
@@ -33,14 +28,13 @@ body > #cookieConsent.cookie-consent-overlay {
 
 .cookie-consent-overlay.is-visible {
   visibility: visible;
-  pointer-events: auto;
-  opacity: 1;
-  transition: opacity 0.28s ease, visibility 0s linear 0s;
+  transition: visibility 0s linear 0s;
 }
 
-/* ─── Dialog ─────────────────────────────────────── */
+/* ─── Sheet (dialog) ──────────────────────────────── */
 .cookie-consent-dialog {
   position: relative;
+  pointer-events: auto;
   width: min(680px, 100%);
   border-radius: 18px;
   background: #ffffff;
@@ -53,38 +47,126 @@ body > #cookieConsent.cookie-consent-overlay {
   border: 1px solid rgba(255, 255, 255, 0.72);
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 3rem);
-  max-height: calc(100dvh - 3rem);
+  max-height: calc(100vh - 2.5rem);
+  max-height: calc(100dvh - 2.5rem);
   overflow: hidden;
-}
-
-/* Entry animation — opacity-only to avoid creating a containing block
-   for position:fixed descendants (which would mis-position the dropdown). */
-@keyframes cookie-dialog-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  /* Slide-up entrance: parked just below the viewport edge while hidden.
+     The language dropdown is portaled to <body>, so the transform here
+     no longer affects its fixed positioning. */
+  transform: translateY(calc(100% + 2.5rem));
+  opacity: 0;
+  transition:
+    transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.35s ease;
 }
 
 .cookie-consent-overlay.is-visible .cookie-consent-dialog {
-  animation: cookie-dialog-in 0.3s ease both;
+  transform: translateY(0);
+  opacity: 1;
 }
 
-/* ─── Header ─────────────────────────────────────── */
+/* ─── Header (always-visible bar / collapse handle) ── */
 .cookie-consent-header {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 1.1rem;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 1rem;
   align-items: center;
   flex-shrink: 0;
-  padding: 1.5rem 1.75rem 1.25rem;
+  padding: 1.25rem 1.5rem;
   border-bottom: 1px solid rgba(15, 23, 42, 0.07);
   background:
     linear-gradient(135deg, rgba(240, 249, 255, 0.92) 0%, rgba(255, 255, 255, 0.96) 58%),
     #ffffff;
+  transition: padding 0.35s ease, border-color 0.35s ease;
 }
 
-.cookie-consent-overlay[data-cookie-consent-closeable="true"] .cookie-consent-header {
-  padding-right: 4rem;
+/* ─── Header collapse toggle ──────────────────────── */
+.cookie-consent-collapse {
+  flex-shrink: 0;
+  width: 2.35rem;
+  height: 2.35rem;
+  display: inline-grid;
+  place-items: center;
+  margin: 0;
+  padding: 0;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #475569;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+}
+
+.cookie-consent-collapse:hover {
+  background: #ffffff;
+  color: #0284c7;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.1);
+}
+
+.cookie-consent-collapse:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 2px;
+}
+
+.cookie-consent-collapse-icon {
+  display: inline-grid;
+  place-items: center;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.cookie-consent-collapse-icon svg {
+  display: block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Rotate the chevron to point up when collapsed ("open me back up"). */
+.cookie-consent-overlay.is-collapsed .cookie-consent-collapse-icon {
+  transform: rotate(180deg);
+}
+
+/* ─── Collapsible body ────────────────────────────── */
+.cookie-consent-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 80vh;
+  max-height: 80dvh;
+  overflow: hidden;
+  transition:
+    max-height 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.3s ease,
+    visibility 0s linear 0s;
+}
+
+.cookie-consent-overlay.is-collapsed .cookie-consent-body {
+  max-height: 0 !important;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    max-height 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.25s ease,
+    visibility 0s linear 0.45s;
+}
+
+/* Slim the bar down when folded. */
+.cookie-consent-overlay.is-collapsed .cookie-consent-header {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom-color: transparent;
+  cursor: pointer;
+}
+
+.cookie-consent-overlay.is-collapsed .cookie-consent-headings p {
+  display: none;
 }
 
 .cookie-consent-icon {
@@ -110,10 +192,7 @@ body > #cookieConsent.cookie-consent-overlay {
 }
 
 .cookie-consent-close {
-  position: absolute;
-  top: 0.95rem;
-  right: 0.95rem;
-  z-index: 2;
+  flex-shrink: 0;
   width: 2.35rem;
   height: 2.35rem;
   display: inline-grid;
@@ -664,34 +743,33 @@ body > .lang-select-list.lang-select-list {
 
 /* ─── Mobile ─────────────────────────────────────── */
 @media (max-width: 575.98px) {
+  /* Full-width sheet flush to the bottom edge of the screen. */
   .cookie-consent-overlay {
-    align-items: center;
-    padding: 1rem;
+    padding: 0;
   }
 
   .cookie-consent-dialog {
     width: 100%;
-    border-radius: 16px;
-    max-height: calc(100vh - 2rem);
-    max-height: calc(100dvh - 2rem);
+    border-radius: 18px 18px 0 0;
+    border-bottom: 0;
+    max-height: 90vh;
+    max-height: 90dvh;
+    transform: translateY(100%);
   }
 
-  /* On mobile, force the settings dialog to fill the viewport so the
-     scrollable body has a usable height (otherwise content collapses
-     between the header and footer). Summary view stays content-sized. */
-  .cookie-consent-overlay[data-cookie-consent-active-view="settings"] .cookie-consent-dialog {
-    height: calc(100vh - 2rem);
-    height: calc(100dvh - 2rem);
+  /* On mobile, give the settings view a tall sheet so the scrollable body
+     has a usable height (otherwise content collapses between header and
+     footer). Summary view stays content-sized. */
+  .cookie-consent-overlay[data-cookie-consent-active-view="settings"]:not(.is-collapsed) .cookie-consent-body {
+    height: 82vh;
+    height: 82dvh;
+    max-height: 82dvh;
   }
 
   .cookie-consent-header {
-    gap: 0.85rem;
-    padding: 1.25rem 1.1rem 1rem;
-    grid-template-columns: 42px 1fr;
-  }
-
-  .cookie-consent-overlay[data-cookie-consent-closeable="true"] .cookie-consent-header {
-    padding-right: 3.5rem;
+    gap: 0.7rem;
+    padding: 1.1rem;
+    grid-template-columns: 42px 1fr auto auto;
   }
 
   .cookie-consent-icon {
@@ -765,13 +843,21 @@ body > .lang-select-list.lang-select-list {
 @media (prefers-reduced-motion: reduce) {
   .cookie-consent-overlay,
   .cookie-consent-dialog,
+  .cookie-consent-body,
   .cookie-consent-button,
   .cookie-consent-close,
+  .cookie-consent-collapse-icon,
   .cookie-consent-toggle-slider::before,
   .lang-select-chevron,
   .lang-select-list,
   .cookie-consent-setting {
     animation: none !important;
     transition: none !important;
+  }
+
+  /* Show the sheet without sliding when motion is reduced. */
+  .cookie-consent-dialog {
+    transform: none;
+    opacity: 1;
   }
 }

--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -128,40 +128,25 @@
     }
   }
 
-  function getFocusableElements(container) {
-    return Array.from(
-      container.querySelectorAll(
-        'a[href], button:not([disabled]):not([hidden]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )
-    ).filter((element) => {
-      return !element.hidden && element.offsetParent !== null && element.getAttribute('aria-hidden') !== 'true';
-    });
-  }
-
   let lastFocusedElement = null;
-  let scrollLockY = 0;
   const langSelectClosers = [];
 
   function closeOpenLangSelects() {
     langSelectClosers.forEach((close) => close({ restoreFocus: false }));
   }
 
-  function lockBodyScroll() {
-    scrollLockY = window.scrollY;
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${scrollLockY}px`;
-    document.body.style.left = '0';
-    document.body.style.right = '0';
-    document.body.style.overflow = 'hidden';
-  }
-
-  function unlockBodyScroll() {
-    document.body.style.removeProperty('position');
-    document.body.style.removeProperty('top');
-    document.body.style.removeProperty('left');
-    document.body.style.removeProperty('right');
-    document.body.style.removeProperty('overflow');
-    window.scrollTo(0, scrollLockY);
+  function setCollapsed(overlay, collapsed) {
+    overlay.classList.toggle('is-collapsed', collapsed);
+    const toggle = overlay.querySelector('[data-cookie-consent="collapse"]');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      const label = collapsed
+        ? toggle.getAttribute('data-label-expand')
+        : toggle.getAttribute('data-label-collapse');
+      if (label) {
+        toggle.setAttribute('aria-label', label);
+      }
+    }
   }
 
   function hideOverlay(overlay, options = {}) {
@@ -170,7 +155,6 @@
     overlay.setAttribute('aria-hidden', 'true');
     overlay.removeAttribute('data-cookie-consent-active-view');
     overlay.removeAttribute('data-cookie-consent-closeable');
-    unlockBodyScroll();
 
     if (options.restoreFocus !== false && lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
       lastFocusedElement.focus();
@@ -188,9 +172,10 @@
   function showOverlay(overlay, options = {}) {
     lastFocusedElement = document.activeElement;
     setCloseable(overlay, Boolean(options.closeable));
+    // Always open expanded; the user can fold it afterwards.
+    setCollapsed(overlay, false);
     overlay.classList.add('is-visible');
     overlay.setAttribute('aria-hidden', 'false');
-    lockBodyScroll();
   }
 
   function switchView(overlay, viewName) {
@@ -410,8 +395,12 @@
 
     function showSummaryView() {
       switchView(overlay, 'summary');
-      const focusTarget = overlay.querySelector('[data-cookie-consent-focus]');
-      focusOnTarget(focusTarget);
+      // Only steal focus when the user explicitly reopened the sheet. On the
+      // very first visit, auto-focusing a button at the bottom of the page
+      // would yank the viewport down, so we leave focus where it is.
+      if (overlay.getAttribute('data-cookie-consent-closeable') === 'true') {
+        focusOnTarget(overlay.querySelector('[data-cookie-consent-focus]'));
+      }
     }
 
     function showSettingsView(options = {}) {
@@ -511,6 +500,24 @@
       });
     }
 
+    const collapseButton = overlay.querySelector('[data-cookie-consent="collapse"]');
+    if (collapseButton) {
+      collapseButton.addEventListener('click', () => {
+        setCollapsed(overlay, !overlay.classList.contains('is-collapsed'));
+      });
+    }
+
+    // While folded into the slim bar, clicking anywhere on the header reopens it.
+    const header = overlay.querySelector('.cookie-consent-header');
+    if (header) {
+      header.addEventListener('click', (event) => {
+        if (!overlay.classList.contains('is-collapsed')) return;
+        if (event.target.closest('[data-cookie-consent="close"]')) return;
+        if (event.target.closest('[data-cookie-consent="collapse"]')) return;
+        setCollapsed(overlay, false);
+      });
+    }
+
     overlay.addEventListener('click', (event) => {
       if (
         event.target === overlay
@@ -520,28 +527,13 @@
       }
     });
 
+    // Non-modal bottom sheet: no focus trap (the page stays usable). Esc still
+    // dismisses the sheet once it can be closed.
     overlay.addEventListener('keydown', (event) => {
       if (!overlay.classList.contains('is-visible')) return;
 
       if (event.key === 'Escape' && overlay.getAttribute('data-cookie-consent-closeable') === 'true') {
         hideOverlay(overlay);
-        return;
-      }
-
-      if (event.key !== 'Tab') return;
-
-      const focusableElements = getFocusableElements(overlay);
-      if (!focusableElements.length) return;
-
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-
-      if (event.shiftKey && document.activeElement === firstElement) {
-        event.preventDefault();
-        lastElement.focus();
-      } else if (!event.shiftKey && document.activeElement === lastElement) {
-        event.preventDefault();
-        firstElement.focus();
       }
     });
 

--- a/templates/cookie-consent.html
+++ b/templates/cookie-consent.html
@@ -18,22 +18,10 @@
   <div
     class="cookie-consent-dialog"
     role="dialog"
-    aria-modal="true"
+    aria-modal="false"
     aria-labelledby="cookieConsentTitle"
     aria-describedby="cookieConsentDescription"
   >
-    <button
-      type="button"
-      class="cookie-consent-close"
-      data-cookie-consent="close"
-      aria-label="{{ t('settings.close') }}"
-      hidden
-    >
-      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
-        <path d="M18 6 6 18M6 6l12 12" />
-      </svg>
-    </button>
-
     <div class="cookie-consent-header">
       <div class="cookie-consent-icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" width="24" height="24" focusable="false">
@@ -47,8 +35,36 @@
           {{ t('settings.description') }}
         </p>
       </div>
+      <button
+        type="button"
+        class="cookie-consent-collapse"
+        data-cookie-consent="collapse"
+        data-label-collapse="{{ t('settings.collapse') }}"
+        data-label-expand="{{ t('settings.expand') }}"
+        aria-controls="cookieConsentBody"
+        aria-expanded="true"
+        aria-label="{{ t('settings.collapse') }}"
+      >
+        <span class="cookie-consent-collapse-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="18" height="18" focusable="false">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </span>
+      </button>
+      <button
+        type="button"
+        class="cookie-consent-close"
+        data-cookie-consent="close"
+        aria-label="{{ t('settings.close') }}"
+        hidden
+      >
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
     </div>
 
+    <div class="cookie-consent-body" id="cookieConsentBody">
     <div class="cookie-consent-view" data-cookie-consent-view="summary" aria-live="polite">
       <div class="lang-select-summary-row">
         <div class="lang-select" data-lang-select>
@@ -193,6 +209,7 @@
           </button>
         </div>
       </div>
+    </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要

初回アクセス時に中央へ表示していた Cookie 同意モーダルを、**画面下部からスライドアップする折り畳み式のボトムシート**に作り変えました。アニメーションでモダンな見た目にし、ユーザーがページを操作したまま後から同意できるようにしています。

## 主な変更点

### モーダル → ボトムシート（非モーダル化）
- 中央寄せの暗転オーバーレイを廃止し、画面下部に固定されるバナー方式に変更
- 背景の暗転・ぼかし、スクロールロック、フォーカストラップを撤去し、背後のページをそのまま閲覧・操作できるように
- 表示時は画面下から `cubic-bezier` でスライドアップ、非表示時はスライドダウン

### 折り畳み（開閉）機能
- ヘッダー右側のシェブロンボタンで本文の折り畳み／展開が可能
- 折り畳むと**アイコン＋タイトルだけのスリムなバー**になり、バーをクリックすると再展開
- 開閉は `max-height` のトランジションでなめらかにアニメーション、シェブロンも回転

### アクセシビリティ
- トグルに `aria-expanded` / `aria-controls` を付与し、状態に応じて `aria-label` を「折りたたむ／開く」で切り替え
- `prefers-reduced-motion` 指定時はスライドせず即時表示
- 非モーダルになったため初回表示でフォーカスを奪わず（最下部のボタンへ飛んで画面が下がる挙動を防止）、ユーザーが明示的に開き直したときのみフォーカスを移動
- Esc キーでの閉じる挙動は維持

### 多言語対応
- 折り畳みボタン用ラベル `settings.collapse` / `settings.expand` を全 22 言語にネイティブ追加

## 動作確認
- `pytest tests/test_i18n.py tests/test_basic_routes.py tests/test_seo.py` 全件パス（64 passed）
- 全ロケールでテンプレートのレンダリングが成功することを確認
- `node --check` で JS の構文を確認

> 注: 当環境はブラウザ実行に必要なシステムライブラリ（libnspr4）が無く sudo も使えないため、ブラウザでのスクリーンショット確認は実施できていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)