### PR TITLE
[codex] Ignore local cleanup artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,58 @@ test_app.py
 .DS_Store
 Thumbs.db
 .vscode/
+.agents/
+.claude/
+
+# Local scratch files generated during translation and cleanup work
+scratch/
+scratch.md
+*_review.txt
+*_comparison.txt
+*_compare.txt
+validation_errors*.log
+translations_to_review.md
+texts.jsonl
+translation_files.txt
+untranslated_keys.json
+chunk_*.json
+fixed_*.json
+prod_part*.json
+combined_translations.json
+all_articles_ja.json
+missing_*.json
+missing_*.txt
+output.txt
+extracted.txt
+dump*.json
+dump*.txt
+ko_review_chunk_*
+
+# One-off root-level helper scripts should stay out of source control.
+/apply_*.py
+/auto_translate.py
+/check_*.py
+/compare*.py
+/complete_missing_translations.py
+/count_keys.py
+/diff_keys.py
+/dump*.py
+/extract*.py
+/find_*.py
+/fix_*.py
+/generate*.py
+/inspect_json.py
+/merge_*.py
+/patch_*.py
+/prepare_chunks.py
+/print_*.py
+/restore_*.py
+/review_*.py
+/split_chunks.py
+/test_trans.py
+/translate*.py
+/update_*.py
+/write_*.py
 
 
 # .gitkeepのみ追跡対象にする


### PR DESCRIPTION
## Summary
- removed local untracked cleanup and translation scratch files from the working tree
- removed the stale Claude worktree registration
- added `.gitignore` rules for local scratch directories, translation review outputs, generated JSON/TXT artifacts, and one-off root helper scripts

## Notes
Most deleted files were already untracked or ignored, so the committed repository change is the `.gitignore` update that prevents these artifacts from reappearing in future status output.

Some root-owned runtime artifacts remain locally because this environment requires a sudo password to delete them: `__pycache__/` directories, `logs/`, and `static/upload/`.

## Validation
- `git check-ignore scratch/foo.py scratch.md translations_to_review.md chunk_1.json fix_tmp.py translate_tmp.py update_tmp.py .claude/worktrees/x .agents/x`
- `git diff --check`