### PR TITLE
[codex] Group/FSQRの作成エラー耐性を改善

### DIFF
--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -210,6 +210,21 @@ def _validate_fsqr_encrypted_payload(
     return None
 
 
+async def _create_fsqr_share_token(
+    *, secure_id: str, id_val: str, password: str, retention_days: int
+) -> str:
+    try:
+        return await create_share_link(
+            service_key=ServiceKey.FSQR,
+            resource_id=secure_id,
+            expires_at=datetime.now() + timedelta(days=retention_days),
+            metadata={"id": id_val, "password_enc": encrypt_share_password(password)},
+        )
+    except Exception:
+        logger.exception("Failed to create FSQR share link: secure_id=%s", secure_id)
+        return ""
+
+
 @router.get("/fs-qr_menu", name="fsqr.fs_qr")
 async def fs_qr(request: Request):
     canonical = _canonical_redirect(request)
@@ -319,11 +334,11 @@ async def upload(  # noqa: C901
             retention_days=retention_days_int,
         )
         metadata_saved = True
-        share_token = await create_share_link(
-            service_key=ServiceKey.FSQR,
-            resource_id=secure_id,
-            expires_at=datetime.now() + timedelta(days=retention_days_int),
-            metadata={"id": id_val, "password_enc": encrypt_share_password(password)},
+        share_token = await _create_fsqr_share_token(
+            secure_id=secure_id,
+            id_val=id_val,
+            password=password,
+            retention_days=retention_days_int,
         )
         os.replace(temp_path, final_path)
     except Exception:

--- a/Group/group_routes_file.py
+++ b/Group/group_routes_file.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import urllib
 import zipfile
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, File, Request, UploadFile
@@ -48,6 +49,8 @@ from .group_storage import (
 )
 from .group_realtime import notify_group_files_updated
 from web import enforce_csrf
+
+logger = logging.getLogger(__name__)
 
 
 _PREVIEW_MIME_TYPES = {
@@ -113,6 +116,15 @@ def _remove_temp_file(path: str):
         os.remove(path)
     except OSError:
         pass
+
+
+async def _notify_files_updated(room_id: str):
+    try:
+        await notify_group_files_updated(room_id)
+    except Exception:
+        logger.warning(
+            "Failed to notify Group file update: room_id=%s", room_id, exc_info=True
+        )
 
 
 def register_group_upload_route(router: APIRouter):
@@ -199,7 +211,7 @@ def register_group_upload_route(router: APIRouter):
 
         if rejected_files:
             if saved_files:
-                await notify_group_files_updated(room_id)
+                await _notify_files_updated(room_id)
             return api_error_response(
                 "HTML/SVG ファイルはアップロードできません。",
                 status_code=400,
@@ -208,14 +220,14 @@ def register_group_upload_route(router: APIRouter):
 
         if error_files:
             if saved_files:
-                await notify_group_files_updated(room_id)
+                await _notify_files_updated(room_id)
             return api_error_response(
                 "以下のファイルが保存できませんでした。",
                 status_code=500,
                 data={"files": error_files},
             )
 
-        await notify_group_files_updated(room_id)
+        await _notify_files_updated(room_id)
         return api_ok_response(
             {
                 "message": "ファイルが正常にアップロードされました。",

--- a/Group/group_routes_room.py
+++ b/Group/group_routes_room.py
@@ -1,8 +1,12 @@
 import logging
 import os
+import secrets
+import string
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Request
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 from starlette.responses import RedirectResponse
 from werkzeug.utils import secure_filename
 
@@ -44,6 +48,38 @@ from .group_responses import room_msg
 from .group_storage import UPLOAD_FOLDER
 
 logger = logging.getLogger(__name__)
+ROOM_ID_ATTEMPTS = 10
+ROOM_ID_CHARS = string.ascii_letters + string.digits
+
+
+def _generate_room_id() -> str:
+    return "".join(secrets.choice(ROOM_ID_CHARS) for _ in range(6))
+
+
+def _is_valid_room_id(room_id: str) -> bool:
+    try:
+        RoomCreateInput(id=room_id, id_mode="manual").validate_manual_id()
+    except (ValidationError, ValueError):
+        return False
+    return True
+
+
+async def _create_group_share_token(
+    *, room_id: str, password: str, retention_days: int
+) -> str:
+    try:
+        return await create_share_link(
+            service_key=ServiceKey.GROUP,
+            resource_id=room_id,
+            expires_at=datetime.now() + timedelta(days=retention_days),
+            metadata={
+                "id": room_id,
+                "password_enc": encrypt_share_password(password),
+            },
+        )
+    except Exception:
+        logger.exception("Failed to create Group share link: room_id=%s", room_id)
+        return ""
 
 
 def _render_group_room(request: Request, room_id: str, record: dict):
@@ -143,9 +179,9 @@ def register_group_room_access_route(router: APIRouter):
         )
 
 
-def register_group_create_room_route(router: APIRouter):
+def register_group_create_room_route(router: APIRouter):  # noqa: C901
     @router.post("/create_group_room", name="group.create_group_room")
-    async def create_group_room(request: Request):
+    async def create_group_room(request: Request):  # noqa: C901
         await enforce_csrf(request)
         json_data = {}
         form_data = {}
@@ -171,70 +207,93 @@ def register_group_create_room_route(router: APIRouter):
         if raw_retention is None:
             raw_retention = json_data.get("retention_days", 7)
 
-        inp = RoomCreateInput(
-            id=raw_id, id_mode=raw_id_mode, retention_days=raw_retention
-        )
+        try:
+            inp = RoomCreateInput(
+                id=raw_id, id_mode=raw_id_mode, retention_days=raw_retention
+            )
+        except ValidationError:
+            return api_error_response("入力内容が不正です。", status_code=400)
         retention_days = inp.retention_days
 
-        if inp.id_mode != "auto":
+        if inp.id_mode == "auto":
+            id_val = inp.id if _is_valid_room_id(inp.id) else ""
+        else:
             try:
                 id_val = inp.validate_manual_id()
             except ValueError as exc:
                 return api_error_response(str(exc), status_code=400)
-        else:
-            id_val = inp.id
-            if not id_val:
-                return api_error_response(
-                    "IDが取得できませんでした。再度お試しください。",
-                    status_code=400,
-                )
+
+        try:
+            if inp.id_mode == "auto":
+                if id_val and await group_data.get_data(id_val):
+                    return api_error_response(
+                        "生成されたIDが重複しています。新しいIDで再試行してください。",
+                        status_code=409,
+                        data={"retry_auto": True},
+                    )
+                if not id_val:
+                    for _ in range(ROOM_ID_ATTEMPTS):
+                        candidate = _generate_room_id()
+                        if not await group_data.get_data(candidate):
+                            id_val = candidate
+                            break
+                    if not id_val:
+                        return api_error_response(
+                            "自動生成IDの作成に失敗しました。時間をおいて再試行してください。",
+                            status_code=500,
+                        )
+            else:
+                existing_room = await group_data.get_data(id_val)
+                if existing_room:
+                    return api_error_response(
+                        "このIDは既に使用されています。別のIDを使用してください。",
+                        status_code=409,
+                    )
+        except Exception:
+            logger.exception("Failed to check Group room ID")
+            return api_error_response(
+                "ルーム作成に失敗しました。時間をおいて再度お試しください。",
+                status_code=500,
+            )
 
         room_id = id_val
-        existing_room = await group_data.get_data(room_id)
-
-        if existing_room:
-            if inp.id_mode == "auto":
-                return api_error_response(
-                    "生成されたIDが重複しています。新しいIDで再試行してください。",
-                    status_code=409,
-                    data={"retry_auto": True},
-                )
-            return api_error_response(
-                "このIDは既に使用されています。別のIDを使用してください。",
-                status_code=409,
-            )
 
         password = generate_room_password()
 
         folder_path = os.path.join(UPLOAD_FOLDER, secure_filename(room_id))
         os.makedirs(folder_path, exist_ok=True)
 
-        await group_data.create_room(
-            id=room_id,
-            password=password,
-            room_id=room_id,
-            retention_days=retention_days,
-        )
         try:
-            share_token = await create_share_link(
-                service_key=ServiceKey.GROUP,
-                resource_id=room_id,
-                expires_at=datetime.now() + timedelta(days=retention_days),
-                metadata={
-                    "id": room_id,
-                    "password_enc": encrypt_share_password(password),
-                },
+            await group_data.create_room(
+                id=room_id,
+                password=password,
+                room_id=room_id,
+                retention_days=retention_days,
+            )
+        except IntegrityError:
+            logger.info("Group room ID conflict while creating room_id=%s", room_id)
+            try:
+                os.rmdir(folder_path)
+            except OSError:
+                pass
+            return api_error_response(
+                "このIDは既に使用されています。別のIDを使用してください。",
+                status_code=409,
+                data={"retry_auto": inp.id_mode == "auto"},
             )
         except Exception:
-            logger.exception("Failed to create Group share link: room_id=%s", room_id)
+            logger.exception("Failed to create Group room: room_id=%s", room_id)
             try:
-                await group_data.remove_data(room_id)
-            except Exception:
-                logger.exception("Failed to roll back Group room: room_id=%s", room_id)
+                os.rmdir(folder_path)
+            except OSError:
+                pass
             return api_error_response(
-                "共有URLの作成に失敗しました。時間をおいて再度お試しください。",
+                "ルーム作成に失敗しました。時間をおいて再度お試しください。",
                 status_code=500,
             )
+        share_token = await _create_group_share_token(
+            room_id=room_id, password=password, retention_days=retention_days
+        )
         remember_group_room_access(
             request,
             room_id,
@@ -251,7 +310,9 @@ def register_group_create_room_route(router: APIRouter):
                     "redirect_url": redirect_url,
                     "share_url": build_share_url(
                         request, service_key=ServiceKey.GROUP, token=share_token
-                    ),
+                    )
+                    if share_token
+                    else "",
                     "password": password,
                 }
             )

--- a/alembic/versions/20260611_0007_repair_share_link_dependencies.py
+++ b/alembic/versions/20260611_0007_repair_share_link_dependencies.py
@@ -1,0 +1,212 @@
+"""repair share link dependencies
+
+Revision ID: 20260611_0007
+Revises: 20260524_0006
+Create Date: 2026-06-11 00:00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260611_0007"
+down_revision = "20260524_0006"
+branch_labels = None
+depends_on = None
+
+_ALLOWED_TABLES = {"fsqr", "room", "share_links"}
+
+
+def upgrade() -> None:
+    _ensure_fsqr_upload_columns()
+    _ensure_group_room_columns()
+    _ensure_share_links_table()
+
+
+def downgrade() -> None:
+    # This revision is a production repair migration. Dropping repaired columns
+    # or the shared link table would break existing share URLs.
+    pass
+
+
+def _ensure_fsqr_upload_columns() -> None:
+    _add_column_if_missing(
+        "fsqr",
+        "share_token_hash",
+        "ALTER TABLE fsqr ADD COLUMN share_token_hash VARCHAR(64) DEFAULT NULL",
+    )
+    _add_column_if_missing(
+        "fsqr",
+        "file_type",
+        "ALTER TABLE fsqr ADD COLUMN file_type VARCHAR(20) DEFAULT 'multiple'",
+    )
+    _add_column_if_missing(
+        "fsqr",
+        "original_filename",
+        "ALTER TABLE fsqr ADD COLUMN original_filename VARCHAR(255) DEFAULT NULL",
+    )
+    _add_column_if_missing(
+        "fsqr",
+        "retention_days",
+        "ALTER TABLE fsqr ADD COLUMN retention_days INT NOT NULL DEFAULT 7",
+    )
+    _add_index_if_missing(
+        "fsqr",
+        "idx_fsqr_secure_id",
+        "ALTER TABLE fsqr ADD INDEX idx_fsqr_secure_id (secure_id)",
+    )
+
+
+def _ensure_group_room_columns() -> None:
+    _add_column_if_missing(
+        "room",
+        "retention_days",
+        "ALTER TABLE room ADD COLUMN retention_days INT NOT NULL DEFAULT 7",
+    )
+    _add_unique_if_missing(
+        "room",
+        "uq_room_room_id",
+        "ALTER TABLE room ADD UNIQUE KEY uq_room_room_id (room_id)",
+    )
+
+
+def _ensure_share_links_table() -> None:
+    if not _table_exists("share_links"):
+        op.execute("""
+            CREATE TABLE share_links (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                service_key VARCHAR(20) NOT NULL,
+                resource_id VARCHAR(255) NOT NULL,
+                token_hash VARCHAR(64) NOT NULL,
+                scope VARCHAR(50) NOT NULL DEFAULT 'read',
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                expires_at DATETIME NULL,
+                revoked_at DATETIME NULL,
+                metadata JSON NULL,
+                UNIQUE KEY uq_share_links_token_hash (token_hash),
+                INDEX idx_share_links_resource (service_key, resource_id),
+                INDEX idx_share_links_expires_at (expires_at),
+                INDEX idx_share_links_active (
+                    service_key, scope, revoked_at, expires_at
+                )
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+        """)
+        return
+
+    _add_column_if_missing(
+        "share_links",
+        "service_key",
+        "ALTER TABLE share_links ADD COLUMN service_key VARCHAR(20) NULL",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "resource_id",
+        "ALTER TABLE share_links ADD COLUMN resource_id VARCHAR(255) NULL",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "token_hash",
+        "ALTER TABLE share_links ADD COLUMN token_hash VARCHAR(64) NULL",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "scope",
+        "ALTER TABLE share_links ADD COLUMN scope VARCHAR(50) NOT NULL DEFAULT 'read'",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "created_at",
+        (
+            "ALTER TABLE share_links ADD COLUMN created_at DATETIME NOT NULL "
+            "DEFAULT CURRENT_TIMESTAMP"
+        ),
+    )
+    _add_column_if_missing(
+        "share_links",
+        "expires_at",
+        "ALTER TABLE share_links ADD COLUMN expires_at DATETIME NULL",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "revoked_at",
+        "ALTER TABLE share_links ADD COLUMN revoked_at DATETIME NULL",
+    )
+    _add_column_if_missing(
+        "share_links",
+        "metadata",
+        "ALTER TABLE share_links ADD COLUMN metadata JSON NULL",
+    )
+    _add_unique_if_missing(
+        "share_links",
+        "uq_share_links_token_hash",
+        "ALTER TABLE share_links ADD UNIQUE KEY uq_share_links_token_hash (token_hash)",
+    )
+    _add_index_if_missing(
+        "share_links",
+        "idx_share_links_resource",
+        "ALTER TABLE share_links ADD INDEX idx_share_links_resource (service_key, resource_id)",
+    )
+    _add_index_if_missing(
+        "share_links",
+        "idx_share_links_expires_at",
+        "ALTER TABLE share_links ADD INDEX idx_share_links_expires_at (expires_at)",
+    )
+    _add_index_if_missing(
+        "share_links",
+        "idx_share_links_active",
+        (
+            "ALTER TABLE share_links ADD INDEX idx_share_links_active "
+            "(service_key, scope, revoked_at, expires_at)"
+        ),
+    )
+
+
+def _table_exists(table_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+          AND COLUMN_NAME = '{column_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+          AND INDEX_NAME = '{index_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _add_column_if_missing(table_name: str, column_name: str, ddl: str) -> None:
+    if _table_exists(table_name) and not _column_exists(table_name, column_name):
+        op.execute(ddl)
+
+
+def _add_index_if_missing(table_name: str, index_name: str, ddl: str) -> None:
+    if _table_exists(table_name) and not _index_exists(table_name, index_name):
+        op.execute(ddl)
+
+
+def _add_unique_if_missing(table_name: str, index_name: str, ddl: str) -> None:
+    _add_index_if_missing(table_name, index_name, ddl)

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -249,6 +249,53 @@ def test_upload_single_filename_with_enc_keeps_download_path_consistent(
     assert "share_token" not in save_mock.await_args.kwargs
 
 
+def test_upload_succeeds_when_share_link_creation_fails(
+    test_client: TestClient, tmp_path
+):
+    """共有URL発行が失敗してもアップロード本体は完了する"""
+    save_mock = AsyncMock()
+    with (
+        patch("FSQR.fsqr_app.STATIC", str(tmp_path)),
+        patch("FSQR.fsqr_app.uuid.uuid4", return_value="1234567890abcdef"),
+        patch("FSQR.fsqr_data.save_file", save_mock),
+        patch(
+            "FSQR.fsqr_app.create_share_link",
+            new=AsyncMock(side_effect=RuntimeError("share table missing")),
+        ),
+    ):
+        response = test_client.post(
+            "/upload",
+            files={
+                "upfile": (
+                    "report.pdf.enc",
+                    b"encrypted-by-browser",
+                    "application/octet-stream",
+                )
+            },
+            data={
+                "name": "abc123",
+                "download_password": "123456",
+                "file_type": "single",
+                "original_filename": "report.pdf",
+                "retention_days": "7",
+            },
+            headers={
+                "X-Requested-With": "XMLHttpRequest",
+                "Accept": "application/json",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert (
+        payload["data"]["redirect_url"]
+        == "/upload_complete/abc123-1234567890-report.pdf"
+    )
+    assert (tmp_path / "abc123-1234567890-report.pdf.enc").exists()
+    save_mock.assert_awaited_once()
+
+
 def test_fsqr_owner_session_can_delete_uploaded_file(test_client: TestClient, tmp_path):
     """アップロード直後の同一セッションだけFSQRファイルを削除できる"""
     secure_id = "own123-1234567890-report.pdf"

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -100,6 +100,81 @@ def test_create_group_room_fetch_returns_redirect_url(test_client: TestClient):
     )
 
 
+def test_create_group_room_auto_empty_id_is_generated_server_side(
+    test_client: TestClient,
+):
+    """auto ID が空でもサーバー側でIDを生成して作成できる"""
+    create_mock = AsyncMock()
+    with (
+        patch("Group.group_routes_room._generate_room_id", return_value="gen001"),
+        patch("Group.group_routes_room.generate_room_password", return_value="000042"),
+        patch(
+            "Group.group_routes_room.create_share_link",
+            new=AsyncMock(return_value="group-share-token"),
+        ),
+        patch(
+            "Group.group_routes_room.group_data.get_data",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("Group.group_routes_room.group_data.create_room", create_mock),
+        patch("Group.group_routes_room.os.makedirs"),
+    ):
+        response = test_client.post(
+            "/create_group_room",
+            json={"id": "", "idMode": "auto", "retention_days": "7"},
+            headers={"X-Requested-With": "fetch", "Accept": "application/json"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["data"]["redirect_url"] == "/group/r/gen001"
+    create_mock.assert_awaited_once_with(
+        id="gen001",
+        password="000042",
+        room_id="gen001",
+        retention_days=7,
+    )
+
+
+def test_create_group_room_succeeds_when_share_link_creation_fails(
+    test_client: TestClient,
+):
+    """共有URL発行が失敗してもルーム作成自体は完了する"""
+    create_mock = AsyncMock()
+    remove_mock = AsyncMock()
+    with (
+        patch("Group.group_routes_room.generate_room_password", return_value="000042"),
+        patch(
+            "Group.group_routes_room.group_data.get_data",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("Group.group_routes_room.group_data.create_room", create_mock),
+        patch("Group.group_routes_room.group_data.remove_data", remove_mock),
+        patch(
+            "Group.group_routes_room.create_share_link",
+            new=AsyncMock(side_effect=RuntimeError("share table missing")),
+        ),
+        patch("Group.group_routes_room.os.makedirs"),
+    ):
+        response = test_client.post(
+            "/create_group_room",
+            data={"id": "abc123", "idMode": "manual", "retention_days": "7"},
+            headers={"X-Requested-With": "fetch", "Accept": "application/json"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["data"]["redirect_url"] == "/group/r/abc123"
+    assert payload["data"]["share_url"] == ""
+    assert payload["data"]["password"] == "000042"
+    create_mock.assert_awaited_once()
+    remove_mock.assert_not_awaited()
+
+
 # --- search_group_process バリデーション ---
 
 
@@ -313,6 +388,38 @@ def test_group_upload_rejects_html_or_svg_content(test_client: TestClient):
     assert payload["status"] == "error"
     assert payload["error"] == "HTML/SVG ファイルはアップロードできません。"
     assert payload["data"]["files"] == ["safe.txt"]
+
+
+def test_group_upload_succeeds_when_realtime_notification_fails(
+    test_client: TestClient, tmp_path
+):
+    """保存後の通知失敗はアップロード成功レスポンスを壊さない"""
+    with (
+        patch("Group.group_routes_file.UPLOAD_FOLDER", str(tmp_path)),
+        patch("Group.group_routes_file.has_group_room_access", return_value=True),
+        patch(
+            "Group.group_routes_file.get_room_if_active",
+            new_callable=AsyncMock,
+            return_value={"id": "abc123"},
+        ),
+        patch(
+            "Group.group_routes_file.validate_upload_file_content", return_value=None
+        ),
+        patch(
+            "Group.group_routes_file.notify_group_files_updated",
+            new=AsyncMock(side_effect=RuntimeError("ws down")),
+        ),
+    ):
+        response = test_client.post(
+            "/group_upload/abc123",
+            files={"upfile": ("notes.txt", b"hello", "text/plain")},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["data"]["saved_files"] == ["notes.txt"]
+    assert (tmp_path / "abc123" / "notes.txt").read_bytes() == b"hello"
 
 
 # --- check (list_files): 認証失敗 → 404 ---


### PR DESCRIPTION
## 概要
- Groupのルーム作成でauto IDが空の場合もサーバー側でIDを生成するようにしました。
- Group/FSQRの共有URL発行が失敗しても、ルーム作成・アップロード本体は完了できるようにしました。
- Groupのファイルアップロード後のWebSocket通知失敗を、アップロード失敗として返さないようにしました。
- 既存DBで共有リンク関連テーブル・列が欠けている場合に補修するAlembicマイグレーションを追加しました。

## 原因
Groupのルーム作成とFSQRアップロードは、DB保存後の共有URL発行に失敗すると処理全体を500エラー扱いにしていました。既存DBの共有リンクスキーマ不足や一時的な通知失敗が、作成・アップロード本体の失敗としてユーザーに見えていました。

## 影響
共有URL発行に失敗した場合でも、作成者のセッションにはID/パスワードと削除権限を保持します。共有リンクDBは起動時マイグレーションで補修されるため、通常運用では共有URLも復旧します。

## 検証
- `ruff check Group/group_routes_room.py Group/group_routes_file.py FSQR/fsqr_app.py tests/test_group.py tests/test_fsqr.py alembic/versions/20260611_0007_repair_share_link_dependencies.py`
- `pytest tests/test_group.py tests/test_fsqr.py tests/test_e2e_user_flows.py -q`
- `pytest -q`（504 passed）