### PR TITLE
perf: 単一ホスト構成のままスケーラビリティを改善（DB/配信/ワーカー）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,19 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
+
+# --- ファイル配信オフロード (nginx X-Accel-Redirect) ---
+# 本番（nginx 経由）では true 推奨。ダウンロードの実体転送を nginx に委譲する。
+# nginx を介さない開発・テストでは false のままにすること。
+# 有効化する場合は fs-qr.conf の internal location（/_protected/...）が必要。
+X_ACCEL_REDIRECT_ENABLED=false
+FSQR_X_ACCEL_LOCATION=/_protected/fsqr
+GROUP_X_ACCEL_LOCATION=/_protected/group
+
+# --- Gunicorn（gunicorn_conf.py が参照） ---
+# ワーカー数。未指定なら 4。CPU コア数の多いホストで引き上げる場合は、
+# db/my.cnf の max_connections と DB 接続プールの整合を確認すること。
+WEB_CONCURRENCY=4
+GUNICORN_MAX_REQUESTS=1000
+GUNICORN_MAX_REQUESTS_JITTER=100
+GUNICORN_TIMEOUT=360

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,10 @@ USER kota
 # Expose port 5000 for Gunicorn app
 EXPOSE 5000
 
-# Run Gunicorn app when the container launches
-CMD ["/usr/local/bin/wait-for-it", "db:3306", "--strict", "--timeout=120", "--", "gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:5000", "--workers", "4", "--timeout", "360", "--access-logfile", "/app/logs/access.log", "--error-logfile", "/app/logs/error.log", "app:app"]
+# Run Gunicorn app when the container launches.
+# Tunable settings live in gunicorn_conf.py (env-driven: WEB_CONCURRENCY,
+# GUNICORN_MAX_REQUESTS, GUNICORN_TIMEOUT, ...).
+CMD ["/usr/local/bin/wait-for-it", "db:3306", "--strict", "--timeout=120", "--", "gunicorn", "-c", "/app/gunicorn_conf.py", "app:app"]
 
 ########## デバッグ用の実行 ##############
 # FastAPI のローカル実行例

--- a/FSQR/fsqr_app.py
+++ b/FSQR/fsqr_app.py
@@ -8,9 +8,11 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from starlette.responses import FileResponse, RedirectResponse
+from starlette.concurrency import run_in_threadpool
+from starlette.responses import RedirectResponse
 
 from api_response import api_error_response, api_ok_response
