### PR TITLE
設定モーダルの下矢印（折りたたみ）ボタンを削除

### DIFF
--- a/templates/cookie-consent.html
+++ b/templates/cookie-consent.html
@@ -37,22 +37,6 @@
       </div>
       <button
         type="button"
-        class="cookie-consent-collapse"
-        data-cookie-consent="collapse"
-        data-label-collapse="{{ t('settings.collapse') }}"
-        data-label-expand="{{ t('settings.expand') }}"
-        aria-controls="cookieConsentBody"
-        aria-expanded="true"
-        aria-label="{{ t('settings.collapse') }}"
-      >
-        <span class="cookie-consent-collapse-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="18" height="18" focusable="false">
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
-        </span>
-      </button>
-      <button
-        type="button"
         class="cookie-consent-close"
         data-cookie-consent="close"
         aria-label="{{ t('settings.close') }}"


### PR DESCRIPTION
## 概要
フッターから開く設定モーダルにおいて、下矢印ボタン（折りたたみ）と×ボタン（閉じる）が両方表示されており、ユーザーにとって分かりにくい状態になっていたため、下矢印ボタンを削除しました。

## 変更内容
- `templates/cookie-consent.html` から `data-cookie-consent="collapse"` ボタンを削除

## テスト確認
- ブラウザにてフッターの「設定」をクリックし、モーダルが開くことを確認
- モーダルのヘッダーに×ボタンのみが存在し、下矢印が表示されていないことを確認
- ×ボタンで正常にモーダルが閉じられることを確認

## 関連
とくになし