### PR TITLE
セキュリティ強化: CSP導入・ヘッダー一元化・非rootコンテナ・アクセスログ伏せ字化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,23 @@ RUN /usr/local/bin/python -m pip install \
 
 COPY --from=builder /opt/venv /opt/venv
 
+# Run as a non-root user. uid/gid 1000 must match the host user that owns the
+# bind-mounted directories in docker-compose (./logs, ./geoip, source tree).
+RUN groupadd --gid 1000 kota \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /usr/sbin/nologin kota
+
 # Copy the current directory contents into the container at /app
-COPY . /app
+COPY --chown=kota:kota . /app
 
 # Add wait-for-it script for database readiness
 COPY wait-for-it.sh /usr/local/bin/wait-for-it
 RUN chmod +x /usr/local/bin/wait-for-it
 
-# Create logs directory and set permissions
-RUN mkdir -p /app/logs && chmod -R 777 /app/logs
+# Writable runtime directories (logs, uploads, GeoIP DB updates)
+RUN mkdir -p /app/logs /app/storage /app/geoip \
+    && chown -R kota:kota /app/logs /app/storage /app/geoip /app/static
+
+USER kota
 
 # Expose port 5000 for Gunicorn app
 EXPOSE 5000

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from settings import (
     TRUSTED_PROXY_HOSTS,
 )
 from i18n import is_language_query_only
+from security_headers import apply_security_headers
 from web import render_cached_template, render_template, wants_json_response
 from api_response import api_error_response
 from geoip_update import geoip_update_loop, update_geoip_database_async
@@ -95,6 +96,13 @@ app.add_middleware(SessionMiddleware, **_build_session_middleware_kwargs())
 app.mount(
     "/static", StaticFiles(directory=os.path.join(BASE_DIR, "static")), name="static"
 )
+
+
+@app.middleware("http")
+async def security_headers_middleware(request: Request, call_next):
+    response = await call_next(request)
+    apply_security_headers(response.headers)
+    return response
 
 
 @app.middleware("http")

--- a/fs-qr.conf
+++ b/fs-qr.conf
@@ -1,3 +1,15 @@
+# 旧形式 /fs-qr/{room_id}/{password} は URL パスに認証情報を含むため、
+# 共有トークンとあわせてアクセスログでは伏せ字にする。
+map $request_uri $fsqr_loggable_uri {
+    ~^/fs-qr/s/                  "/fs-qr/s/[redacted]";
+    ~^/fs-qr/[^/]+/[^/]+         "/fs-qr/[redacted]/[redacted]";
+    default                      $request_uri;
+}
+
+log_format fsqr_redacted '$remote_addr - $remote_user [$time_local] '
+                         '"$request_method $fsqr_loggable_uri $server_protocol" '
+                         '$status $body_bytes_sent "$http_referer" "$http_user_agent"';
+
 server {
     listen 443 ssl;
     server_name www.fs-qr.net;
@@ -45,8 +57,6 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "public, max-age=31536000, immutable" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header X-Content-Type-Options "nosniff" always;
     }
 
     # 配信内容が定期的に変わるためブラウザ側で短時間キャッシュさせる。
@@ -85,10 +95,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # セキュリティヘッダー（HSTS / CSP / X-Frame-Options など）はアプリ側の
+    # security_headers.py ミドルウェアが全レスポンスに付与する。
+    # nginx の add_header は location 単位で server レベル定義を上書きして
+    # 漏れる location ができるため、ここでは定義しない。
+
+    access_log /var/log/nginx/access.log fsqr_redacted;
 
     client_max_body_size 500M;
 

--- a/log_config.py
+++ b/log_config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
@@ -18,6 +19,48 @@ def _build_error_handler():
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return handler
 
+
+# 旧形式 /fs-qr/{room_id}/{password} は URL パスに認証情報を含むため、
+# 共有リンクのトークン /fs-qr/s/{token} とあわせてアクセスログから伏せる。
+_SENSITIVE_PATH_PATTERNS = (
+    (re.compile(r"/fs-qr/s/[^/?#\s\"]+"), "/fs-qr/s/[redacted]"),
+    (
+        re.compile(r"/fs-qr/(?!s/|delete/)[^/?#\s\"]+/[^/?#\s\"]+"),
+        "/fs-qr/[redacted]/[redacted]",
+    ),
+)
+
+
+def redact_sensitive_paths(text: str) -> str:
+    for pattern, replacement in _SENSITIVE_PATH_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+class SensitivePathRedactionFilter(logging.Filter):
+    """アクセスログのレコードから認証情報入りパスを伏せる。"""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = redact_sensitive_paths(record.msg)
+        if isinstance(record.args, tuple):
+            record.args = tuple(
+                redact_sensitive_paths(arg) if isinstance(arg, str) else arg
+                for arg in record.args
+            )
+        return True
+
+
+def _install_redaction_filter() -> None:
+    # uvicorn.access: UvicornWorker 経由のアクセスログ
+    # gunicorn.access: gunicorn ネイティブのアクセスログ（フォールバック）
+    for logger_name in ("uvicorn.access", "gunicorn.access"):
+        target = logging.getLogger(logger_name)
+        if not any(isinstance(f, SensitivePathRedactionFilter) for f in target.filters):
+            target.addFilter(SensitivePathRedactionFilter())
+
+
+_install_redaction_filter()
 
 root_logger = logging.getLogger()
 if not root_logger.handlers:

