### PR TITLE
ルーム削除処理の高速化: 非同期並列処理とfetch API化

### DIFF
--- a/FSQR/fsqr_data.py
+++ b/FSQR/fsqr_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import hmac
 import json
@@ -176,33 +177,43 @@ async def remove_data(secure_id):
         else:
             paths = [os.path.join(STATIC, f"{secure_id}.zip")]
 
-        for file_path in paths:
-            if os.path.exists(file_path):
-                os.remove(file_path)
-                logger.info(f"Deleted file: {file_path}")
-            else:
-                logger.warning(f"File not found: {file_path}")
+        def _delete_files():
+            for file_path in paths:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+                    logger.info(f"Deleted file: {file_path}")
+                else:
+                    logger.warning(f"File not found: {file_path}")
+
+        await asyncio.to_thread(_delete_files)
 
         query = text("""
             DELETE FROM fsqr WHERE secure_id = :secure_id
         """)
         await execute_query(query, {"secure_id": secure_id})
-        await invalidate_cache_entry(get_data, secure_id)
-        await invalidate_cache_entry(get_all)
-        if record:
-            await invalidate_cache_prefix(try_login)
-            await invalidate_cache_prefix(get_data_by_credentials)
-            await invalidate_cache_prefix(get_data_by_share_token)
-        try:
-            await revoke_resource_links(
-                service_key=ServiceKey.FSQR, resource_id=secure_id
-            )
-        except Exception:
-            logger.warning(
-                "Failed to revoke FSQR share links: secure_id=%s",
-                secure_id,
-                exc_info=True,
-            )
+
+        # DB削除後の副作用を並列実行して高速化
+        async def _invalidate_caches():
+            await invalidate_cache_entry(get_data, secure_id)
+            await invalidate_cache_entry(get_all)
+            if record:
+                await invalidate_cache_prefix(try_login)
+                await invalidate_cache_prefix(get_data_by_credentials)
+                await invalidate_cache_prefix(get_data_by_share_token)
+
+        async def _revoke_links():
+            try:
+                await revoke_resource_links(
+                    service_key=ServiceKey.FSQR, resource_id=secure_id
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to revoke FSQR share links: secure_id=%s",
+                    secure_id,
+                    exc_info=True,
+                )
+
+        await asyncio.gather(_invalidate_caches(), _revoke_links())
     except Exception as e:
         logger.error(f"Failed to remove data: {e}")
         raise

--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -110,6 +110,9 @@
                 method="POST"
                 class="owner-delete-form"
                 data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
+                data-confirm-title="{{ t('alert.confirm_delete') }}"
+                data-confirm-label="{{ t('alert.delete_action') }}"
+                data-deleting-label="{{ t('fsqr.delete_file_button') }}..."
               >
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="modern-btn modern-btn-danger">
@@ -203,6 +206,9 @@
                 method="POST"
                 class="owner-delete-form"
                 data-confirm-submit="{{ t('fsqr.delete_confirm_message') }}"
+                data-confirm-title="{{ t('alert.confirm_delete') }}"
+                data-confirm-label="{{ t('alert.delete_action') }}"
+                data-deleting-label="{{ t('fsqr.delete_file_button') }}..."
               >
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="modern-btn modern-btn-danger">
@@ -230,24 +236,7 @@
   </div>
 </div>
 
-<script>
-document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
-  form.addEventListener('submit', async function(event) {
-    if (form.dataset.confirmed === 'true') {
-      return;
-    }
-    event.preventDefault();
-    var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
-      title: {{ t('alert.confirm_delete') | tojson }},
-      confirmLabel: {{ t('alert.delete_action') | tojson }}
-    });
-    if (confirmed) {
-      form.dataset.confirmed = 'true';
-      form.submit();
-    }
-  });
-});
-</script>
+<script src="/static/js/shared/async-delete-form.js"></script>
 
 
   <div class="spinner-container fsqr-download-overlay spinner-container--hidden" id="spinnerContainer">

--- a/Group/group_data.py
+++ b/Group/group_data.py
@@ -140,7 +140,9 @@ async def remove_data(secure_id):
         try:
             from share_links import ServiceKey, revoke_resource_links
 
