### PR TITLE
[codex] Xカードの画像URLを修正

### DIFF
--- a/Articles/templates/_article_base.html
+++ b/Articles/templates/_article_base.html
@@ -34,12 +34,12 @@
 
 {% block og_title %}{{ article_title }} | FS!QR解説記事{% endblock %}
 {% block og_description %}{{ article_description }}{% endblock %}
-{% block og_image %}{{ staticfile(_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_title }}{% endblock %}
 
 {% block twitter_title %}{{ article_title }} | FS!QR解説記事{% endblock %}
 {% block twitter_description %}{{ article_description }}{% endblock %}
-{% block twitter_image %}{{ staticfile(_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_title }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -59,7 +59,7 @@
   "description": {{ article_description | tojson }},
   "datePublished": "{{ _published_iso }}",
   "dateModified": "{{ _modified_iso }}",
-  "image": "{{ request.url_root }}static/{{ _thumbnail }}",
+  "image": "{{ social_staticfile(_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/business.html
+++ b/Articles/templates/business.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}業務での活用例 | FS!QRビジネス利用ガイド{% endblock %}
 {% block og_description %}FS!QRの業務活用例を詳しく紹介。社内研修・トレーニング、プロジェクト管理、リモートワークでのファイル共有など、ビジネスシーンでの効果的な活用方法とメリットを解説します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}業務での活用例 | FS!QRビジネス利用ガイド{% endblock %}
 {% block twitter_description %}FS!QRの業務活用例を詳しく紹介。社内研修・トレーニング、プロジェクト管理、リモートワークでのファイル共有など、ビジネスシーンでの効果的な活用方法とメリットを解説します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "FS!QRの業務活用例を詳しく紹介。社内研修・トレーニング、プロジェクト管理、リモートワークでのファイル共有など、ビジネスシーンでの効果的な活用方法とメリットを解説します。",
   "datePublished": "2025-08-21T00:00:00+09:00",
   "dateModified": "2025-08-21T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/education.html
+++ b/Articles/templates/education.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}教育での活用例 | FS!QR教育現場利用ガイド{% endblock %}
 {% block og_description %}FS!QRの教育現場での活用方法を詳しく解説。授業でのファイル配布、課題提出とフィードバック、グループ学習での協働など、学校・大学での効果的な利用例をご紹介します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}教育での活用例 | FS!QR教育現場利用ガイド{% endblock %}
 {% block twitter_description %}FS!QRの教育現場での活用方法を詳しく解説。授業でのファイル配布、課題提出とフィードバック、グループ学習での協働など、学校・大学での効果的な利用例をご紹介します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "FS!QRの教育現場での活用方法を詳しく解説。授業でのファイル配布、課題提出とフィードバック、グループ学習での協働など、学校・大学での効果的な利用例をご紹介します。",
   "datePublished": "2025-08-21T00:00:00+09:00",
   "dateModified": "2025-08-21T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/encryption.html
+++ b/Articles/templates/encryption.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}暗号化の基礎知識 | FS!QRデータ保護技術解説{% endblock %}
 {% block og_description %}暗号化技術の基礎からFS!QRでの活用まで詳しく解説。共通鍵暗号、公開鍵暗号の仕組み、鍵管理のベストプラクティス、HTTPS通信の重要性など、データ保護に必要な知識を分かりやすく説明します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}暗号化の基礎知識 | FS!QRデータ保護技術解説{% endblock %}
 {% block twitter_description %}暗号化技術の基礎からFS!QRでの活用まで詳しく解説。共通鍵暗号、公開鍵暗号の仕組み、鍵管理のベストプラクティス、HTTPS通信の重要性など、データ保護に必要な知識を分かりやすく説明します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "暗号化技術の基礎からFS!QRでの活用まで詳しく解説。共通鍵暗号、公開鍵暗号の仕組み、鍵管理のベストプラクティス、HTTPS通信の重要性など、データ保護に必要な知識を分かりやすく説明します。",
   "datePublished": "2025-08-21T00:00:00+09:00",
   "dateModified": "2025-08-21T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/fs-qr-concept.html
