### PR TITLE
初回アクセス時のCookieバナーから閉じる(×)ボタンを削除（PR #207 を差し戻し）

### DIFF
--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -155,7 +155,6 @@
     overlay.setAttribute('aria-hidden', 'true');
     overlay.removeAttribute('data-cookie-consent-active-view');
     overlay.removeAttribute('data-cookie-consent-closeable');
-    overlay.removeAttribute('data-cookie-consent-autofocus');
 
     if (options.restoreFocus !== false && lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
       lastFocusedElement.focus();
@@ -173,14 +172,6 @@
   function showOverlay(overlay, options = {}) {
     lastFocusedElement = document.activeElement;
     setCloseable(overlay, Boolean(options.closeable));
-    // Whether to move focus into the sheet on open. Defaults to whether the
-    // sheet is closeable (i.e. the user explicitly reopened it). The first-visit
-    // banner overrides this to false so it can show its close button without
-    // stealing focus and yanking the viewport down to the bottom of the page.
-    const autofocus = options.autofocus !== undefined
-      ? Boolean(options.autofocus)
-      : Boolean(options.closeable);
-    overlay.setAttribute('data-cookie-consent-autofocus', autofocus ? 'true' : 'false');
     // Always open expanded; the user can fold it afterwards.
     setCollapsed(overlay, false);
     overlay.classList.add('is-visible');
@@ -404,11 +395,10 @@
 
     function showSummaryView() {
       switchView(overlay, 'summary');
-      // Only steal focus when the sheet asked for it (an explicit reopen). On
-      // the very first visit, auto-focusing a button at the bottom of the page
-      // would yank the viewport down, so we leave focus where it is even though
-      // the close button is now shown.
-      if (overlay.getAttribute('data-cookie-consent-autofocus') === 'true') {
+      // Only steal focus when the user explicitly reopened the sheet. On the
+      // very first visit, auto-focusing a button at the bottom of the page
+      // would yank the viewport down, so we leave focus where it is.
+      if (overlay.getAttribute('data-cookie-consent-closeable') === 'true') {
         focusOnTarget(overlay.querySelector('[data-cookie-consent-focus]'));
       }
     }
@@ -562,9 +552,7 @@
     });
 
     if (!hasConsent()) {
-      // Show the close button on first visit too (same as the settings modal),
-      // but keep autofocus off so the page doesn't jump to the bottom sheet.
-      showOverlay(overlay, { closeable: true, autofocus: false });
+      showOverlay(overlay, { closeable: false });
       showSummaryView();
     } else {
       applyOptionalTags(getStoredConsentSettings());


### PR DESCRIPTION
## 概要
PR #207 で初回アクセス時のCookie/言語バナーにも×ボタンを表示するようにしましたが、検討の結果**初回バナーには×を表示しない方針**に決定したため、PR #207（マージコミット 3386f05）を revert します。

## 方針決定の理由
- バナーには既に「拒否する」ボタンがあり、GDPR/ePrivacy が求める「拒否は同意と同じくらい簡単に」の導線は確保済み。
- ×を初回に置くと「拒否なのか保留なのか」が利用者に伝わらず曖昧で、同意状態が未決定のまま毎回バナーが再表示される中途半端な挙動になる。
- ×は『フッターの設定から再表示した設定モーダル』にだけ残すのが自然（既に選択済みで、見直して閉じるだけのため）。

## 変更内容
- マージコミット `3386f05`（PR #207）を `git revert` で差し戻し
- 結果として、初回バナーは `closeable: false`（×なし）、設定モーダルは `closeable: true`（×あり）の元の挙動に復帰
- PR #207 で追加した未使用の `autofocus` オプションも併せて除去

## 動作確認
- `node --check static/cookie-consent.js` で構文チェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)