### PR TITLE
[codex] AdSense ポリシー違反候補を修正

### DIFF
--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -81,9 +81,12 @@
   <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
   <link href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
         rel="stylesheet">
-  <!-- Google 広告用のコード -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4557554518872474"
-     crossorigin="anonymous"></script>
+  <script>
+    window.FSQR_TAGS = Object.freeze({
+      googleAnalyticsId: {{ google_analytics_id | tojson }},
+      adsenseClientId: {{ google_adsense_client_id | tojson }}
+    });
+  </script>
   <title>{% block page_title %}FS!QR Note | 無料リアルタイム同時編集ノート・コラボレーションサービス{% endblock %}</title>
   
   <!-- Structured Data -->
@@ -144,17 +147,6 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body class="note-section">
-  <!-- Google アナリティクス用のコード -->
-  <script async
-      src="https://www.googletagmanager.com/gtag/js?id=G-D26D8ZXKNV"></script>
-  <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-D26D8ZXKNV');
-  </script>
-
   <!-- ── Header ───────────────────────── -->
   <header>
     <div class="container text-center">

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 BASE_DIR = os.path.dirname(__file__)
+PUBLIC_SITE_URL = os.getenv("PUBLIC_SITE_URL", "https://fs-qr.net").rstrip("/")
 
 ADMIN_KEY = os.getenv("ADMIN_KEY")
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -85,8 +85,8 @@
       rel="stylesheet">
     <script>
       window.FSQR_TAGS = Object.freeze({
-        googleAnalyticsId: 'G-D26D8ZXKNV',
-        adsenseClientId: 'ca-pub-4557554518872474'
+        googleAnalyticsId: {{ google_analytics_id | tojson }},
+        adsenseClientId: {{ google_adsense_client_id | tojson }}
       });
     </script>
     <title>{% block page_title %}FS!QR Group | 無料グループファイル共有・チーム協業クラウドサービス{% endblock %}</title>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -85,8 +85,8 @@
       rel="stylesheet">
     <script>
       window.FSQR_TAGS = Object.freeze({
-        googleAnalyticsId: 'G-D26D8ZXKNV',
-        adsenseClientId: 'ca-pub-4557554518872474'
+        googleAnalyticsId: {{ google_analytics_id | tojson }},
+        adsenseClientId: {{ google_adsense_client_id | tojson }}
       });
     </script>
     <title>{% block page_title %}FS!QR | 無料で簡単なファイル共有サービス - QRコード・グループ・ノート共有{% endblock %}</title>

--- a/tests/test_basic_routes.py
+++ b/tests/test_basic_routes.py
@@ -254,12 +254,26 @@ def test_privacy_policy(test_client: TestClient):
 
 
 def test_google_tags_are_loaded_through_cookie_consent(test_client: TestClient):
-    for path in ("/privacy-policy", "/group"):
+    for path in ("/about", "/usage"):
         response = test_client.get(path)
         assert response.status_code == 200
         assert "window.FSQR_TAGS" in response.text