+from file_serving import build_file_response
 from file_validation import (
     build_content_disposition_attachment,
     normalize_upload_filename,
@@ -188,6 +190,12 @@ def _strip_upload_suffix(filename: str, suffix: str) -> str:
     return filename
 
 
+def _write_upload_to_disk(src, temp_path: str) -> None:
+    """アップロードストリームをディスクへ書き出す（同期・スレッドプール実行用）。"""
+    with open(temp_path, "wb") as buffer:
+        shutil.copyfileobj(src, buffer)
+
+
 def _validate_fsqr_encrypted_payload(
     file_type: str, files: List[UploadFile]
 ) -> str | None:
@@ -318,8 +326,8 @@ async def upload(  # noqa: C901
         final_path = os.path.join(STATIC, secure_id + ".zip")
 
     temp_path = os.path.join(STATIC, f".{secure_id}.{secrets.token_hex(8)}.uploading")
-    with open(temp_path, "wb") as buffer:
-        shutil.copyfileobj(file.file, buffer)
+    # ブロッキングなディスク書き込みはスレッドプールへ逃がし、イベントループを止めない。
+    await run_in_threadpool(_write_upload_to_disk, file.file, temp_path)
 
     metadata_saved = False
     share_token = ""
@@ -591,7 +599,9 @@ async def _send_file_response(request: Request, secure_id: str):
     safe_original_filename = sanitize_download_filename(original_filename, default="")
     if safe_original_filename:
         headers["X-Original-Filename"] = safe_original_filename
-    return FileResponse(path, media_type=mimetype, headers=headers)
+    return build_file_response(
+        path, media_type=mimetype, headers=headers, accel_scope="fsqr"
+    )
 
 
 @router.get("/search_fs-qr", name="fsqr.search_fs_qr")

--- a/Group/group_routes_file.py
+++ b/Group/group_routes_file.py
@@ -9,10 +9,12 @@ from typing import Optional
 
 from fastapi import APIRouter, File, Request, UploadFile
 from starlette.background import BackgroundTask
+from starlette.concurrency import run_in_threadpool
 from starlette.responses import FileResponse
 from werkzeug.utils import secure_filename
 
 from api_response import api_error_response, api_ok_response
+from file_serving import build_file_response
 from file_validation import (
     build_content_disposition_attachment,
     build_content_disposition_inline,
@@ -234,7 +236,10 @@ def register_group_upload_route(router: APIRouter):
                 "サーバーエラーによりファイルを保存できませんでした。", status_code=500
             )
 
-        _save_uploaded_files(
+        # 内容検証＋ブロッキングなディスク書き込みをまとめてスレッドプールへ逃がし、
+        # 大きな（または多数の）ファイルでもイベントループを止めない。
+        await run_in_threadpool(
+            _save_uploaded_files,
             upfile,
             room_id=room_id,
             save_path=save_path,
@@ -401,10 +406,11 @@ def register_group_download_file_route(router: APIRouter):
                 ),
                 "Content-Length": str(os.path.getsize(file_path)),
             }
-            return FileResponse(
+            return build_file_response(
                 file_path,
                 media_type="application/octet-stream",
                 headers=headers,
+                accel_scope="group",
             )
         except Exception as e:
             return api_error_response(f"エラー: {str(e)}", status_code=500)
@@ -455,10 +461,11 @@ def register_group_preview_file_route(router: APIRouter):
                 "Content-Length": str(os.path.getsize(file_path)),
                 "X-Content-Type-Options": "nosniff",
             }
-            return FileResponse(
+            return build_file_response(
                 file_path,
                 media_type=str(preview_metadata["preview_mime_type"]),
                 headers=headers,
+                accel_scope="group",
             )
         except Exception as e:
             return api_error_response(f"エラー: {str(e)}", status_code=500)

--- a/db/my.cnf
+++ b/db/my.cnf
@@ -1,0 +1,37 @@
+# FS!QR MySQL チューニング設定
+# docker-compose で /etc/mysql/conf.d/zz-fsqr.cnf として読み込む（ファイル名の
+# zz- で最後に評価させ、イメージ既定値を確実に上書きする）。
+#
+# 値はホストのスペックに合わせて調整すること。コメントの目安を参照。
+[mysqld]
+
+# --- メモリ ----------------------------------------------------------------
+# InnoDB のデータ/インデックスを載せるキャッシュ。ここが小さいと毎回ディスクを
+# 読みに行き、読み取り負荷で頭打ちになる。ホスト RAM の 50〜60% が目安。
+# （イメージ既定は 128MB と小さいため、本設定の効果が最も大きい。）
+innodb_buffer_pool_size = 1G
+innodb_buffer_pool_instances = 1
+
+# --- 接続数 ----------------------------------------------------------------
+# 同時接続上限。アプリ側の最大接続数
+#   gunicorn workers × (SQLAlchemy pool_size + max_overflow)
+#   = 4 × (10 + 5) = 60
+# に加え、scheduler・管理接続・余裕分を見込んで設定する。
+# workers を増やす場合はこの値も併せて引き上げること。
+max_connections = 200
+# DNS 逆引きを行わず IP のまま認証する。接続確立が速くなる（権限は '%' 前提）。
+skip_name_resolve = ON
+
+# --- 耐久性 / スループット --------------------------------------------------
+# 1=各コミットで fsync（最も安全）, 2=各コミットで OS バッファへ書き出し、
+# fsync は約1秒ごと。共有ファイル/ノートサービスとしては 2 で十分安全かつ高速。
+innodb_flush_log_at_trx_commit = 2
+# ダブルバッファリングを避け、OS キャッシュと二重に持たない。
+innodb_flush_method = O_DIRECT
+# REDO ログ容量（MySQL 8.0.30+/8.4 では innodb_log_file_size の後継）。
+# 大きいほど書き込みのバーストを吸収できる。
+innodb_redo_log_capacity = 512M
+
+# --- 文字コード ------------------------------------------------------------
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     volumes:
       - db_data:/var/lib/mysql
       - ./db_init/create_tables.sql:/docker-entrypoint-initdb.d/00_create_tables.sql:ro
+      - ./db/my.cnf:/etc/mysql/conf.d/zz-fsqr.cnf:ro
     healthcheck:
       test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
       interval: 5s

--- a/file_serving.py
+++ b/file_serving.py
@@ -1,0 +1,89 @@
+"""ファイル配信ヘルパー。
+
+大きなアップロードファイルの実体転送を Python ワーカー（uvicorn のイベント
+ループ）に抱えさせると、転送が終わるまでそのワーカーが占有され、同時接続が増えた
+ときのボトルネックになる。本番では nginx の ``X-Accel-Redirect`` を使い、認証・
+認可だけをアプリが行い、実ファイルのバイト送出は nginx に委譲する。
+
+``X_ACCEL_REDIRECT_ENABLED`` が無効な環境（ローカル開発・テスト・nginx を介さない
+起動）では従来どおり :class:`starlette.responses.FileResponse` で配信するため、
+挙動は完全に後方互換となる。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import urllib.parse
+from typing import Mapping, Optional
+
+from starlette.background import BackgroundTask
+from starlette.responses import FileResponse, Response
+
+from settings import X_ACCEL_LOCATIONS, X_ACCEL_REDIRECT_ENABLED
+
+logger = logging.getLogger(__name__)
+
+
+def _build_accel_uri(internal_prefix: str, fs_root: str, path: str) -> Optional[str]:
+    """``path`` を nginx 内部ロケーション用の URI に変換する。
+
+    ``path`` が ``fs_root`` の外（例: レガシー保存場所）にある場合は ``None`` を返し、
+    呼び出し側で :class:`FileResponse` にフォールバックさせる。
+    """
+    try:
+        rel = os.path.relpath(os.path.abspath(path), os.path.abspath(fs_root))
+    except ValueError:
+        # Windows のドライブ違いなどで relpath が失敗するケース。
+        return None
+    # ``fs_root`` 配下でなければオフロード不可。パストラバーサルもここで弾く。
+    if rel == os.pardir or rel.startswith(os.pardir + os.sep) or os.path.isabs(rel):
+        return None
+    quoted = "/".join(urllib.parse.quote(seg) for seg in rel.split(os.sep))
+    return internal_prefix.rstrip("/") + "/" + quoted
+
+
+def build_file_response(
+    path: str,
+    *,
+    media_type: str,
+    headers: Optional[Mapping[str, str]] = None,
+    background: Optional[BackgroundTask] = None,
+    accel_scope: Optional[str] = None,
+) -> Response:
+    """ファイル配信レスポンスを生成する。
+
+    ``X_ACCEL_REDIRECT_ENABLED`` かつ ``accel_scope`` が設定済みで、対象ファイルが
+    そのスコープの保存ルート配下にある場合は ``X-Accel-Redirect`` で nginx に委譲する。
+    それ以外は :class:`FileResponse` を返す。
+    """
+    response_headers = dict(headers or {})
+
+    if X_ACCEL_REDIRECT_ENABLED and accel_scope:
+        location = X_ACCEL_LOCATIONS.get(accel_scope)
+        if location:
+            internal_prefix, fs_root = location
+            accel_uri = _build_accel_uri(internal_prefix, fs_root, path)
+            if accel_uri is not None:
+                # nginx が実体ファイルから Content-Length を再計算するため、
+                # アプリ側の値を残すと不整合になる。削除して nginx に任せる。
+                for key in list(response_headers):
+                    if key.lower() == "content-length":
+                        del response_headers[key]
+                response_headers["X-Accel-Redirect"] = accel_uri
+                # nginx 側のロケーションで Content-Type を確定させるが、保険として
+                # アプリの意図する型も渡しておく。
+                return Response(
+                    status_code=200,
+                    media_type=media_type,
+                    headers=response_headers,
+                    background=background,
+                )
+            logger.debug("X-Accel offload skipped (path outside scope root): %s", path)
+
+    return FileResponse(
+        path,
+        media_type=media_type,
+        headers=response_headers,
+        background=background,
+    )

--- a/fs-qr.conf
+++ b/fs-qr.conf
@@ -10,6 +10,31 @@ log_format fsqr_redacted '$remote_addr - $remote_user [$time_local] '
                          '"$request_method $fsqr_loggable_uri $server_protocol" '
                          '$status $body_bytes_sent "$http_referer" "$http_user_agent"';
 
+# アプリ（gunicorn）への upstream。keepalive で毎リクエストの TCP 確立コストを
+# 削減する。keepalive を効かせるには proxy 側で HTTP/1.1 かつ Connection 空が必須。
+upstream fsqr_app {
+    server 127.0.0.1:5000;
+    keepalive 32;
+}
+
+# テキスト系レスポンスを圧縮し、転送量と体感速度を改善する。
+# （画像・zip などバイナリは既に圧縮済みのため対象外。）
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 5;
+gzip_min_length 1024;
+gzip_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/javascript
+    application/json
+    application/xml
+    application/rss+xml
+    image/svg+xml;
+
 server {
     listen 443 ssl;
     server_name www.fs-qr.net;
@@ -28,7 +53,7 @@ server {
     # Certbotが最適なリダイレクトを自動設定します。
     # もしHTTPでもアクセスさせたい場合は、以下のlocationブロックを追加してください。
     location /ws/ {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://fsqr_app;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -38,6 +63,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 3600;
         proxy_send_timeout 3600;
+    }
+
+    # アプリが X-Accel-Redirect で指定する内部専用ロケーション。
+    # ダウンロード時の実ファイル転送を nginx に委譲し、Python ワーカーを占有させない。
+    # `internal` のため外部から直接アクセスはできず、認証はアプリ側で済んでいる。
+    # alias のパスは docker-compose の bind mount（./storage → /app/storage）が
+    # 指すホスト側の絶対パスに一致させること。
+    location /_protected/fsqr/ {
+        internal;
+        alias /home/kota/fs-qr/storage/fsqr_uploads/;
+    }
+
+    location /_protected/group/ {
+        internal;
+        alias /home/kota/fs-qr/storage/group_uploads/;
     }
 
     # /static/ 配下はテンプレート側で `?v=<mtime>` のキャッシュバスティングを行うため
@@ -50,18 +90,20 @@ server {
         return 404;
     }
 
+    # 静的アセットは nginx が直接配信し、アプリ（gunicorn）を経由させない。
+    # alias は bind mount（./static → /app/static）が指すホスト側パスに一致させること。
     location /static/ {
-        proxy_pass http://127.0.0.1:5000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        alias /home/kota/fs-qr/static/;
+        try_files $uri =404;
+        access_log off;
         add_header Cache-Control "public, max-age=31536000, immutable" always;
     }
 
     # 配信内容が定期的に変わるためブラウザ側で短時間キャッシュさせる。
     location = /sitemap.xml {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://fsqr_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -70,7 +112,9 @@ server {
     }
 
     location = /robots.txt {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://fsqr_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -79,7 +123,9 @@ server {
     }
 
     location = /ads.txt {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://fsqr_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -88,7 +134,9 @@ server {
     }
 
     location / {
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://fsqr_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -1,0 +1,42 @@
+"""Gunicorn 設定（本番）。
+
+環境変数で調整できるようにしつつ、従来の挙動（4 ワーカー / timeout 360）を
+デフォルト値として維持する。``uvicorn.workers.UvicornWorker`` は gunicorn の
+``max_requests`` / ``max_requests_jitter`` を uvicorn の ``limit_max_requests``
+として解釈するため、ワーカーの定期再起動によるメモリ肥大の抑制が有効に働く。
+"""
+
+import os
+
+
+def _int_env(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value >= minimum else default
+
+
+bind = "0.0.0.0:5000"
+worker_class = "uvicorn.workers.UvicornWorker"
+
+# 非同期ワーカーのため少数で多数の同時接続を捌ける。既定は従来同様 4。
+# CPU コア数の多いホストでは WEB_CONCURRENCY で引き上げる（DB の max_connections
+# とプール設定の整合を必ず確認すること）。
+workers = _int_env("WEB_CONCURRENCY", 4)
+
+# 一定リクエストごとにワーカーを入れ替え、長時間稼働によるメモリ肥大を防ぐ。
+# jitter で全ワーカーの同時再起動を避ける。0 で無効化。
+max_requests = _int_env("GUNICORN_MAX_REQUESTS", 1000, minimum=0)
+max_requests_jitter = _int_env("GUNICORN_MAX_REQUESTS_JITTER", 100, minimum=0)
+
+# 大きなアップロード/ダウンロードを考慮した従来同様のタイムアウト。
+timeout = _int_env("GUNICORN_TIMEOUT", 360)
+graceful_timeout = _int_env("GUNICORN_GRACEFUL_TIMEOUT", 30)
+keepalive = _int_env("GUNICORN_KEEPALIVE", 5)
+
+accesslog = os.getenv("GUNICORN_ACCESS_LOG", "/app/logs/access.log")
+errorlog = os.getenv("GUNICORN_ERROR_LOG", "/app/logs/error.log")

--- a/settings.py
+++ b/settings.py
@@ -71,6 +71,20 @@ GROUP_UPLOAD_DIR = os.getenv(
     os.path.join(BASE_DIR, "storage", "group_uploads"),
 )
 
+# --- ファイル配信オフロード (nginx X-Accel-Redirect) ---------------------------
+# 有効化すると、ダウンロード時の実ファイル転送を nginx へ委譲し、Python ワーカーは
+# 認証・認可だけを担う。nginx 側に対応する internal location が必要（fs-qr.conf 参照）。
+# nginx を介さない開発・テスト環境では無効のままにすること（FileResponse で配信）。
+X_ACCEL_REDIRECT_ENABLED = _env_flag("X_ACCEL_REDIRECT_ENABLED", default=False)
+# nginx の internal location プレフィックス（fs-qr.conf の location と一致させる）。
+FSQR_X_ACCEL_LOCATION = os.getenv("FSQR_X_ACCEL_LOCATION", "/_protected/fsqr")
+GROUP_X_ACCEL_LOCATION = os.getenv("GROUP_X_ACCEL_LOCATION", "/_protected/group")
+# accel_scope -> (internal_prefix, filesystem_root) の対応表。
+X_ACCEL_LOCATIONS: dict[str, tuple[str, str]] = {
+    "fsqr": (FSQR_X_ACCEL_LOCATION, FSQR_UPLOAD_DIR),
+    "group": (GROUP_X_ACCEL_LOCATION, GROUP_UPLOAD_DIR),
+}
+
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS = _env_int(
     "GROUP_FILE_LIST_REQUEST_TIMEOUT_MS", default=10_000, minimum=1
 )

--- a/tests/test_file_serving.py
+++ b/tests/test_file_serving.py
@@ -1,0 +1,110 @@
+"""file_serving.build_file_response / _build_accel_uri の単体テスト。
+
+X-Accel-Redirect オフロードと FileResponse フォールバックの両分岐を検証する。
+"""
+
+import importlib
+import os
+
+import pytest
+from starlette.responses import FileResponse, Response
+
+
+def _reload_with(monkeypatch, *, enabled, fsqr_root, group_root):
+    """settings を差し替えて file_serving を読み込み直す。"""
+    import settings
+
+    monkeypatch.setattr(settings, "X_ACCEL_REDIRECT_ENABLED", enabled, raising=False)
+    monkeypatch.setattr(
+        settings,
+        "X_ACCEL_LOCATIONS",
+        {
+            "fsqr": ("/_protected/fsqr", fsqr_root),
+            "group": ("/_protected/group", group_root),
+        },
+        raising=False,
+    )
+    import file_serving
+
+    return importlib.reload(file_serving)
+
+
+def test_accel_uri_encodes_and_keeps_subdirs(monkeypatch, tmp_path):
+    fs = _reload_with(
+        monkeypatch, enabled=True, fsqr_root=str(tmp_path), group_root=str(tmp_path)
+    )
+    uri = fs._build_accel_uri(
+        "/_protected/group", str(tmp_path), str(tmp_path / "room1" / "a b.png")
+    )
+    assert uri == "/_protected/group/room1/a%20b.png"
+
+
+def test_accel_uri_rejects_path_outside_root(monkeypatch, tmp_path):
+    fs = _reload_with(
+        monkeypatch, enabled=True, fsqr_root=str(tmp_path), group_root=str(tmp_path)
+    )
+    outside = os.path.join(str(tmp_path), "..", "secret.enc")
+    assert fs._build_accel_uri("/_protected/fsqr", str(tmp_path), outside) is None
+
+
+def test_build_file_response_uses_x_accel_when_enabled(monkeypatch, tmp_path):
+    fs = _reload_with(
+        monkeypatch, enabled=True, fsqr_root=str(tmp_path), group_root=str(tmp_path)
+    )
+    target = tmp_path / "file.enc"
+    target.write_bytes(b"data")
+    resp = fs.build_file_response(
+        str(target),
+        media_type="application/octet-stream",
+        headers={"Content-Length": "4", "X-File-Type": "single"},
+        accel_scope="fsqr",
+    )
+    assert isinstance(resp, Response) and not isinstance(resp, FileResponse)
+    assert resp.headers["X-Accel-Redirect"] == "/_protected/fsqr/file.enc"
+    # 本体は空（実体は nginx が配信）。アプリが渡した実ファイルサイズ "4" は載せず、
+    # nginx が内部リダイレクト先のファイルから Content-Length を再計算する。
+    assert resp.body == b""
+    assert resp.headers["content-length"] == "0"
+    # 認可由来のヘッダは保持される。
+    assert resp.headers["X-File-Type"] == "single"
+
+
+def test_build_file_response_falls_back_to_fileresponse_when_disabled(
+    monkeypatch, tmp_path
+):
+    fs = _reload_with(
+        monkeypatch, enabled=False, fsqr_root=str(tmp_path), group_root=str(tmp_path)
+    )
+    target = tmp_path / "file.zip"
+    target.write_bytes(b"zipdata")
+    resp = fs.build_file_response(
+        str(target), media_type="application/zip", accel_scope="fsqr"
+    )
+    assert isinstance(resp, FileResponse)
+    assert "X-Accel-Redirect" not in resp.headers
+
+
+def test_build_file_response_falls_back_when_path_outside_scope(monkeypatch, tmp_path):
+    inside = tmp_path / "uploads"
+    inside.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    fs = _reload_with(
+        monkeypatch, enabled=True, fsqr_root=str(inside), group_root=str(inside)
+    )
+    target = other / "legacy.bin"
+    target.write_bytes(b"x")
+    resp = fs.build_file_response(
+        str(target), media_type="application/octet-stream", accel_scope="fsqr"
+    )
+    # スコープ外（例: レガシー保存場所）は FileResponse にフォールバック。
+    assert isinstance(resp, FileResponse)
+
+
+@pytest.fixture(autouse=True)
+def _restore_file_serving():
+    """テスト後に本番設定で file_serving を読み戻し、他テストへの影響を防ぐ。"""
+    yield
+    import file_serving
+
+    importlib.reload(file_serving)


### PR DESCRIPTION
## 概要

外部サービスを一切追加せず、**現行の docker-compose 1台構成のまま**ユーザー数増に耐えられるよう改善します。方針は「**1台あたりの処理効率を上げる**」＋「**Pythonワーカーに無駄な仕事をさせない**」の2点です。

リアルタイム系（Note の Redis Pub/Sub、presence、レート制限）は既にマルチインスタンス前提で書かれている一方、MySQL も nginx もほぼデフォルト設定で伸びしろが大きく、ファイル転送が Python ワーカーを占有する構造がボトルネックでした。本PRはそこを潰します。

## 変更内容

### 1. MySQL チューニング（`db/my.cnf`・最も効果大）
イメージ既定の `innodb_buffer_pool_size` は **128MB** で、読み取りのたびにディスクへ行く状態でした。
- `innodb_buffer_pool_size = 1G`（ホスト RAM の 50〜60% が目安。要調整）
- `max_connections = 200`、`skip_name_resolve = ON`
- `innodb_flush_log_at_trx_commit = 2` / `innodb_flush_method = O_DIRECT` / `innodb_redo_log_capacity = 512M`
- `docker-compose.yml` で `/etc/mysql/conf.d/zz-fsqr.cnf` としてマウント（`zz-` で確実に上書き）

### 2. ダウンロードの nginx X-Accel-Redirect オフロード（`file_serving.py`）
最大500MBの実体転送を uvicorn ワーカー4本が抱えていたのを、**認可はアプリ／転送は nginx** に分離。
- `build_file_response()` を新設し、FSQR / Group の配信経路を集約
- `X_ACCEL_REDIRECT_ENABLED`（既定 **off**）で切替。off の場合は従来どおり `FileResponse`＝**完全後方互換**
- スコープ外（レガシー保存場所など）のパスは安全に `FileResponse` へフォールバック。`internal` ロケーションのため外部から直接叩けない
- ファイル名は URL エンコード、パストラバーサルは弾く

### 3. アップロード I/O のスレッドプール退避
`open()`＋`shutil.copyfileobj` を `async` ハンドラ内で同期実行しており、転送中イベントループが固まっていました。
- FSQR / Group いずれも `run_in_threadpool` で退避し、同時アップロード耐性を改善

### 4. nginx 最適化（`fs-qr.conf`）
- **gzip** 有効化（HTML/JS/CSS/JSON/SVG）
- **静的アセットを nginx 直配信**（従来は `proxy_pass` で Python 経由）
- **upstream keepalive**（毎リクエストの TCP 確立コスト削減）

### 5. Gunicorn 設定の外部化（`gunicorn_conf.py`）
- `WEB_CONCURRENCY` 等を env 駆動化（既定は従来同等の **4 worker / timeout 360**）
- `max_requests`（+jitter）でワーカーを定期再起動し、長時間稼働によるメモリ肥大を抑制
  - `UvicornWorker` は gunicorn の `max_requests` を uvicorn の `limit_max_requests` として解釈するため有効

## 意図的に見送った点：HTML の proxy_cache
当初案にあった nginx の HTML キャッシュは、本サービスが**言語 Cookie・GeoIP・セッション**で出し分けを行うため、不適切な `Vary` 設計だと**誤った言語のページ配信やセッション混線**を招きます。正しさを優先し、本PRでは見送りました（安全な gzip / 静的直配信 / keepalive のみ採用）。将来やるなら Cookie 非依存の匿名エンドポイントに限定し、慎重な `Vary` 設計が前提です。

## デプロイ時の注意
- `fs-qr.conf` の `alias`（`/home/kota/fs-qr/static`・`/home/kota/fs-qr/storage/...`）は **bind mount のホスト側絶対パス**に一致させること
- 本番では `.env` に `X_ACCEL_REDIRECT_ENABLED=true` を設定（nginx 経由が前提）
- `db/my.cnf` の値はホストスペックに合わせて調整
- nginx 設定変更後は `nginx -t && systemctl reload nginx`

## テスト
- `528 passed`（`file_serving` の単体テスト **5件**を新規追加。X-Accel 分岐・フォールバック・URLエンコード・パストラバーサル拒否を検証）
- `ruff check` / `ruff format` パス、`docker compose config` / `gunicorn --check-config` 検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)