+++ b/Articles/templates/fs-qr-concept.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}FS!QRの基本的な考え方 | サービスコンセプトと設計思想{% endblock %}
 {% block og_description %}FS!QRの基本コンセプトと設計思想を詳しく解説。QRコードによる直感的な共有体験、一時的な共有に特化した設計、簡単で安全なファイル共有の新しい形について説明します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}FS!QRの基本的な考え方 | サービスコンセプトと設計思想{% endblock %}
 {% block twitter_description %}FS!QRの基本コンセプトと設計思想を詳しく解説。QRコードによる直感的な共有体験、一時的な共有に特化した設計、簡単で安全なファイル共有の新しい形について説明します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "FS!QRの基本コンセプトと設計思想を詳しく解説。QRコードによる直感的な共有体験、一時的な共有に特化した設計、簡単で安全なファイル共有の新しい形について説明します。",
   "datePublished": "2025-08-31T00:00:00+09:00",
   "dateModified": "2025-08-31T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/risk-mitigation.html
+++ b/Articles/templates/risk-mitigation.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}リスクと対策の考え方 | FS!QRファイル共有セキュリティ対策{% endblock %}
 {% block og_description %}オンラインファイル共有のリスクと対策を詳しく解説。情報漏えい、中間者攻撃、ソーシャルエンジニアリングなどの脅威と、FS!QRでの安全な対処法について説明します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}リスクと対策の考え方 | FS!QRファイル共有セキュリティ対策{% endblock %}
 {% block twitter_description %}オンラインファイル共有のリスクと対策を詳しく解説。情報漏えい、中間者攻撃、ソーシャルエンジニアリングなどの脅威と、FS!QRでの安全な対処法について説明します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "オンラインファイル共有のリスクと対策を詳しく解説。情報漏えい、中間者攻撃、ソーシャルエンジニアリングなどの脅威と、FS!QRでの安全な対処法について説明します。",
   "datePublished": "2025-08-21T00:00:00+09:00",
   "dateModified": "2025-08-21T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/Articles/templates/safe-sharing.html
+++ b/Articles/templates/safe-sharing.html
@@ -10,12 +10,12 @@
 
 {% block og_title %}安全な共有のポイント | FS!QRファイル共有セキュリティガイド{% endblock %}
 {% block og_description %}オンラインファイル共有の安全対策を詳しく解説。共有先の明確化、期間管理、受信環境の注意点、権限設定など、FS!QRを使った安全なデータ交換のベストプラクティスをご紹介します。{% endblock %}
-{% block og_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block og_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block og_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block twitter_title %}安全な共有のポイント | FS!QRファイル共有セキュリティガイド{% endblock %}
 {% block twitter_description %}オンラインファイル共有の安全対策を詳しく解説。共有先の明確化、期間管理、受信環境の注意点、権限設定など、FS!QRを使った安全なデータ交換のベストプラクティスをご紹介します。{% endblock %}
-{% block twitter_image %}{{ staticfile(article_thumbnail) }}{% endblock %}
+{% block twitter_image %}{{ social_staticfile(article_thumbnail) }}{% endblock %}
 {% block twitter_image_alt %}{{ article_thumbnail_alt }}{% endblock %}
 
 {% block og_type %}article{% endblock %}
@@ -35,7 +35,7 @@
   "description": "オンラインファイル共有の安全対策を詳しく解説。共有先の明確化、期間管理、受信環境の注意点、権限設定など、FS!QRを使った安全なデータ交換のベストプラクティスをご紹介します。",
   "datePublished": "2025-08-31T00:00:00+09:00",
   "dateModified": "2025-08-31T00:00:00+09:00",
