### PR TITLE
[codex] FSQRのモバイルファイル表示を調整

### DIFF
--- a/FSQR/templates/fs_qr_upload/_styles.html
+++ b/FSQR/templates/fs_qr_upload/_styles.html
@@ -144,6 +144,51 @@ footer {
   background: var(--theme-fsqr-file-item-hover-bg);
 }
 
+@media (max-width: 575.98px) {
+  #fileList .modern-file-item {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.75rem;
+  }
+
+  #fileList .modern-file-name {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    min-height: 2.5rem;
+  }
+
+  #fileList .modern-file-name-info {
+    min-width: 0;
+  }
+
+  #fileList .modern-file-name-text {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #fileList .modern-file-icon {
+    flex: 0 0 auto;
+  }
+
+  #fileList .modern-file-actions {
+    align-self: center;
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    gap: 0.25rem;
+  }
+
+  #fileList .modern-file-action-btn {
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0.5rem;
+  }
+}
+
 .modern-btn-success {
   background: var(--glossy-theme-gradient);
   box-shadow: 0 12px 24px var(--glossy-shadow);


### PR DESCRIPTION
## 概要

`/fs-qr` のアップロード画面で、スマホ表示時に選択済みファイル名とゴミ箱アイコンの高さがずれて見える問題を修正しました。

## 変更内容

- FSQR の選択済みファイルリストに、スマホ幅向けのレイアウト調整を追加
- ファイル名部分と削除ボタンを横並び中央揃えに統一
- 長いファイル名は `group` ページと同様に省略表示されるよう調整

## 原因

`group` ページにはスマホ表示用のファイルリスト調整がありましたが、`/fs-qr` 側には同等の上書きがなく、ファイル名領域とゴミ箱アイコンの高さが揃わない状態でした。

## 影響

スマホ表示で `/fs-qr` のアップロード待ちファイル一覧が `group` ページと近い見た目になり、ファイル名と削除アイコンの位置ずれが解消されます。

## 検証

- `pytest tests/test_basic_routes.py tests/test_fsqr.py -q`
  - `70 passed`