-        assert "googleAnalyticsId: 'G-D26D8ZXKNV'" in response.text
-        assert "adsenseClientId: 'ca-pub-4557554518872474'" in response.text
+        assert 'googleAnalyticsId: "G-D26D8ZXKNV"' in response.text
+        assert 'adsenseClientId: "ca-pub-4557554518872474"' in response.text
+        assert 'src="https://www.googletagmanager.com/gtag/js' not in response.text
+        assert (
+            'src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
+            not in response.text
+        )
+
+
+def test_adsense_is_not_exposed_on_functional_note_pages(test_client: TestClient):
+    for path in ("/note", "/create_note_room", "/search_note"):
+        response = test_client.get(path)
+        assert response.status_code == 200
+        assert "window.FSQR_TAGS" in response.text
+        assert 'googleAnalyticsId: "G-D26D8ZXKNV"' in response.text
+        assert "ca-pub-4557554518872474" not in response.text
         assert 'src="https://www.googletagmanager.com/gtag/js' not in response.text
         assert (
             'src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -204,4 +204,12 @@ def test_home_hreflang_alternates_include_every_supported_language(
 def test_canonical_url_is_set_on_home(test_client: TestClient):
     response = test_client.get("/")
     assert response.status_code == 200
-    assert re.search(r'<link rel="canonical" href="[^"]+"', response.text)
+    assert '<link rel="canonical" href="https://fs-qr.net/"' in response.text
+    assert "http://127.0.0.1:5000/" not in response.text
+
+
+def test_canonical_url_uses_public_https_origin(test_client: TestClient):
+    response = test_client.get("/note")
+    assert response.status_code == 200
+    assert '<link rel="canonical" href="https://fs-qr.net/note"' in response.text
+    assert "http://fs-qr.net/note" not in response.text

--- a/web.py
+++ b/web.py
@@ -5,7 +5,7 @@ import os
 import secrets
 import time
 from typing import Any, Dict, Iterable
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlsplit, urlunsplit
 
 from fastapi import HTTPException, Request, WebSocket
 from fastapi.templating import Jinja2Templates
@@ -30,6 +30,7 @@ from settings import (
     GROUP_FILE_LIST_REQUEST_TIMEOUT_MS,
     NOTE_MAX_CONTENT_LENGTH,
     NOTE_SELF_EDIT_TIMEOUT_MS,
+    PUBLIC_SITE_URL,
     UPLOAD_MAX_FILES,
     UPLOAD_MAX_TOTAL_SIZE_BYTES,
     UPLOAD_MAX_TOTAL_SIZE_MB,
@@ -62,10 +63,28 @@ class TemplateRequestProxy:
     def __init__(self, request: Request) -> None:
         self._request = request
 
+    def _absolute_public_url(self, *, path: str | None = None, query: str | None = None) -> str:
+        url = self._request.url
+        resolved_path = path if path is not None else url.path
+        resolved_query = url.query if query is None else query
+
+        if PUBLIC_SITE_URL:
+            public_base = urlsplit(PUBLIC_SITE_URL)
+            return urlunsplit(
+                (
+                    public_base.scheme or "https",
+                    public_base.netloc,
+                    resolved_path,
+                    resolved_query,
+                    "",
+                )
+            )
+
+        return str(url.replace(path=resolved_path, query=resolved_query))
+
     @property
     def url_root(self) -> str:
-        url = self._request.url
-        return str(url.replace(path="/", query=""))
+        return self._absolute_public_url(path="/", query="")
 
     def _current_lang_param(self) -> str:
         raw = self._request.query_params.get("lang", "").strip()
@@ -81,11 +100,10 @@ class TemplateRequestProxy:
 
     @property
     def canonical_url(self) -> str:
-        url = self._request.url
         lang = self._current_lang_param()
         if lang:
-            return str(url.replace(query=f"lang={lang}"))
-        return str(url.replace(query=""))
+            return self._absolute_public_url(query=f"lang={lang}")
+        return self._absolute_public_url(query="")
 
     @property
     def language_alternates(self) -> list[dict[str, str]]:
@@ -95,7 +113,7 @@ class TemplateRequestProxy:
         - その他は ?lang=<code>
         - x-default は ja と同じURL
         """
-        base = str(self._request.url.replace(query=""))
+        base = self._absolute_public_url(query="")
         alternates: list[dict[str, str]] = []
         for code in self.SUPPORTED_HREFLANG_LANGS:
             if code == "ja":
@@ -116,6 +134,35 @@ def staticfile(fname: str) -> str:
         mtime = str(int(os.stat(path).st_mtime))
         return "/static/" + fname + "?v=" + str(mtime)
     return "/static/" + fname
+
+
+GOOGLE_ANALYTICS_ID = "G-D26D8ZXKNV"
+GOOGLE_ADSENSE_CLIENT_ID = "ca-pub-4557554518872474"
+ADSENSE_ALLOWED_STATIC_PATHS = frozenset(
+    {
+        "/",
+        "/about",
+        "/usage",
+        "/articles",
+        "/fs-qr_menu",
+        "/group_menu",
+    }
+)
+
+
+def _is_adsense_allowed_path(path: str) -> bool:
+    """AdSense は編集・検索・アップロード等の機能画面では読み込まない。"""
+    normalized_path = path.rstrip("/") or "/"
+    if normalized_path in ADSENSE_ALLOWED_STATIC_PATHS:
+        return True
+
+    try:
+        from Articles.articles_registry import get_all_articles
+
+        article_paths = {f"/{article['slug']}" for article in get_all_articles()}
+    except Exception:
+        article_paths = set()
+    return normalized_path in article_paths
 
 
 @pass_context
@@ -264,12 +311,17 @@ logger = logging.getLogger(__name__)
 
 def render_template(request: Request, template_name: str, **context: Any):
     language = resolve_language(request)
+    adsense_client_id = (
+        GOOGLE_ADSENSE_CLIENT_ID if _is_adsense_allowed_path(request.url.path) else None
+    )
     payload = {
         "request": TemplateRequestProxy(request),
         "current_language": language,
         "language_options": get_language_options(language),
         "frontend_messages": get_frontend_messages(language),
         "t": make_translator(language),
+        "google_analytics_id": GOOGLE_ANALYTICS_ID,
+        "google_adsense_client_id": adsense_client_id,
     }
     payload.update(context)
     try:
@@ -288,7 +340,7 @@ def render_template(request: Request, template_name: str, **context: Any):
         raise e
 
 
-RENDER_CACHE_KEY_PREFIX = "render_cache"
+RENDER_CACHE_KEY_PREFIX = "render_cache:v2"
 RENDER_CACHE_CSRF_PLACEHOLDER = "__FSQR_CSRF_TOKEN_PLACEHOLDER__"
 
 
@@ -298,7 +350,14 @@ def _render_cache_key(template_name: str, language: str, request: Request) -> st
     qp = getattr(request, "query_params", None)
     if qp is not None:
         raw_lang = (qp.get("lang") or "").strip().lower()
-    payload = f"{template_name}|{language}|{raw_lang}|{int(bool(FRONTEND_DEBUG))}"
+    url = getattr(request, "url", None)
+    public_base = PUBLIC_SITE_URL or ""
+    request_scheme = getattr(url, "scheme", "")
+    request_host = getattr(url, "netloc", "")
+    payload = (
+        f"{template_name}|{language}|{raw_lang}|{int(bool(FRONTEND_DEBUG))}|"
+        f"{public_base}|{request_scheme}|{request_host}"
+    )
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
     return f"{RENDER_CACHE_KEY_PREFIX}:{digest}"
 

--- a/web.py
+++ b/web.py
@@ -63,7 +63,9 @@ class TemplateRequestProxy:
     def __init__(self, request: Request) -> None:
         self._request = request
 
-    def _absolute_public_url(self, *, path: str | None = None, query: str | None = None) -> str:
+    def _absolute_public_url(
+        self, *, path: str | None = None, query: str | None = None
+    ) -> str:
         url = self._request.url
         resolved_path = path if path is not None else url.path
         resolved_query = url.query if query is None else query


### PR DESCRIPTION
## 概要

Google AdSense 申請時のポリシー違反候補を減らすため、広告/計測タグの読み込み制御と canonical URL 生成を修正しました。

## 変更内容

- Note レイアウトに残っていた AdSense / Google Analytics の直読みを削除
- Google タグを Cookie 同意スクリプト経由の読み込みに統一
- AdSense client ID を記事・概要・使い方などのコンテンツページだけに出すよう制御
- `/note`、`/create_note_room`、`/search_note` などの機能画面では AdSense ID を出さないように変更
- `PUBLIC_SITE_URL` を追加し、canonical / hreflang / JSON-LD の URL を公開 HTTPS オリジンで生成
- レンダーキャッシュキーに公開 URL 条件を含め、古い `127.0.0.1` や `http://` の canonical が混入しないように変更

## 原因

`Note/templates/note_layout.html` だけが古い実装のまま AdSense と Analytics を同意前に直読みしていました。そのため、ユーザー生成コンテンツや共同編集が主目的の Note 画面、検索・作成フォーム中心の画面にも広告コードが出る状態でした。

また、静的ページのレンダーキャッシュが host / scheme を含まないキーで再利用されていたため、公開ページの canonical に `http://127.0.0.1:5000/` や `http://fs-qr.net/...` が混入する可能性がありました。

## 確認

- `pytest tests/test_basic_routes.py tests/test_seo.py`
- `pytest`

全体テストは `506 passed` です。