### PR TITLE
Fix duplicate gzip directive in fs-qr.conf

### DIFF
--- a/fs-qr.conf
+++ b/fs-qr.conf
@@ -19,7 +19,7 @@ upstream fsqr_app {
 
 # テキスト系レスポンスを圧縮し、転送量と体感速度を改善する。
 # （画像・zip などバイナリは既に圧縮済みのため対象外。）
-gzip on;
+# gzip on;
 gzip_vary on;
 gzip_proxied any;
 gzip_comp_level 5;


### PR DESCRIPTION
Nginx設定ファイル(fs-qr.conf)内のgzipディレクティブが、大元のnginx.confと重複してエラーになっていた問題を修正しました。