### PR TITLE
[codex] Parallelize leakage pytest in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,13 +126,19 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt pytest httpx pytest-cov
+          python -m pip install -r requirements.txt pytest httpx pytest-cov pytest-xdist
 
       - name: Run test suite
         run: |
           set -euo pipefail
-          python -m pytest -q \
+          python -m coverage erase
+          python -m pytest -q -n auto tests/test_no_japanese_leakage.py \
             --cov=. \
+            --cov-report=
+          python -m pytest -q \
+            --ignore=tests/test_no_japanese_leakage.py \
+            --cov=. \
+            --cov-append \
             --cov-report=term-missing \
             --cov-fail-under=67
 

--- a/tests/test_no_japanese_leakage.py
+++ b/tests/test_no_japanese_leakage.py
@@ -3,6 +3,7 @@
 import asyncio
 import re
 from httpx import ASGITransport, AsyncClient
+import pytest
 
 from Articles.articles_registry import get_all_articles
 from i18n import SUPPORTED_LANGUAGES
@@ -20,6 +21,7 @@ ALLOWED_STRINGS = {
     "繁體中文",
     "한국어",
 }
+ARTICLE_CASES = tuple(get_all_articles())
 
 
 def _segments(html: str) -> list[str]:
@@ -46,7 +48,12 @@ def _has_japanese(s: str, lang: str) -> bool:
     return False
 
 
-def test_no_japanese_leakage(test_client) -> None:
+@pytest.mark.parametrize(
+    "article",
+    ARTICLE_CASES,
+    ids=[article["slug"] for article in ARTICLE_CASES],
+)
+def test_no_japanese_leakage(test_client, article) -> None:
     """全記事 × 全言語（ja除く）で日本語が漏れていないことを確認する。"""
     langs = [lang for lang in SUPPORTED_LANGUAGES if lang != "ja"]
     leaks: list[tuple[str, str, str]] = []
@@ -63,20 +70,19 @@ def test_no_japanese_leakage(test_client) -> None:
                 resp = await client.get(f"{url}?lang={lang}")
                 return lang, _segments(resp.text)
 
-            for article in get_all_articles():
-                url = "/" + article["slug"]
-                ja_resp = await client.get(url + "?lang=ja")
-                ja_segs = _segments(ja_resp.text)
+            url = "/" + article["slug"]
+            ja_resp = await client.get(url + "?lang=ja")
+            ja_segs = _segments(ja_resp.text)
 
-                tasks = [fetch_segs(url, lang) for lang in langs]
-                results = await asyncio.gather(*tasks)
+            tasks = [fetch_segs(url, lang) for lang in langs]
+            results = await asyncio.gather(*tasks)
 
-                for lang, tr_segs in results:
-                    if len(tr_segs) != len(ja_segs):
-                        continue
-                    for ja_seg, tr_seg in zip(ja_segs, tr_segs):
-                        if _has_japanese(tr_seg, lang) and _has_japanese(ja_seg, "en"):
-                            leaks.append((url, lang, tr_seg[:80]))
+            for lang, tr_segs in results:
+                if len(tr_segs) != len(ja_segs):
+                    continue
+                for ja_seg, tr_seg in zip(ja_segs, tr_segs):
+                    if _has_japanese(tr_seg, lang) and _has_japanese(ja_seg, "en"):
+                        leaks.append((url, lang, tr_seg[:80]))
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary

- Parametrize the Japanese leakage regression test by article slug so pytest can schedule each article case independently.
- Add `pytest-xdist` to the CI test install and run the leakage test file with `-n auto`.
- Keep the rest of the suite on the existing serial path and append coverage, avoiding current app import/session assumptions in unrelated tests.

## Validation

- `python3 -m pytest -q tests/test_no_japanese_leakage.py --durations=10`
- `python3 -m coverage erase && python3 -m pytest -q -n auto tests/test_no_japanese_leakage.py --cov=. --cov-report= && python3 -m pytest -q --ignore=tests/test_no_japanese_leakage.py --cov=. --cov-append --cov-report=term-missing --cov-fail-under=67`
- `python3 -m ruff check tests/test_no_japanese_leakage.py`
- `python3 -m ruff format --check tests/test_no_japanese_leakage.py`
- `git diff --check -- .github/workflows/tests.yml tests/test_no_japanese_leakage.py`