### PR TITLE
初回アクセス時のCookieバナーにも閉じる(×)ボタンを表示

### DIFF
--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -155,6 +155,7 @@
     overlay.setAttribute('aria-hidden', 'true');
     overlay.removeAttribute('data-cookie-consent-active-view');
     overlay.removeAttribute('data-cookie-consent-closeable');
+    overlay.removeAttribute('data-cookie-consent-autofocus');
 
     if (options.restoreFocus !== false && lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
       lastFocusedElement.focus();
@@ -172,6 +173,14 @@
   function showOverlay(overlay, options = {}) {
     lastFocusedElement = document.activeElement;
     setCloseable(overlay, Boolean(options.closeable));
+    // Whether to move focus into the sheet on open. Defaults to whether the
+    // sheet is closeable (i.e. the user explicitly reopened it). The first-visit
+    // banner overrides this to false so it can show its close button without
+    // stealing focus and yanking the viewport down to the bottom of the page.
+    const autofocus = options.autofocus !== undefined
+      ? Boolean(options.autofocus)
+      : Boolean(options.closeable);
+    overlay.setAttribute('data-cookie-consent-autofocus', autofocus ? 'true' : 'false');
     // Always open expanded; the user can fold it afterwards.
     setCollapsed(overlay, false);
     overlay.classList.add('is-visible');
@@ -395,10 +404,11 @@
 
     function showSummaryView() {
       switchView(overlay, 'summary');
-      // Only steal focus when the user explicitly reopened the sheet. On the
-      // very first visit, auto-focusing a button at the bottom of the page
-      // would yank the viewport down, so we leave focus where it is.
-      if (overlay.getAttribute('data-cookie-consent-closeable') === 'true') {
+      // Only steal focus when the sheet asked for it (an explicit reopen). On
+      // the very first visit, auto-focusing a button at the bottom of the page
+      // would yank the viewport down, so we leave focus where it is even though
+      // the close button is now shown.
+      if (overlay.getAttribute('data-cookie-consent-autofocus') === 'true') {
         focusOnTarget(overlay.querySelector('[data-cookie-consent-focus]'));
       }
     }
@@ -552,7 +562,9 @@
     });
 
     if (!hasConsent()) {
-      showOverlay(overlay, { closeable: false });
+      // Show the close button on first visit too (same as the settings modal),
+      // but keep autofocus off so the page doesn't jump to the bottom sheet.
+      showOverlay(overlay, { closeable: true, autofocus: false });
       showSummaryView();
     } else {
       applyOptionalTags(getStoredConsentSettings());


### PR DESCRIPTION
## 概要
初回アクセス時に自動表示されるCookie/言語設定バナーに閉じる(×)ボタンが表示されず、フッターの「設定」から開く設定モーダルと挙動が異なっていました。本PRで、初回バナーにも設定モーダルと同じように×ボタンを表示します。

## 背景
- フッターの「設定」から開いた場合: `closeable: true` で表示されるため×ボタンあり
- 初回アクセス時: `closeable: false` で表示されるため×ボタンなし

`closeable` フラグは「×ボタンの表示」だけでなく「自動フォーカス」も制御していました。初回表示で自動フォーカスを有効にすると、ページ下部のバナーにフォーカスが移りビューポートが下へ飛んでしまうため、単純に `closeable: true` にはできませんでした。

## 変更内容
- フォーカス制御を `closeable` から切り離し、新しい `autofocus` オプションとして分離（未指定時は従来どおり `closeable` の値を引き継ぐ）
- 初回バナーを `{ closeable: true, autofocus: false }` で表示するように変更
  - ×ボタン・Escキー・外側クリックで閉じられるようになり、設定モーダルと挙動が一致
  - 自動フォーカスは無効のままなので、初回表示時にビューポートが下部へ飛ぶ既存挙動は維持
- `hideOverlay` で `data-cookie-consent-autofocus` 属性をクリーンアップ

## 動作確認
- `node --check static/cookie-consent.js` で構文チェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)