### PR TITLE
[codex] 多言語版サービスのCIスモークテストを追加

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,10 +128,22 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt pytest httpx pytest-cov
 
-      - name: Run test suite
+      - name: Run multilingual service smoke tests
         run: |
           set -euo pipefail
-          python -m pytest -q --cov=. --cov-report=term-missing --cov-fail-under=67
+          python -m pytest -q tests/test_multilingual_service.py \
+            --cov=. \
+            --cov-report=
+
+      - name: Run remaining test suite
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --ignore=tests/test_multilingual_service.py \
+            --cov=. \
+            --cov-append \
+            --cov-report=term-missing \
+            --cov-fail-under=67
 
       - name: Build Docker image
         run: |

--- a/tests/test_multilingual_service.py
+++ b/tests/test_multilingual_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from starlette.testclient import TestClient
+
+
+SERVICE_SMOKE_PATHS = (
+    "/",
+    "/fs-qr_menu",
+    "/fs-qr",
+    "/search_fs-qr",
+    "/group_menu",
+    "/group",
+    "/create_room",
+    "/search_group",
+    "/note_menu",
+    "/note",
+    "/create_note_room",
+    "/search_note",
+)
+
+
+HTML_TAG_RE = re.compile(r"<html[^>]*>", re.IGNORECASE)
+
+
+def _assert_localized_service_response(response, language: str, path: str) -> None:
+    assert response.status_code == 200, f"{path}?lang={language}"
+    assert "text/html" in response.headers["content-type"], f"{path}?lang={language}"
+    assert response.headers["content-language"] == language, f"{path}?lang={language}"
+
+    html_tag = HTML_TAG_RE.search(response.text)
+    assert html_tag, f"{path}?lang={language}: missing <html> tag"
+
+    expected_dir = "rtl" if language == "ar" else "ltr"
+    assert f'lang="{language}"' in html_tag.group(0), f"{path}?lang={language}"
+    assert f'dir="{expected_dir}"' in html_tag.group(0), f"{path}?lang={language}"
+
+    # The cookie/settings component must receive the same locale that rendered
+    # the page, otherwise client-side language switching can drift from the HTML.
+    assert f"language: {json.dumps(language)}" in response.text, (
+        f"{path}?lang={language}"
+    )
+    assert f'value="{language}"' in response.text, f"{path}?lang={language}"
+    assert f'data-value="{language}"' in response.text, f"{path}?lang={language}"
+
+
+@pytest.mark.parametrize("path", SERVICE_SMOKE_PATHS)
+def test_multilingual_service_pages_render_for_every_supported_language(
+    test_client: TestClient, path: str
+):
+    from i18n import SUPPORTED_LANGUAGES
+
+    for language in SUPPORTED_LANGUAGES:
+        response = test_client.get(f"{path}?lang={language}")
+
+        _assert_localized_service_response(response, language, path)
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_lang", "expected_dir"),
+    [
+        ("en-US", "en", "ltr"),
+        ("zh-hant", "zh-TW", "ltr"),
+        ("zh_hans", "zh-CN", "ltr"),
+        ("kr", "ko", "ltr"),
+        ("ar-SA", "ar", "rtl"),
+    ],
+)
+def test_multilingual_service_accepts_common_language_aliases(
+    test_client: TestClient, language: str, expected_lang: str, expected_dir: str
+):
+    response = test_client.get(f"/fs-qr?lang={language}")
+
+    assert response.status_code == 200
+    assert response.headers["content-language"] == expected_lang
+    html_tag = HTML_TAG_RE.search(response.text)
+    assert html_tag
+    assert f'lang="{expected_lang}"' in html_tag.group(0)
+    assert f'dir="{expected_dir}"' in html_tag.group(0)


### PR DESCRIPTION
## 概要

GitHub Actions の CI で、多言語版サービスが実レスポンスとして正しく動作することを確認するスモークテストを追加しました。

## 変更内容

- 主要な公開サービスページを対象に、全対応言語で `200` が返ることを確認するテストを追加
- `Content-Language`、`<html lang>`、`dir`、言語選択UIの言語状態が一致することを検証
- `en-US`、`zh-hant`、`zh_hans`、`kr`、`ar-SA` など代表的な言語エイリアスの解決も確認
- CI の pytest ステップを分割し、多言語スモークテストを明示的なステップとして実行
- coverage は既存テストへ `--cov-append` で引き継ぎ、従来の閾値判定を維持

## 影響

多言語対応ページのレンダリング、レスポンスヘッダー、HTML属性、クライアント側言語設定の不整合をCIで検知しやすくなります。アプリケーションの実行時挙動には変更ありません。

## 検証

- `python3 -m pytest -q tests/test_multilingual_service.py`
- `python3 -m pytest -q --ignore=tests/test_multilingual_service.py --cov=. --cov-append --cov-report=term-missing --cov-fail-under=67`
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`