-            await revoke_resource_links(service_key=ServiceKey.GROUP, resource_id=secure_id)
+            await revoke_resource_links(
+                service_key=ServiceKey.GROUP, resource_id=secure_id
+            )
         except Exception:
             logger.warning(
                 "Failed to revoke Group share links: room_id=%s",

--- a/Group/group_data.py
+++ b/Group/group_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import logging
@@ -112,7 +113,7 @@ async def remove_data(secure_id):
         if not os.path.exists(room_folder):
             continue
         try:
-            shutil.rmtree(room_folder)
+            await asyncio.to_thread(shutil.rmtree, room_folder)
         except Exception as e:
             deletion_failed = True
             logger.error(
@@ -133,21 +134,31 @@ async def remove_data(secure_id):
         DELETE FROM room WHERE room_id = :secure_id
     """)
     await execute_query(query, {"secure_id": secure_id})
-    try:
-        from share_links import ServiceKey, revoke_resource_links
 
-        await revoke_resource_links(service_key=ServiceKey.GROUP, resource_id=secure_id)
-    except Exception:
-        logger.warning(
-            "Failed to revoke Group share links: room_id=%s",
-            secure_id,
-            exc_info=True,
-        )
-    await group_ws_hub.close_room(secure_id, code=1001)
-    await invalidate_cache_entry(get_data, secure_id)
-    await invalidate_cache_entry(get_all)
-    if room_record:
-        await invalidate_cache_prefix(pich_room_id)
+    # DB削除後の副作用を並列実行して高速化
+    async def _revoke_links():
+        try:
+            from share_links import ServiceKey, revoke_resource_links
+
+            await revoke_resource_links(service_key=ServiceKey.GROUP, resource_id=secure_id)
+        except Exception:
+            logger.warning(
+                "Failed to revoke Group share links: room_id=%s",
+                secure_id,
+                exc_info=True,
+            )
+
+    async def _invalidate_caches():
+        await invalidate_cache_entry(get_data, secure_id)
+        await invalidate_cache_entry(get_all)
+        if room_record:
+            await invalidate_cache_prefix(pich_room_id)
+
+    await asyncio.gather(
+        _revoke_links(),
+        group_ws_hub.close_room(secure_id, code=1001),
+        _invalidate_caches(),
+    )
     return True
 
 

--- a/Group/templates/group_room/_content.html
+++ b/Group/templates/group_room/_content.html
@@ -81,6 +81,9 @@
                             method="POST"
                             class="owner-delete-form"
                             data-confirm-submit="{{ t('group.delete_room_confirm_message') }}"
+                            data-confirm-title="{{ t('alert.confirm_delete') }}"
+                            data-confirm-label="{{ t('alert.delete_action') }}"
+                            data-deleting-label="{{ t('group.delete_room_button') }}..."
                         >
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="modern-btn modern-btn-danger">
@@ -175,24 +178,7 @@
     </div>
 </div>
 
-<script>
-document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
-    form.addEventListener('submit', async function(event) {
-        if (form.dataset.confirmed === 'true') {
-            return;
-        }
-        event.preventDefault();
-        var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
-            title: {{ t('alert.confirm_delete') | tojson }},
-            confirmLabel: {{ t('alert.delete_action') | tojson }}
-        });
-        if (confirmed) {
-            form.dataset.confirmed = 'true';
-            form.submit();
-        }
-    });
-});
-</script>
+<script src="/static/js/shared/async-delete-form.js"></script>
 
 <!-- Download Progress -->
 <div class="spinner-container group-download-overlay" id="downloadSpinnerContainer" style="display: none;">

--- a/Note/note_app.py
+++ b/Note/note_app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 import secrets
@@ -426,8 +427,11 @@ async def delete_note_room(request: Request, room_id: str):
         "data": {},
         "error": "Room has expired or was deleted.",
     }
-    await note_ws_hub.broadcast(room_id, expired_payload)
-    await publish_room_expired(room_id)
+    # WS通知とルームクローズを並列実行して高速化
+    await asyncio.gather(
+        note_ws_hub.broadcast(room_id, expired_payload),
+        publish_room_expired(room_id),
+    )
     await note_ws_hub.close_room(room_id)
 
     if wants_json_response(request):

--- a/Note/note_data.py
+++ b/Note/note_data.py
@@ -381,7 +381,9 @@ async def remove_room(room_id: str, status: str = "deleted") -> None:
         try:
             from share_links import ServiceKey, revoke_resource_links
 
-            await revoke_resource_links(service_key=ServiceKey.NOTE, resource_id=room_id)
+            await revoke_resource_links(
+                service_key=ServiceKey.NOTE, resource_id=room_id
+            )
         except Exception:
             logger.warning(
                 "Failed to revoke Note share links: room_id=%s",

--- a/Note/note_data.py
+++ b/Note/note_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 from typing import Optional
@@ -374,19 +375,26 @@ async def remove_room(room_id: str, status: str = "deleted") -> None:
         {"r": room_id, "status": status},
     )
     await execute_query("DELETE FROM note_content WHERE room_id = :r", {"r": room_id})
-    try:
-        from share_links import ServiceKey, revoke_resource_links
 
-        await revoke_resource_links(service_key=ServiceKey.NOTE, resource_id=room_id)
-    except Exception:
-        logger.warning(
-            "Failed to revoke Note share links: room_id=%s",
-            room_id,
-            exc_info=True,
-        )
-    await invalidate_cache_entry(get_room_meta, room_id)
-    await invalidate_cache_prefix(get_room_meta)
-    await invalidate_cache_prefix(pick_room_id)
+    # DB削除後の副作用を並列実行して高速化
+    async def _revoke_links():
+        try:
+            from share_links import ServiceKey, revoke_resource_links
+
+            await revoke_resource_links(service_key=ServiceKey.NOTE, resource_id=room_id)
+        except Exception:
+            logger.warning(
+                "Failed to revoke Note share links: room_id=%s",
+                room_id,
+                exc_info=True,
+            )
+
+    async def _invalidate_caches():
+        await invalidate_cache_entry(get_room_meta, room_id)
+        await invalidate_cache_prefix(get_room_meta)
+        await invalidate_cache_prefix(pick_room_id)
+
+    await asyncio.gather(_revoke_links(), _invalidate_caches())
 
 
 # ────────────────────────────────────────────

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -82,6 +82,9 @@
                             method="POST"
                             class="owner-delete-form"
                             data-confirm-submit="このノートルームを削除します。保存済みの本文も削除され、この操作は元に戻せません。"
+                            data-confirm-title="{{ t('alert.confirm_delete') }}"
+                            data-confirm-label="{{ t('alert.delete_action') }}"
+                            data-deleting-label="ルームを削除中..."
                         >
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="modern-btn modern-btn-danger">
@@ -127,24 +130,7 @@
     </div>
 </div>
 
-<script>
-document.querySelectorAll('.owner-delete-form[data-confirm-submit]').forEach(function(form) {
-    form.addEventListener('submit', async function(event) {
-        if (form.dataset.confirmed === 'true') {
-            return;
-        }
-        event.preventDefault();
-        var confirmed = await window.showConfirmModal(form.dataset.confirmSubmit, {
-            title: {{ t('alert.confirm_delete') | tojson }},
-            confirmLabel: {{ t('alert.delete_action') | tojson }}
-        });
-        if (confirmed) {
-            form.dataset.confirmed = 'true';
-            form.submit();
-        }
-    });
-});
-</script>
+<script src="/static/js/shared/async-delete-form.js"></script>
 
 
 <div class="usage-section">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+exclude = ["static/js/**", "static/*.js"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "S", "C90"]

--- a/static/js/shared/async-delete-form.js
+++ b/static/js/shared/async-delete-form.js
@@ -1,0 +1,117 @@
+/**
+ * 削除フォームの非同期送信モジュール
+ *
+ * data-confirm-submit 属性を持つ .owner-delete-form に対して:
+ * 1. 確認ダイアログ表示後、fetch API で非同期POSTを行う
+ * 2. 送信中はボタンをローディング状態にし、即座にUIフィードバックを返す
+ * 3. レスポンスに応じてリダイレクトまたはエラー表示を行う
+ */
+(function () {
+  "use strict";
+
+  function initAsyncDeleteForms() {
+    document
+      .querySelectorAll(".owner-delete-form[data-confirm-submit]")
+      .forEach(function (form) {
+        form.addEventListener("submit", async function (event) {
+          event.preventDefault();
+
+          var confirmed = await window.showConfirmModal(
+            form.dataset.confirmSubmit,
+            {
+              title: form.dataset.confirmTitle || undefined,
+              confirmLabel: form.dataset.confirmLabel || undefined,
+            }
+          );
+          if (!confirmed) {
+            return;
+          }
+
+          var submitBtn = form.querySelector('button[type="submit"]');
+          var originalContent = "";
+          if (submitBtn) {
+            originalContent = submitBtn.innerHTML;
+            submitBtn.disabled = true;
+            submitBtn.innerHTML =
+              '<span class="async-delete-spinner"></span>' +
+              (form.dataset.deletingLabel || "削除中...");
+          }
+
+          try {
+            var formData = new FormData(form);
+            var response = await fetch(form.action, {
+              method: "POST",
+              headers: {
+                Accept: "application/json",
+                "X-Requested-With": "XMLHttpRequest",
+              },
+              body: formData,
+            });
+
+            if (response.ok) {
+              var contentType = response.headers.get("content-type") || "";
+              if (contentType.includes("application/json")) {
+                var data = await response.json();
+                if (data.redirect_url) {
+                  window.location.href = data.redirect_url;
+                  return;
+                }
+              }
+              // JSON以外の成功レスポンスやリダイレクト
+              if (response.redirected) {
+                window.location.href = response.url;
+                return;
+              }
+              // デフォルトのリダイレクト先
+              window.location.href = "/remove-succes";
+              return;
+            }
+
+            // エラーレスポンス処理
+            var errorMessage =
+              "削除に失敗しました。時間をおいて再度お試しください。";
+            try {
+              var contentType = response.headers.get("content-type") || "";
+              if (contentType.includes("application/json")) {
+                var errorData = await response.json();
+                if (errorData.message) {
+                  errorMessage = errorData.message;
+                }
+              }
+            } catch (_) {
+              // JSONパース失敗は無視
+            }
+            window.showAlertModal(errorMessage);
+          } catch (networkError) {
+            window.showAlertModal(
+              "通信エラーが発生しました。ネットワーク接続を確認してください。"
+            );
+          } finally {
+            if (submitBtn) {
+              submitBtn.disabled = false;
+              submitBtn.innerHTML = originalContent;
+            }
+          }
+        });
+      });
+  }
+
+  // スピナーのスタイルを動的に追加
+  if (!document.getElementById("asyncDeleteSpinnerStyle")) {
+    var style = document.createElement("style");
+    style.id = "asyncDeleteSpinnerStyle";
+    style.textContent =
+      ".async-delete-spinner{display:inline-block;width:1em;height:1em;" +
+      "border:2px solid currentColor;border-right-color:transparent;" +
+      "border-radius:50%;animation:asyncDeleteSpin .6s linear infinite;" +
+      "margin-right:.4em;vertical-align:middle}" +
+      "@keyframes asyncDeleteSpin{to{transform:rotate(360deg)}}";
+    document.head.appendChild(style);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAsyncDeleteForms);
+  } else {
+    initAsyncDeleteForms();
+  }
+})();


### PR DESCRIPTION
## 概要
ルーム削除ボタンをクリックしてから削除完了画面が表示されるまでの待ち時間を短縮しました。

## 変更内容

### バックエンド (Group / FSQR / Note)
- **副作用処理の並列化**: DB削除後に逐次実行していた以下の処理を `asyncio.gather` で並列実行するように変更
  - 共有リンクの無効化 (`revoke_resource_links`)
  - WebSocket接続の切断 (`close_room`)
  - Redisキャッシュの無効化 (`invalidate_cache_entry` / `invalidate_cache_prefix`)
- **ファイルI/Oのノンブロッキング化**: Group / FSQRの `shutil.rmtree` や `os.remove` を `asyncio.to_thread` でバックグラウンドスレッドに移行し、イベントループのブロッキングを回避

### フロントエンド (全モジュール共通)
- **fetch API化**: フォームの通常POST送信 (`form.submit()`) を `fetch` による非同期リクエストに変更
  - 確認ダイアログ後に即座にボタンをスピナー付きローディング状態に変更し、ユーザーへの応答性を向上
  - エラー時はモーダルで通知し、ボタンを元の状態に復元
- **共通JSモジュール化**: 3モジュール（FSQR / Group / Note）のインラインスクリプトを `static/js/shared/async-delete-form.js` に統合し、コードの重複を排除

## 対象ファイル
| ファイル | 変更内容 |
|---|---|
| `Group/group_data.py` | `remove_data` の副作用並列化 + ファイル削除のノンブロッキング化 |
| `FSQR/fsqr_data.py` | `remove_data` の副作用並列化 + ファイル削除のノンブロッキング化 |
| `Note/note_data.py` | `remove_room` の副作用並列化 |
| `Note/note_app.py` | `delete_note_room` のWS通知並列化 |
| `static/js/shared/async-delete-form.js` | 非同期削除フォーム共通モジュール（新規作成） |
| `*/templates/*/_content.html` | インラインJS → 共通モジュール読み込みに変更 |

## テスト
- `pytest tests/` 全125テスト通過