### PR TITLE
記事・情報ページの配色と可読性、記事カードの高さを改善

### DIFF
--- a/Articles/templates/articles.html
+++ b/Articles/templates/articles.html
@@ -187,6 +187,12 @@
     margin-bottom: 0.75rem;
     line-height: 1.4;
     font-family: 'Kaisei Opti', serif;
+    /* タイトルは2行で固定し、超過は省略 → カード高さを揃える */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    min-height: calc(1.3rem * 1.4 * 2);
   }
   .article-description {
     font-size: 0.95rem;
@@ -194,6 +200,12 @@
     line-height: 1.6;
     margin-bottom: 1.25rem;
     flex-grow: 1;
+    /* 説明文は3行で固定。短くても3行分を確保し、超過は省略 */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    min-height: calc(0.95rem * 1.6 * 3);
   }
   .read-more {
     display: inline-flex;

--- a/Articles/templates/articles.html
+++ b/Articles/templates/articles.html
@@ -100,7 +100,7 @@
     color: var(--primary-color);
   }
   .filter-chip.active {
-    background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+    background: var(--primary-action-gradient, linear-gradient(135deg, #1e40af 0%, #2563eb 100%));
     color: white;
     border-color: transparent;
   }
@@ -280,7 +280,7 @@
     transform: translateY(-1px);
   }
   .pagination-current {
-    background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+    background: var(--primary-action-gradient, linear-gradient(135deg, #1e40af 0%, #2563eb 100%));
     color: white;
     border: 1px solid transparent;
     font-weight: 700;

--- a/static/css/02-design-retention.css
+++ b/static/css/02-design-retention.css
@@ -1,12 +1,12 @@
 /* Modern design system for info pages */
 :root {
-  --primary-color: rgb(0, 109, 128);
-  --primary-light: rgba(0, 109, 128, 0.1);
-  --primary-gradient: linear-gradient(135deg, rgb(0, 109, 128) 0%, rgb(32, 178, 170) 100%);
-  --primary-action-gradient: linear-gradient(135deg, #075985 0%, #0f766e 100%);
-  --primary-action-gradient-hover: linear-gradient(135deg, #064e7a 0%, #115e59 100%);
-  --primary-action-shadow: rgba(7, 89, 133, 0.28);
-  --primary-action-shadow-hover: rgba(7, 89, 133, 0.38);
+  --primary-color: rgb(29, 78, 216);
+  --primary-light: rgba(29, 78, 216, 0.1);
+  --primary-gradient: linear-gradient(135deg, rgb(29, 78, 216) 0%, rgb(59, 130, 246) 100%);
+  --primary-action-gradient: linear-gradient(135deg, #1e40af 0%, #2563eb 100%);
+  --primary-action-gradient-hover: linear-gradient(135deg, #1e3a8a 0%, #1d4ed8 100%);
+  --primary-action-shadow: rgba(30, 64, 175, 0.28);
+  --primary-action-shadow-hover: rgba(30, 64, 175, 0.38);
   --focus-ring-color: rgba(37, 99, 235, 0.32);
   --focus-ring-strong: 0 0 0 3px var(--focus-ring-color);
   --focus-ring-offset: 0 0 0 3px rgba(255, 255, 255, 0.95), 0 0 0 7px var(--focus-ring-color);
@@ -122,7 +122,7 @@
   --theme-group-end: #22c55e;
   --theme-group-accent: var(--theme-group-end);
   --theme-group-gradient: linear-gradient(135deg, var(--theme-group-start) 0%, var(--theme-group-end) 100%);
-  --theme-group-copy-copied-gradient: linear-gradient(135deg, #0f766e 0%, #14b8a6 100%);
+  --theme-group-copy-copied-gradient: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);
   --theme-group-shadow-soft: rgba(22, 101, 52, 0.5);
   --theme-group-inline-hover-bg: rgba(34, 197, 94, 0.1);
   --theme-group-file-item-hover-bg: rgba(34, 197, 94, 0.05);

--- a/static/css/03-info-box-contact.css
+++ b/static/css/03-info-box-contact.css
@@ -110,13 +110,13 @@
 
 .info-box-content p {
   margin-bottom: 1.25rem;
-  color: var(--text-medium);
+  color: var(--text-dark);
   font-size: 1rem;
 }
 
 .info-box-content ul, .info-box-content ol {
   margin: 1rem 0 1.5rem 1.5rem;
-  color: var(--text-medium);
+  color: var(--text-dark);
 }
 
 .info-box-content li {

--- a/static/css/03-info-box-contact.css
+++ b/static/css/03-info-box-contact.css
@@ -156,7 +156,7 @@
 .contact-form-link {
   display: inline-flex;
   align-items: center;
-  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+  background: var(--primary-action-gradient, linear-gradient(135deg, #1e40af 0%, #2563eb 100%));
   color: white;
   padding: 1rem 2rem;
   border-radius: 50px;
@@ -169,7 +169,7 @@
 }
 
 .contact-form-link:hover {
-  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #1e3a8a 0%, #1d4ed8 100%));
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
   color: white;

--- a/static/css/06-usage-section.css
+++ b/static/css/06-usage-section.css
@@ -6,7 +6,7 @@
 .usage-section {
   --usage-card-radius: 20px;
   --usage-header-gradient: var(--primary-gradient);
-  --usage-header-accent: rgb(32, 178, 170);
+  --usage-header-accent: rgb(59, 130, 246);
   max-width: 900px;
   margin: 2rem auto;
   background: var(--bg-white);

--- a/static/css/07-modern-components.css
+++ b/static/css/07-modern-components.css
@@ -11,7 +11,7 @@
 .modern-content-card {
   --modern-card-radius: 24px;
   --modern-card-header-gradient: var(--primary-gradient);
-  --modern-card-header-accent: rgb(32, 178, 170);
+  --modern-card-header-accent: rgb(59, 130, 246);
   max-width: 900px;
   margin: 0 auto;
   background: var(--bg-white);
@@ -86,7 +86,7 @@
 .modern-upload-area {
   border: 3px dashed var(--primary-color);
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(0, 109, 128, 0.02) 0%, rgba(32, 178, 170, 0.05) 100%);
+  background: linear-gradient(135deg, rgba(29, 78, 216, 0.02) 0%, rgba(59, 130, 246, 0.05) 100%);
   text-align: center;
   padding: 3rem 2rem;
   margin: 2rem 0;
@@ -103,7 +103,7 @@
   left: -50%;
   width: 200%;
   height: 200%;
-  background: radial-gradient(circle, rgba(0, 109, 128, 0.03) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(29, 78, 216, 0.03) 0%, transparent 70%);
   opacity: 0;
   transition: opacity 0.3s ease;
 }
@@ -115,10 +115,10 @@
 
 .modern-upload-area:hover,
 .modern-upload-area.dragover {
-  border-color: rgb(32, 178, 170);
-  background: linear-gradient(135deg, rgba(0, 109, 128, 0.05) 0%, rgba(32, 178, 170, 0.1) 100%);
+  border-color: rgb(59, 130, 246);
+  background: linear-gradient(135deg, rgba(29, 78, 216, 0.05) 0%, rgba(59, 130, 246, 0.1) 100%);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 109, 128, 0.15);
+  box-shadow: 0 8px 25px rgba(29, 78, 216, 0.15);
 }
 
 .upload-icon-modern {
@@ -142,7 +142,7 @@
 }
 
 .upload-button-modern {
-  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+  background: var(--primary-action-gradient, linear-gradient(135deg, #1e40af 0%, #2563eb 100%));
   color: white;
   border: none;
   border-radius: 12px;
@@ -151,13 +151,13 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
+  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(30, 64, 175, 0.28));
 }
 
 .upload-button-modern:hover {
-  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #1e3a8a 0%, #1d4ed8 100%));
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
+  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(30, 64, 175, 0.38));
 }
 
 /* ===============================================
@@ -332,7 +332,7 @@
 
 .modern-form-input:focus-visible {
   outline: 3px solid transparent;
-  box-shadow: var(--focus-ring-strong, 0 0 0 3px rgba(0, 109, 128, 0.22));
+  box-shadow: var(--focus-ring-strong, 0 0 0 3px rgba(29, 78, 216, 0.22));
 }
 
 .upload-limit-status {
@@ -374,16 +374,16 @@
 }
 
 .modern-editor:focus {
-  box-shadow: 0 0 0 3px rgba(0, 109, 128, 0.1);
+  box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.1);
 }
 
 .modern-editor:focus-visible {
   outline: 3px solid transparent;
-  box-shadow: var(--focus-ring-strong, 0 0 0 3px rgba(0, 109, 128, 0.22));
+  box-shadow: var(--focus-ring-strong, 0 0 0 3px rgba(29, 78, 216, 0.22));
 }
 
 .modern-btn {
-  background: var(--primary-action-gradient, linear-gradient(135deg, #075985 0%, #0f766e 100%));
+  background: var(--primary-action-gradient, linear-gradient(135deg, #1e40af 0%, #2563eb 100%));
   color: white;
   border: none;
   border-radius: 12px;
@@ -392,7 +392,7 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(7, 89, 133, 0.28));
+  box-shadow: 0 4px 12px var(--primary-action-shadow, rgba(30, 64, 175, 0.28));
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -400,9 +400,9 @@
 }
 
 .modern-btn:hover {
-  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #064e7a 0%, #115e59 100%));
+  background: var(--primary-action-gradient-hover, linear-gradient(135deg, #1e3a8a 0%, #1d4ed8 100%));
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(7, 89, 133, 0.38));
+  box-shadow: 0 6px 20px var(--primary-action-shadow-hover, rgba(30, 64, 175, 0.38));
   color: white;
   text-decoration: none;
 }
@@ -575,7 +575,7 @@
 }
 
 .modern-file-item:hover {
-  background: rgba(0, 109, 128, 0.05);
+  background: rgba(29, 78, 216, 0.05);
 }
 
 .modern-file-name {

--- a/static/css/14-article-reading.css
+++ b/static/css/14-article-reading.css
@@ -127,7 +127,7 @@
 /* --- 本文中リンク: 読みやすい控えめな下線 --- */
 .article-reading .info-box-content p a,
 .article-reading .info-box-content li a {
-  border-bottom-color: rgba(0, 109, 128, 0.32);
+  border-bottom-color: rgba(29, 78, 216, 0.32);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## 概要
記事ページ・情報ページまわりの見た目と読みやすさを改善する3点の修正です。各コミットを論理単位で分けています。

## 変更内容

### 1. テーマ色を青緑(ティール)からロイヤルブルーへ
記事ページやポリシーページなどで使われていた暗い青緑のグラデーションが緑と青の混ざった印象だったため、緑味のないロイヤルブルー系へ統一しました。
- アクション基準グラデ `#075985→#0f766e` → `#1e40af→#2563eb`
- ホバー `#064e7a→#115e59` → `#1e3a8a→#1d4ed8`
- アクセント `rgb(0,109,128)`/`rgb(32,178,170)` → 青系
- シャドウ・フォーカスリング等の派生色も同系統に統一
- 基幹トークン(`02-design-retention.css`)を中心に値ベースで一括置換

### 2. 情報ページの本文を濃くして可読性を改善
About / Privacy Policy / Terms of Use / Contact / How to Use / Site Operator など `.info-box-content` を使うページで、本文の段落・リストが薄いグレー(`--text-medium #6b7280`)で読みにくかったため、見出しと同じ濃さ(`--text-dark #1f2937`)に揃えました。

### 3. 記事カードの高さを統一
記事一覧でタイトルや説明文の文字数によってカードの高さがばらつく問題を解消しました。
- タイトルを2行、説明文を3行でクランプし、それぞれの行数分の高さを確保(超過は末尾省略)
- サムネイルは元々アスペクト比固定のため、文字数に関わらず全カードが同じ高さに

## 確認方法
- `/articles` … カードの高さが揃っていること、テーマ色が青系であること
- `/about`・`/privacy`・`/terms` 等 … 本文が濃く読みやすいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)