### PR TITLE
[codex] FSQRのダウンロード導線を修正

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -223,7 +223,10 @@
 
         <form id="downloadForm" action="{{ url }}" method="POST" class="mt-4 text-center">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="modern-btn modern-btn-success">ダウンロード</button>
+          <button type="submit" class="modern-btn modern-btn-success">
+            {{ icons.icon('arrow_down', size='lg', with_text=True) }}
+            ダウンロード
+          </button>
         </form>
 
         <div class="text-center mt-4">

--- a/FSQR/templates/fs_qr_info/_scripts.html
+++ b/FSQR/templates/fs_qr_info/_scripts.html
@@ -319,17 +319,17 @@
         if (rawKey.length !== 32) {
           throw new Error(translate('download.decrypt_failed', 'Decryption failed.'));
         }
-        return crypto.subtle.importKey('raw', rawKey, { name: 'AES-256-GCM' }, false, ['decrypt']);
+        return crypto.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['decrypt']);
       }
       const keyBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(key));
-      return crypto.subtle.importKey('raw', keyBuffer, { name: 'AES-256-GCM' }, false, ['decrypt']);
+      return crypto.subtle.importKey('raw', keyBuffer, { name: 'AES-GCM' }, false, ['decrypt']);
     }
 
     async function decryptFile(encryptedBuffer, key, iv) {
       const cryptoKey = await importDecryptionKey(key);
 
       try {
-        return await crypto.subtle.decrypt({ name: 'AES-256-GCM', iv }, cryptoKey, encryptedBuffer);
+        return await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, cryptoKey, encryptedBuffer);
       } catch (error) {
         console.error('Decryption error:', error);
         return null;

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -56,9 +56,7 @@ def test_fsqr_upload_generated_password_matches_server_policy():
 
 
 def test_fsqr_download_script_uses_webcrypto_aes_gcm_name():
-    script = Path("FSQR/templates/fs_qr_info/_scripts.html").read_text(
-        encoding="utf-8"
-    )
+    script = Path("FSQR/templates/fs_qr_info/_scripts.html").read_text(encoding="utf-8")
     assert "AES-256-GCM" not in script
     assert "{ name: 'AES-GCM' }" in script
     assert "crypto.subtle.decrypt({ name: 'AES-GCM', iv }" in script

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -55,6 +55,15 @@ def test_fsqr_upload_generated_password_matches_server_policy():
     assert "PASSWORD_DIGITS[bytes[i] % PASSWORD_DIGITS.length]" in script
 
 
+def test_fsqr_download_script_uses_webcrypto_aes_gcm_name():
+    script = Path("FSQR/templates/fs_qr_info/_scripts.html").read_text(
+        encoding="utf-8"
+    )
+    assert "AES-256-GCM" not in script
+    assert "{ name: 'AES-GCM' }" in script
+    assert "crypto.subtle.decrypt({ name: 'AES-GCM', iv }" in script
+
+
 def test_fsqr_search_page(test_client: TestClient):
     response = test_client.get("/search_fs-qr")
     assert response.status_code == 200
@@ -781,6 +790,8 @@ def test_fs_qr_share_token_route_returns_download_page(test_client: TestClient):
     assert response.status_code == 200
     assert "report.pdf" in response.text
     assert f"/fs-qr/s/{share_token}/download" in response.text
+    assert 'class="svg-icon svg-icon--lg svg-icon--with-text"' in response.text
+    assert "ダウンロード" in response.text
     assert "downloadPasswordValue" not in response.text
 
 


### PR DESCRIPTION
## 概要

- FSQRのダウンロードボタンに既存の下向き矢印アイコンを追加しました。
- ダウンロード時の復号処理で、WebCryptoが認識できない `AES-256-GCM` ではなく正式な `AES-GCM` を使うよう修正しました。
- ボタン表示と復号アルゴリズム名の回帰を防ぐテストを追加しました。

## 原因

復号側の `crypto.subtle.importKey` / `crypto.subtle.decrypt` に渡すアルゴリズム名だけが `AES-256-GCM` になっており、WebCrypto APIの有効な名称ではなかったため、ブラウザで `Failed to execute 'importKey' on 'SubtleCrypto': Algorithm: Unrecognized name` が発生していました。

## 確認

- `python3 -m pytest tests/test_fsqr.py`