--- a/security_headers.py
+++ b/security_headers.py
@@ -1,0 +1,91 @@
+"""全 HTTP レスポンスに付与するセキュリティヘッダー。
+
+nginx の add_header は location 内に 1 つでも add_header があると
+server レベルの定義を継承しない（ヘッダーが漏れる location ができる）ため、
+アプリ側ミドルウェアで一元的に付与する。
+"""
+
+from __future__ import annotations
+
+import os
+
+# CSP のホワイトリストはテンプレート・JS が実際に参照する外部オリジンに基づく:
+# - Google AdSense / gtag: pagead2.googlesyndication.com, googletagmanager.com ほか
+# - CDN: cdn.jsdelivr.net (Bootstrap), cdnjs.cloudflare.com (Font Awesome, JSZip)
+# - Web フォント: fonts.googleapis.com / fonts.gstatic.com
+# script-src の 'unsafe-inline' はテンプレート内インラインスクリプトのために必要。
+# 広告の画像・iframe・計測先は配信ドメインが流動的なため img/frame は https: で許可。
+_CSP_DIRECTIVES = (
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'"
+    " https://pagead2.googlesyndication.com"
+    " https://googleads.g.doubleclick.net"
+    " https://tpc.googlesyndication.com"
+    " https://www.googletagmanager.com"
+    " https://cdn.jsdelivr.net"
+    " https://cdnjs.cloudflare.com",
+    "style-src 'self' 'unsafe-inline'"
+    " https://fonts.googleapis.com"
+    " https://cdn.jsdelivr.net"
+    " https://cdnjs.cloudflare.com",
+    "font-src 'self' data:"
+    " https://fonts.gstatic.com"
+    " https://cdn.jsdelivr.net"
+    " https://cdnjs.cloudflare.com",
+    "img-src 'self' data: blob: https:",
+    "frame-src https:",
+    "connect-src 'self'"
+    " https://pagead2.googlesyndication.com"
+    " https://googleads.g.doubleclick.net"
+    " https://ep1.adtrafficquality.google"
+    " https://www.google-analytics.com"
+    " https://region1.google-analytics.com"
+    " https://www.googletagmanager.com",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'",
+)
+
+DEFAULT_CONTENT_SECURITY_POLICY = "; ".join(_CSP_DIRECTIVES)
+
+# SECURITY_CSP でポリシー全体を差し替え可能。
+# SECURITY_CSP_REPORT_ONLY=true で Report-Only 配信に切り替え（観察モード）。
+CONTENT_SECURITY_POLICY = (
+    os.getenv("SECURITY_CSP", "").strip() or DEFAULT_CONTENT_SECURITY_POLICY
+)
+CSP_REPORT_ONLY = os.getenv("SECURITY_CSP_REPORT_ONLY", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+SECURITY_HEADERS = {
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+}
+
+
+def apply_security_headers(headers) -> None:
+    """レスポンスヘッダーに不足分のセキュリティヘッダーを追加する。
+
+    既にエンドポイント側で同名ヘッダーを設定している場合は上書きしない。
+    """
+    for name, value in SECURITY_HEADERS.items():
+        if name not in headers:
+            headers[name] = value
+
+    csp_header_name = (
+        "Content-Security-Policy-Report-Only"
+        if CSP_REPORT_ONLY
+        else "Content-Security-Policy"
+    )
+    if (
+        "Content-Security-Policy" not in headers
+        and "Content-Security-Policy-Report-Only" not in headers
+    ):
+        headers[csp_header_name] = CONTENT_SECURITY_POLICY

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,66 @@
+"""セキュリティヘッダーとアクセスログ伏せ字化のテスト。"""
+
+import pytest
+
+from log_config import redact_sensitive_paths
+from security_headers import SECURITY_HEADERS
+
+EXPECTED_HEADER_NAMES = (
+    "Strict-Transport-Security",
+    "X-Content-Type-Options",
+    "X-Frame-Options",
+    "Referrer-Policy",
+    "Permissions-Policy",
+)
+
+
+def test_index_has_security_headers(test_client):
+    response = test_client.get("/")
+    assert response.status_code == 200
+    for name in EXPECTED_HEADER_NAMES:
+        assert response.headers.get(name) == SECURITY_HEADERS[name]
+    csp = response.headers.get("Content-Security-Policy") or response.headers.get(
+        "Content-Security-Policy-Report-Only"
+    )
+    assert csp is not None
+    assert "default-src 'self'" in csp
+    assert "object-src 'none'" in csp
+    assert "frame-ancestors 'self'" in csp
+
+
+def test_404_response_has_security_headers(test_client):
+    response = test_client.get("/no-such-page")
+    assert response.status_code == 404
+    for name in EXPECTED_HEADER_NAMES:
+        assert response.headers.get(name) == SECURITY_HEADERS[name]
+
+
+def test_static_response_has_security_headers(test_client):
+    response = test_client.get("/robots.txt")
+    assert response.status_code == 200
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/fs-qr/room1/secret-pw", "/fs-qr/[redacted]/[redacted]"),
+        (
+            "/fs-qr/room1/secret-pw/download",
+            "/fs-qr/[redacted]/[redacted]/download",
+        ),
+        ("/fs-qr/s/token123", "/fs-qr/s/[redacted]"),
+        ("/fs-qr/s/token123/download", "/fs-qr/s/[redacted]/download"),
+        (
+            'GET /fs-qr/room1/secret-pw HTTP/1.1" 410',
+            'GET /fs-qr/[redacted]/[redacted] HTTP/1.1" 410',
+        ),
+        # 認証情報を含まないパスはそのまま
+        ("/fs-qr", "/fs-qr"),
+        ("/fs-qr_menu", "/fs-qr_menu"),
+        ("/fs-qr/delete/abc", "/fs-qr/delete/abc"),
+        ("/download/abc", "/download/abc"),
+    ],
+)
+def test_redact_sensitive_paths(path, expected):
+    assert redact_sensitive_paths(path) == expected