-  "image": "{{ request.url_root }}static/{{ article_thumbnail }}",
+  "image": "{{ social_staticfile(article_thumbnail) }}",
   "author": { "@type": "Organization", "name": "FS!QR", "url": "{{ request.url_root }}" },
   "publisher": {
     "@type": "Organization",

--- a/FSQR/templates/fs-qr.html
+++ b/FSQR/templates/fs-qr.html
@@ -21,7 +21,7 @@
     <meta property="og:title" content="FS!QR | 無料QRコード暗号化ファイル共有サービス" />
     <meta property="og:description" content="ファイルを暗号化してQRコード化。最高レベルのセキュリティで安全・簡単なファイル共有を無料提供。" />
     <meta property="og:url" content="{{ request.canonical_url }}" />
-    <meta property="og:image" content="{{staticfile('logo.png')}}" />
+    <meta property="og:image" content="{{ social_staticfile('logo.png') }}" />
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="FS!QR QRコードファイル共有サービス">
@@ -30,7 +30,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FS!QR | 無料QRコード暗号化ファイル共有サービス" />
     <meta name="twitter:description" content="ファイルを暗号化してQRコード化。最高レベルのセキュリティで安全・簡単なファイル共有を無料提供。" />
-    <meta name="twitter:image" content="{{staticfile('logo.png')}}" />
+    <meta name="twitter:image" content="{{ social_staticfile('logo.png') }}" />
     <meta name="twitter:image:alt" content="FS!QR サービス">
     
     <!-- SEO -->

--- a/Group/templates/group.html
+++ b/Group/templates/group.html
@@ -21,7 +21,7 @@
     <meta property="og:title" content="FS!QR Group | 無料グループファイル共有・チーム協業サービス" />
     <meta property="og:description" content="安全なルーム作成で複数人でのファイル共有・管理。企業チーム、プロジェクト管理に最適な無料グループウェア。" />
     <meta property="og:url" content="{{ request.base_url }}" />
-    <meta property="og:image" content="{{staticfile('group_logo.png')}}" />
+    <meta property="og:image" content="{{ social_staticfile('group_logo.png') }}" />
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="FS!QR Group グループファイル共有サービス">
@@ -30,7 +30,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FS!QR Group | 無料グループファイル共有・チーム協業サービス" />
     <meta name="twitter:description" content="安全なルーム作成で複数人でのファイル共有・管理。企業チーム、プロジェクト管理に最適。" />
-    <meta name="twitter:image" content="{{staticfile('group_logo.png')}}" />
+    <meta name="twitter:image" content="{{ social_staticfile('group_logo.png') }}" />
     <meta name="twitter:image:alt" content="FS!QR Group サービス">
     
     <!-- SEO -->

--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -40,7 +40,7 @@
   <meta property="og:title" content="{% block og_title %}FS!QR Note | 無料リアルタイム同時編集ノートサービス{% endblock %}" />
   <meta property="og:description" content="{% block og_description %}複数人でリアルタイム同時編集できるオンラインノート。会議メモ、プロジェクト管理、学習支援に最適な無料コラボレーションツール。{% endblock %}" />
   <meta property="og:url" content="{{ request.canonical_url }}" />
-  <meta property="og:image" content="{{staticfile('note_logo.png')}}" />
+  <meta property="og:image" content="{{ social_staticfile('note_logo.png') }}" />
   <meta property="og:image:type" content="image/png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -50,7 +50,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{% block twitter_title %}FS!QR Note | 無料リアルタイム同時編集ノートサービス{% endblock %}" />
   <meta name="twitter:description" content="{% block twitter_description %}複数人でリアルタイム同時編集できるオンラインノート。会議メモ、プロジェクト管理、学習支援に最適。{% endblock %}" />
-  <meta name="twitter:image" content="{{staticfile('note_logo.png')}}" />
+  <meta name="twitter:image" content="{{ social_staticfile('note_logo.png') }}" />
   <meta name="twitter:image:alt" content="FS!QR Note サービス" />
   
   <!-- SEO -->

--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -21,7 +21,7 @@
     <meta property="og:title" content="FS!QR Note | 無料リアルタイム同時編集ノートサービス" />
     <meta property="og:description" content="複数人でリアルタイム同時編集できるオンラインノート。会議メモ、プロジェクト管理、学習支援に最適な無料コラボレーションツール。" />
     <meta property="og:url" content="{{ request.canonical_url }}" />
-    <meta property="og:image" content="{{staticfile('note_logo.png')}}" />
+    <meta property="og:image" content="{{ social_staticfile('note_logo.png') }}" />
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="FS!QR Note リアルタイムノート共有サービス">
@@ -30,7 +30,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FS!QR Note | 無料リアルタイム同時編集ノートサービス" />
     <meta name="twitter:description" content="複数人でリアルタイム同時編集できるオンラインノート。会議メモ、プロジェクト管理、学習支援に最適。" />
-    <meta name="twitter:image" content="{{staticfile('note_logo.png')}}" />
+    <meta name="twitter:image" content="{{ social_staticfile('note_logo.png') }}" />
     <meta name="twitter:image:alt" content="FS!QR Note サービス">
     
     <!-- SEO -->

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -41,7 +41,7 @@
     <meta property="og:title" content="{% block og_title %}FS!QR Group | 無料グループファイル共有・チーム協業サービス{% endblock %}" />
     <meta property="og:description" content="{% block og_description %}安全なルーム作成で複数人でのファイル共有・管理。企業チーム、プロジェクト管理に最適な無料グループウェア。{% endblock %}" />
     <meta property="og:url" content="{{ request.canonical_url }}" />
-    <meta property="og:image" content="{{staticfile('group_logo.png')}}" />
+    <meta property="og:image" content="{{ social_staticfile('group_logo.png') }}" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -51,7 +51,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{% block twitter_title %}FS!QR Group | 無料グループファイル共有・チーム協業サービス{% endblock %}" />
     <meta name="twitter:description" content="{% block twitter_description %}安全なルーム作成で複数人でのファイル共有・管理。企業チーム、プロジェクト管理に最適。{% endblock %}" />
-    <meta name="twitter:image" content="{{staticfile('group_logo.png')}}" />
+    <meta name="twitter:image" content="{{ social_staticfile('group_logo.png') }}" />
     <meta name="twitter:image:alt" content="FS!QR Group サービス" />
     
     <!-- SEO -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
   <meta property="og:title" content="FS!QR | 無料で簡単なQRコードファイル共有サービス">
   <meta property="og:description" content="QRコード、グループ、ノートで簡単にファイルを共有。無料で使える日本語対応のクラウドサービス。個人から企業まで安全にデータ管理できます。">
   <meta property="og:url" content="{{ request.canonical_url }}">
-  <meta property="og:image" content="{{staticfile('fs-qr-og-compressed.jpg')}}">
+  <meta property="og:image" content="{{ social_staticfile('fs-qr-og-compressed.jpg') }}">
   <meta property="og:image:type" content="image/jpeg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -29,7 +29,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="FS!QR | 無料で簡単なQRコードファイル共有サービス">
   <meta name="twitter:description" content="QRコード、グループ、ノートで簡単にファイルを共有。無料で使える日本語対応のクラウドサービス。個人から企業まで安全にデータ管理できます。">
-  <meta name="twitter:image" content="{{staticfile('fs-qr-og-compressed.jpg')}}">
+  <meta name="twitter:image" content="{{ social_staticfile('fs-qr-og-compressed.jpg') }}">
   <meta name="twitter:image:alt" content="FS!QR ファイル共有サービス">
   
   <!-- SEO -->

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -40,7 +40,7 @@
     <meta property="og:title" content="{% block og_title %}FS!QR | 無料で簡単なファイル共有サービス{% endblock %}" />
     <meta property="og:description" content="{% block og_description %}QRコード、グループ、ノートで簡単にファイルを共有。無料で使える日本語対応のクラウドサービスです。{% endblock %}" />
     <meta property="og:url" content="{{ request.canonical_url }}" />
-    <meta property="og:image" content="{% block og_image %}{{staticfile('fs-qr-og-compressed.jpg')}}{% endblock %}" />
+    <meta property="og:image" content="{% block og_image %}{{ social_staticfile('fs-qr-og-compressed.jpg') }}{% endblock %}" />
     <meta property="og:image:type" content="{% block og_image_type %}image/jpeg{% endblock %}" />
     <meta property="og:image:width" content="{% block og_image_width %}1200{% endblock %}" />
     <meta property="og:image:height" content="{% block og_image_height %}630{% endblock %}" />
@@ -51,7 +51,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{% block twitter_title %}FS!QR | 無料で簡単なファイル共有サービス{% endblock %}" />
     <meta name="twitter:description" content="{% block twitter_description %}QRコード、グループ、ノートで簡単にファイルを共有。無料で使える日本語対応のクラウドサービス。{% endblock %}" />
-    <meta name="twitter:image" content="{% block twitter_image %}{{staticfile('fs-qr-og-compressed.jpg')}}{% endblock %}" />
+    <meta name="twitter:image" content="{% block twitter_image %}{{ social_staticfile('fs-qr-og-compressed.jpg') }}{% endblock %}" />
     <meta name="twitter:image:alt" content="{% block twitter_image_alt %}FS!QR ファイル共有サービス{% endblock %}" />
     
     <!-- SEO -->

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -86,7 +86,7 @@ def test_registered_article_route(test_client: TestClient, article):
     assert response.status_code == 200
     assert f"/static/{article['thumbnail']}?v=" in response.text
     assert (
-        f'<meta property="og:image" content="/static/{article["thumbnail"]}?v='
+        f'<meta property="og:image" content="https://fs-qr.net/static/{article["thumbnail"]}"'
         in response.text
     )
 

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -213,3 +213,21 @@ def test_canonical_url_uses_public_https_origin(test_client: TestClient):
     assert response.status_code == 200
     assert '<link rel="canonical" href="https://fs-qr.net/note"' in response.text
     assert "http://fs-qr.net/note" not in response.text
+
+
+def test_social_card_images_use_public_https_urls(test_client: TestClient):
+    routes = {
+        "/": "fs-qr-og-compressed.jpg",
+        "/fs-qr_menu": "logo.png",
+        "/group_menu": "group_logo.png",
+        "/note_menu": "note_logo.png",
+        "/safe-sharing": "articles/thumbnails/safe-sharing.jpg",
+    }
+
+    for route, image_path in routes.items():
+        response = test_client.get(route)
+        assert response.status_code == 200, route
+        expected = f"https://fs-qr.net/static/{image_path}"
+        assert f'<meta property="og:image" content="{expected}"' in response.text
+        assert f'<meta name="twitter:image" content="{expected}"' in response.text
+        assert f'content="/static/{image_path}' not in response.text

--- a/web.py
+++ b/web.py
@@ -130,12 +130,39 @@ class TemplateRequestProxy:
         return getattr(self._request, name)
 
 
-def staticfile(fname: str) -> str:
+def _staticfile_ref(fname: str, *, version: bool) -> tuple[str, str]:
     path = os.path.join(BASE_DIR, "static", fname)
-    if os.path.exists(path):
+    if version and os.path.exists(path):
         mtime = str(int(os.stat(path).st_mtime))
-        return "/static/" + fname + "?v=" + str(mtime)
-    return "/static/" + fname
+        return "/static/" + fname, "v=" + str(mtime)
+    return "/static/" + fname, ""
+
+
+def staticfile(fname: str) -> str:
+    path, query = _staticfile_ref(fname, version=True)
+    if query:
+        return path + "?" + query
+    return path
+
+
+@pass_context
+def social_staticfile(context: Dict[str, Any], fname: str) -> str:
+    """Return an absolute static URL for Open Graph and Twitter Card crawlers."""
+    path, query = _staticfile_ref(fname, version=False)
+    request = context.get("request")
+    if isinstance(request, TemplateRequestProxy):
+        return request._absolute_public_url(path=path, query=query)
+
+    public_base = urlsplit(PUBLIC_SITE_URL)
+    return urlunsplit(
+        (
+            public_base.scheme or "https",
+            public_base.netloc,
+            path,
+            query,
+            "",
+        )
+    )
 
 
 GOOGLE_ANALYTICS_ID = "G-D26D8ZXKNV"
@@ -342,7 +369,7 @@ def render_template(request: Request, template_name: str, **context: Any):
         raise e
 
 
-RENDER_CACHE_KEY_PREFIX = "render_cache:v2"
+RENDER_CACHE_KEY_PREFIX = "render_cache:v3"
 RENDER_CACHE_CSRF_PLACEHOLDER = "__FSQR_CSRF_TOKEN_PLACEHOLDER__"
 
 
@@ -440,6 +467,7 @@ templates.env.filters.setdefault("urlencode", _filter_urlencode)
 
 templates.env.globals.update(
     staticfile=staticfile,
+    social_staticfile=social_staticfile,
     url_for=url_for,
     get_flashed_messages=get_flashed_messages,
     csrf_token=csrf_token,


### PR DESCRIPTION
## 概要
- OGP / Twitter Card の画像URLを相対パスから公開HTTPS URLへ変更しました。
- ホーム、FS!QR、Group、Note、解説記事のSNSサムネイル指定を共通ヘルパーに統一しました。
- レンダーキャッシュキーを更新し、デプロイ直後から新しいメタタグが返るようにしました。

## 修正理由
X のカードクローラーに `/static/...` の相対URLが渡ると、サムネイル画像を取得できず表示されない可能性があります。SNS向けメタタグでは `https://fs-qr.net/static/...` の絶対URLを返すようにして、画像を正しく取得できるようにしました。

## 影響
- 通常ページ内の画像・CSS参照は従来どおり `staticfile()` の相対URLとバージョン付きクエリを使います。
- SNSカード向けの `og:image` / `twitter:image` と記事JSON-LDの `image` だけが公開HTTPS URLになります。

## 確認
- `python3 -m pytest tests/test_seo.py tests/test_articles.py`
- 結果: 120 passed