### PR TITLE
フッターの背景を濃色にして視認性を改善

### DIFF
--- a/static/css/04-service-landing.css
+++ b/static/css/04-service-landing.css
@@ -344,10 +344,10 @@
   padding: 20px 18px;
   margin-top: 0;
   border-radius: 22px;
-  background: rgba(10, 18, 36, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(13, 24, 44, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.24);
+  color: #ffffff;
 }
 
 .service-footer nav {
@@ -398,7 +398,7 @@
   display: block;
   margin-top: 12px;
   text-align: center;
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .service-menu-page a:focus-visible,


### PR DESCRIPTION
## 概要
トップページのフッターの色が薄くて見えにくい問題を修正しました。

## 原因
共通フッター（`_footer.html` / クラス `simple-footer service-footer`）は、トップページなどの明るいグラデーション背景（青〜緑）の上に、ほぼ透明な暗い背景 `rgba(10, 18, 36, 0.18)` と半透明の白文字（`rgba(255,255,255,0.92)` / コピーライト `0.78`）で表示されていました。そのため背景のグラデーションが透けてコントラストが低く、フッター全体が薄く読みづらくなっていました。

## 変更内容
`static/css/04-service-landing.css` の `.service-footer`：
- 背景 `rgba(10, 18, 36, 0.18)` → `rgba(13, 24, 44, 0.85)`（しっかりした濃紺）
- 文字色 `rgba(255, 255, 255, 0.92)` → `#ffffff`
- ボーダー / シャドウを軽く強調
- コピーライト（`small`）の文字色 `rgba(255,255,255,0.78)` → `rgba(255,255,255,0.88)`

これにより明るい背景の上でも白文字のコントラスト比が十分に確保され（約12:1）、視認性が改善します。トップページだけでなく同フッターを使う各サービスページにも一律で効果があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)