### PR TITLE
CI: テストジョブを統合しDocker/Trivyを並列ジョブへ分離

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,49 +128,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt pytest httpx pytest-cov
 
-      - name: Run multilingual service smoke tests
-        run: |
-          set -euo pipefail
-          python -m pytest -q tests/test_multilingual_service.py \
-            --cov=. \
-            --cov-report=
-
-      - name: Run multilingual leakage tests
-        run: |
-          set -euo pipefail
-          python -m pytest -q tests/test_no_japanese_leakage.py \
-            --cov=. \
-            --cov-append \
-            --cov-report=
-
-      - name: Run strict multilingual purity tests
-        run: |
-          set -euo pipefail
-          python -m pytest -q tests/test_strict_multilingual_purity.py \
-            --cov=. \
-            --cov-append \
-            --cov-report=
-
-      - name: Run user flow E2E tests
-        run: |
-          set -euo pipefail
-          python -m pytest -q tests/test_e2e_user_flows.py \
-            --cov=. \
-            --cov-append \
-            --cov-report=
-
-      - name: Run remaining test suite
+      - name: Run test suite
         run: |
           set -euo pipefail
           python -m pytest -q \
-            --ignore=tests/test_multilingual_service.py \
-            --ignore=tests/test_no_japanese_leakage.py \
-            --ignore=tests/test_strict_multilingual_purity.py \
-            --ignore=tests/test_e2e_user_flows.py \
             --cov=. \
-            --cov-append \
             --cov-report=term-missing \
             --cov-fail-under=67
+
+  image-scan:
+    name: Docker build + Trivy scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            checkout_ref="refs/pull/${PR_NUMBER}/merge"
+          else
+            checkout_ref="${GITHUB_SHA}"
+          fi
+
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin "${checkout_ref}"
+          git checkout --detach FETCH_HEAD
 
       - name: Build Docker image
         run: |
@@ -237,7 +224,7 @@ jobs:
   deploy:
     name: Deploy (main push)
     runs-on: ubuntu-latest
-    needs: [lint, audit, test, typecheck]
+    needs: [lint, audit, test, image-scan, typecheck]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## 概要

CI の `test` ジョブを見直し、**テスト内容は一切変更せず**にwall-clockを短縮する。

実装前に `pytest-xdist` でのプロセス並列を検証したが、以下の理由から見送った（別途メモ参照）:
- ボトルネックは単一テスト `test_no_japanese_leakage`（約40秒）で、これは分割できないため並列の効果が頭打ち。
- 並列実行が潜在的なテスト独立性の問題を露呈させる（`test_group.py` の順序依存3件、`test_seo.py` の module-scope フィクスチャ衝突）。これらの解消にはテストコードの変更が必要なため、「テスト無変更」の方針に反する。

代わりに、テストを変えずに確実に効く2点を実装した。

## 変更内容

1. **逐次5回のpytestを1回に統合**
   - 従来は `--cov-append` でカバレッジを段階加算するため pytest を5回起動しており、app import・テスト収集・起動コストを毎回支払っていた。
   - 単一実行に統合。実行順（直列）・対象テスト・カバレッジ・`--cov-fail-under=67` ゲートはすべて不変。
   - ローカル検証: **537 passed / coverage 73.18%**（ゲート67%クリア）。

2. **Docker build + Trivy スキャンを `image-scan` ジョブへ分離**
   - 従来は `test` ジョブ内で「テスト → docker build → trivy」が直列だった。
   - 別ジョブ化し pytest と**並列**に実行。クリティカルパスを短縮。
   - `deploy` の `needs` に `image-scan` を追加し、デプロイゲートを維持。

## テスト

- `python -m pytest --cov=. --cov-fail-under=67` → 537 passed, 73.18%
- workflow YAML の妥当性確認済み（jobs: lint / audit / test / image-scan / typecheck / deploy）

🤖 Generated with [Claude Code](https://claude.com/claude-code)