### PR TITLE
ノートのコピー/ペーストボタンに成功フィードバックを追加

### DIFF
--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -108,10 +108,12 @@
                     <span id="charCount" class="note-char-count" aria-live="polite">0 / {{ note_max_content_length }}文字</span>
                     <div class="note-editor-actions">
                         <button type="button" id="pasteButton" class="note-action-button" aria-label="ペースト" data-tooltip="ペースト">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                            <svg class="note-action-icon-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                            <svg class="note-action-icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                         </button>
                         <button type="button" id="copyAllButton" class="note-action-button" aria-label="全文コピー" data-tooltip="全文コピー">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            <svg class="note-action-icon-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            <svg class="note-action-icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                         </button>
                     </div>
                 </div>

--- a/Note/templates/note_room_partials/_scripts.html
+++ b/Note/templates/note_room_partials/_scripts.html
@@ -46,6 +46,7 @@
     }
   }
 
+  let shareFeedbackTimer = null;
   function setShareFeedback(message, kind) {
     const feedback = document.getElementById('shareFeedback');
     if (!feedback) {
@@ -53,6 +54,13 @@
     }
     feedback.textContent = message;
     feedback.className = `share-feedback is-visible is-${kind}`;
+    if (shareFeedbackTimer) {
+      clearTimeout(shareFeedbackTimer);
+    }
+    shareFeedbackTimer = setTimeout(() => {
+      feedback.classList.remove('is-visible');
+      shareFeedbackTimer = null;
+    }, 4000);
   }
 
   function translate(key, fallback) {

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -344,4 +344,21 @@ footer.simple-footer {
 .note-action-button:active {
   transform: translateY(0);
 }
+
+.note-action-button .note-action-icon-check {
+  display: none;
+}
+
+.note-action-button.copied {
+  color: var(--theme-note-inline-copied);
+  background: var(--theme-note-action-background-hover);
+}
+
+.note-action-button.copied .note-action-icon-default {
+  display: none;
+}
+
+.note-action-button.copied .note-action-icon-check {
+  display: inline-flex;
+}
 </style>

--- a/static/js/note_room_realtime/clipboard.js
+++ b/static/js/note_room_realtime/clipboard.js
@@ -15,6 +15,20 @@
   }
 
   function createClipboardHandlers(context) {
+    function flashButtonSuccess(button) {
+      if (!button) {
+        return;
+      }
+      button.classList.add("copied");
+      if (button._copiedTimer) {
+        clearTimeout(button._copiedTimer);
+      }
+      button._copiedTimer = setTimeout(function () {
+        button.classList.remove("copied");
+        button._copiedTimer = null;
+      }, 2000);
+    }
+
     async function handlePasteFromClipboard() {
       if (!navigator.clipboard || !navigator.clipboard.readText) {
         ui.showEditorFeedback(translate("note.clipboard_paste_unavailable", "Paste is not available in this environment."), "error");
@@ -56,6 +70,7 @@
         } else {
           ui.showEditorFeedback(translate("note.paste_success", "Pasted."), "success");
         }
+        flashButtonSuccess(context.pasteButton);
       } catch (error) {
         ui.showEditorFeedback(translate("note.paste_error", "Paste failed. Check your browser permission settings."), "error");
       }
@@ -74,6 +89,7 @@
         }
         await copyTextToClipboard(text);
         ui.showEditorFeedback(translate("note.copy_success", "Copied the full note."), "success");
+        flashButtonSuccess(context.copyAllButton);
       } catch (error) {
         ui.showEditorFeedback(translate("note.copy_error", "Copy failed. Please copy manually."), "error");
       }


### PR DESCRIPTION
## 概要

noteページの「ペースト」「全文コピー」ボタンを、他のコピーボタンと同様に押したことが分かりやすくなるよう改善しました。あわせて、コピー/ペースト時のフィードバックテキストが消えない問題を修正しました。

## 変更内容

### 1. チェックアイコンへの一瞬の切り替え
- 「ペースト」「全文コピー」ボタンに、成功時へ表示するチェックマークのSVGを追加
- 成功時に `.copied` クラスを付与してチェックアイコンへ切り替え、2秒後に元へ戻す（インラインのコピーボタンと同じ挙動）

### 2. フィードバックテキストの自動消去
- 「ノート全文をコピーしました。」「ペーストしました。」などのテキストが消えなかった問題を修正
- `setShareFeedback` に一定時間（4秒）後に非表示にするタイマーを追加

## 変更ファイル
- `Note/templates/note_room_partials/_content.html` — チェックアイコンSVGの追加
- `Note/templates/note_room_partials/_styles.html` — アイコン切り替え用CSSの追加
- `Note/templates/note_room_partials/_scripts.html` — フィードバックの自動消去タイマー
- `static/js/note_room_realtime/clipboard.js` — 成功時のチェックアイコン表示処理

🤖 Generated with [Claude Code](https://claude.com/claude-code)