### PR TITLE
記事ページを読みやすいeditorialデザインに改善

### DIFF
--- a/Articles/templates/_article_base.html
+++ b/Articles/templates/_article_base.html
@@ -88,7 +88,7 @@
 
 {% block contents %}
 <div class="container my-5">
-  <div class="info-box">
+  <div class="info-box article-reading">
     <div class="info-box-content">
       <nav class="article-breadcrumb" aria-label="パンくずリスト">
         <a href="/">ホーム</a>
@@ -108,6 +108,124 @@
   </div>
 </div>
 <style>
+  /* ===========================================================
+     記事「読み物」レイヤー (editorial)
+     .info-box はお問い合わせフォーム等と共有のため、ここでの調整は
+     すべて .article-reading スコープに限定し、他画面へは影響させない。
+     主目的: 本文を濃いインクにして可読性を上げ、読書幅・階層を整える。
+     =========================================================== */
+  .article-reading {
+    /* 本文インク: 灰(--text-medium #6b7280)をやめ、ティールに寄せた濃い黒 */
+    --reading-ink: #283142;
+    --reading-ink-strong: #1c2733;
+    --reading-measure: 720px;
+    max-width: calc(var(--reading-measure) + 6rem);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
+                0 16px 40px rgba(15, 23, 42, 0.06);
+    border-color: rgba(229, 231, 235, 0.85);
+    border-radius: 18px;
+  }
+  /* フォーム用の上部グラデーションバーは読み物では外す */
+  .article-reading::before { display: none; }
+
+  .article-reading .info-box-content {
+    max-width: var(--reading-measure);
+    margin-inline: auto;
+    padding: 3.25rem 3rem 3.5rem;
+    color: var(--reading-ink);
+    font-size: 1.0625rem;   /* 17px: 長文向けに底上げ */
+    line-height: 1.9;
+    letter-spacing: 0.012em;
+  }
+
+  /* --- 本文: 灰色をやめて濃いインクへ(薄さ解消の本丸) --- */
+  .article-reading .info-box-content p {
+    color: var(--reading-ink);
+    font-size: inherit;
+    margin-bottom: 1.5rem;
+  }
+  .article-reading .info-box-content ul,
+  .article-reading .info-box-content ol {
+    color: var(--reading-ink);
+    margin: 1.25rem 0 1.75rem 1.5rem;
+  }
+  .article-reading .info-box-content li {
+    margin-bottom: 0.6rem;
+    line-height: 1.85;
+  }
+  .article-reading .info-box-content li::marker { color: var(--primary-color); }
+  .article-reading .info-box-content strong,
+  .article-reading .info-box-content li strong {
+    color: var(--reading-ink-strong);
+    font-weight: 700;
+  }
+
+  /* --- 見出し: 全部ティールで叫ばせず、強弱を作る --- */
+  .article-reading .info-box-content h3 {
+    color: var(--reading-ink-strong);   /* h3 はインク + ティール罫 */
+    font-size: 1.45rem;
+    line-height: 1.5;
+    margin: 2.75rem 0 1rem;
+    padding-left: 0.9rem;
+    border-left: 4px solid var(--primary-color);
+  }
+  .article-reading .info-box-content h4 {
+    color: var(--primary-color);        /* h4 はティールでアクセント */
+    font-size: 1.15rem;
+    margin: 2rem 0 0.6rem;
+  }
+  .article-reading .info-box-content h4::before {
+    color: var(--primary-color);        /* ▶ を本体配色のティールに統一 */
+  }
+
+  /* --- 用語解説(dl): 区切り線つきで読みやすく --- */
+  .article-reading .info-box-content dl { margin: 1.75rem 0; }
+  .article-reading .info-box-content dt {
+    font-weight: 700;
+    color: var(--reading-ink-strong);
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-light);
+  }
+  .article-reading .info-box-content dt:first-of-type {
+    margin-top: 0.5rem;
+    padding-top: 0;
+    border-top: 0;
+  }
+  .article-reading .info-box-content dd {
+    margin: 0.45rem 0 0 1rem;
+    color: var(--reading-ink);
+  }
+
+  /* --- 引用 / ポイントのコールアウト --- */
+  .article-reading .info-box-content blockquote {
+    margin: 1.85rem 0;
+    padding: 1rem 1.35rem;
+    border-left: 4px solid var(--primary-color);
+    background: var(--primary-light);
+    border-radius: 0 10px 10px 0;
+    color: var(--reading-ink-strong);
+  }
+  .article-reading .info-box-content blockquote p:last-child { margin-bottom: 0; }
+
+  /* --- 本文中リンク: 読みやすい控えめな下線 --- */
+  .article-reading .info-box-content p a,
+  .article-reading .info-box-content li a {
+    border-bottom-color: rgba(0, 109, 128, 0.32);
+  }
+
+  @media (max-width: 640px) {
+    .article-reading .info-box-content {
+      padding: 1.85rem 1.35rem 2.25rem;
+      font-size: 1.02rem;
+      line-height: 1.85;
+    }
+    .article-reading .info-box-content h3 {
+      font-size: 1.28rem;
+      margin-top: 2.25rem;
+    }
+  }
+
   .article-breadcrumb {
     font-size: 0.85rem;
     color: var(--text-medium);


### PR DESCRIPTION
## 背景・課題

記事ページの本文が「薄くて読みづらい」状態でした。原因は、記事本文がお問い合わせフォーム用のカード（`.info-box`）を流用しており、本文色が灰色（`--text-medium` = `#6b7280`）固定になっていたことです。長文記事に対して文字サイズ・可読幅・見出しの強弱も読書向けに最適化されていませんでした。

## 対応方針

アプリ本体の箱型UIとは切り離し、落ち着いた **editorial（読み物）レイヤー** に整えました。サービスのティール配色と既存の明朝見出し（Kaisei Opti）はそのまま活かしています。

全記事は `_article_base.html` を継承しているため、**1ファイルの変更で全記事に反映**されます。調整はすべて記事コンテナに付与した `.article-reading` スコープ配下に限定しており、お問い合わせフォーム等ほかの `.info-box` 利用画面には影響しません。

## 変更点

| 項目 | Before | After |
|---|---|---|
| **本文色（薄さの主因）** | `#6b7280` 灰色 | `#283142` 濃いインク |
| リスト / dd の色 | 灰色 | 濃いインク |
| 本文サイズ / 行間 | 16px / 1.8 | 17px / 1.9 |
| 可読幅 | 実測760px | 720pxに調整＋中央寄せ |
| 見出し階層 | h3もh4も主張色 | h3=インク＋ティール罫 / h4=ティール |
| h4の▶マーク | 藍色(#4f46e5)で浮く | ティールに統一 |
| コンテナ | フォーム用の重い影＋上部グラデバー | 影を軽く・バー除去 |
| 強調(strong) | — | 濃いインク＋太字で明確化 |
| 用語解説(dl) | 素のまま | 区切り線つきで整理 |
| 引用(blockquote) | 未定義 | ティールのコールアウト様式を用意 |
| リストマーカー | 黒 | ティール |
| モバイル | — | 余白・サイズを最適化 |

## 確認内容

- ローカル起動（`http://localhost:5000/smartphone-receiving`）で配信HTMLを検証し、`class="info-box article-reading"` の出力と新スタイルの適用、本文色上書き（詳細度が元ルールより高い）を確認済み。
- ※実行環境でヘッドレスChromiumの共有ライブラリが不足していたため、ブラウザでのスクリーンショット確認は未実施。レビュー時にブラウザでの目視確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)