### PR DESCRIPTION
## 概要

セキュリティレビューで見つかった優先度の高い4項目を実装しました。

### 1. CSP（Content-Security-Policy）の導入
- `security_headers.py` を新規追加。テンプレート・JS が実際に参照する外部オリジン（AdSense / gtag / cdn.jsdelivr.net / cdnjs.cloudflare.com / Google Fonts）を調査してホワイトリストを作成
- `object-src 'none'`・`base-uri 'self'`・`form-action 'self'`・`frame-ancestors 'self'` で XSS 時の被害を制限
- 環境変数で調整可能:
  - `SECURITY_CSP_REPORT_ONLY=true` → Report-Only 配信（観察モード）に切替
  - `SECURITY_CSP` → ポリシー全体を上書き

### 2. セキュリティヘッダーのアプリ側一元化
- nginx の `add_header` は location 内に 1 つでも `add_header` があると server レベルの定義を継承しないため、`/sitemap.xml`・`/robots.txt`・`/ads.txt` で HSTS 等が漏れていた
- アプリ側ミドルウェアで全レスポンス（エラーページ・静的ファイル含む）に付与する方式へ変更し、`fs-qr.conf` の重複定義を削除

### 3. コンテナの非 root 化
- `Dockerfile` に非 root ユーザー `kota`（uid/gid 1000 = ホストユーザーと同一でバインドマウントと整合）を追加
- `chmod -R 777 /app/logs` を廃止し、書き込みが必要なディレクトリ（logs / storage / geoip / static）のみ chown

### 4. パスワード入り URL のアクセスログ伏せ字化
- 旧形式 `/fs-qr/{room_id}/{password}` ルートはすでに 410 で停止済みだが、アクセスログには平文で残っていた
- `uvicorn.access` / `gunicorn.access` ロガーにフィルタを追加し、旧形式 URL と共有トークン `/fs-qr/s/{token}` を `[redacted]` に置換
- nginx 側も `map` + 専用 `log_format` で同様に伏せ字化

## テスト

- 全 481 テストがパス（新規追加の `tests/test_security_headers.py` 12 件を含む）
- Docker イメージのビルドと非 root ユーザーでの書き込み動作を確認
- `fs-qr.conf` は nginx コンテナで `nginx -t` の構文チェック済み

## デプロイ時の注意

1. 既存の `logs/access.log`・`logs/error.log` が root 所有のため、新イメージ起動前にホストで `sudo chown -R kota:kota logs` が必要
2. `fs-qr.conf` をサーバーへ反映し `nginx -t && nginx -s reload` が必要
3. デプロイ後、広告（AdSense）と GA が正常に動くか確認を推奨。問題があれば `SECURITY_CSP_REPORT_ONLY=true` で一時的に観察モードへ戻せます

🤖 Generated with [Claude Code](https://claude.com/claude-code)