### PR TITLE
【再提出】Nginxの静的ファイル配信設定の修正 (404エラー対応)

### DIFF
--- a/fs-qr.conf
+++ b/fs-qr.conf
@@ -93,7 +93,7 @@ server {
     # 静的アセットは nginx が直接配信し、アプリ（gunicorn）を経由させない。
     # alias は bind mount（./static → /app/static）が指すホスト側パスに一致させること。
     location /static/ {
-        alias /home/kota/fs-qr/static/;
+        root /home/kota/fs-qr;
         try_files $uri =404;
         access_log off;
         add_header Cache-Control "public, max-age=31536000, immutable" always;


### PR DESCRIPTION
## 概要
先ほど変更が戻ってしまったとのことで、再度Nginxでの静的ファイル（`core.js`, `main.js`, `manifest.json` など）へのアクセス時に 404 Not Found エラーが発生する問題を修正するPRを作成しました。

## 変更内容
`fs-qr.conf` 内の `location /static/` ブロックにおいて、`alias` の代わりに `root` を使用するように変更しました。
これにより `try_files ` が正しくパスを解決できるようになります。

- 修正前: `alias /home/kota/fs-qr/static/;`
- 修正後: `root /home/kota/fs-qr;`

## 確認手順
1. 本設定反映後、Nginx を再起動（または `sudo nginx -s reload`）します。
2. ブラウザまたはコンソールから `/static/js/fs_qr_upload/core.js` や `/static/manifest.json` などのURLにアクセスし、200 OK で正しくファイルが読み込まれることを確認してください。