### PR TITLE
トップページのフッターの視認性と左右余白を改善

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -544,31 +544,32 @@
       }
     }
 
-    .top-footer {
+    /* トップページのフッター: 左右に余白を確保し、視認性の高い濃色背景にする */
+    .service-footer {
       width: min(calc(100% - 32px), 1100px);
       margin: 32px auto calc(32px + env(safe-area-inset-bottom));
       padding: 22px clamp(18px, 4vw, 36px);
       background: #132238;
-      border: 1px solid rgba(19, 34, 56, 0.18);
+      border: 1px solid rgba(255, 255, 255, 0.16);
       color: #ffffff;
       box-shadow: 0 16px 32px rgba(15, 23, 42, 0.16);
     }
 
-    .top-footer nav {
+    .service-footer nav {
       gap: 10px 18px;
     }
 
-    .top-footer a,
-    .top-footer .footer-link-button {
+    .service-footer a,
+    .service-footer .footer-link-button {
       color: #ffffff;
     }
 
-    .top-footer small {
+    .service-footer small {
       color: rgba(255, 255, 255, 0.82);
     }
 
     @media (max-width: 575.98px) {
-      .top-footer {
+      .service-footer {
         width: min(calc(100% - 24px), 1100px);
         margin-top: 24px;
         margin-bottom: calc(24px + env(safe-area-inset-bottom));


### PR DESCRIPTION
## 概要
トップページ（`/`）のフッターが「色が見えにくい」「左右に余白がなく端にくっついている」問題を修正します。

## 原因
`templates/index.html` 内にフッター用の整形スタイル（横幅制限・左右マージン・濃色背景・白文字）が用意されていましたが、実際にレンダリングされる要素（`_footer.html` の `class="simple-footer service-footer"`）には付与されていない **未使用クラス `.top-footer` を対象**にしていたため、まったく適用されていませんでした。

結果として、トップページのフッターは `04-service-landing.css` の `.service-footer`（半透明背景・横マージンなし）のまま表示され、端にくっつき色も薄く見えていました。

## 修正内容
未使用の `.top-footer` ルールを、実際のクラス `.service-footer` に向け直しました（このスタイルブロックは `index.html` の `<head>` にあるためトップページのみに適用されます）。

- `width: min(calc(100% - 32px), 1100px)` + `margin: ... auto` で左右に余白を確保 → 端へのくっつきを解消
- 背景を半透明から濃色 `#132238`、文字を `#ffffff` にして視認性を確保
- ボーダーを暗色 → 淡い白系（`rgba(255,255,255,0.16)`）に変更し、濃背景上で輪郭が出るよう改善
- `border-radius: 22px`（既存）は維持され、余白が付いたことで角丸が自然に見えるように

## 影響範囲
- 変更はトップページのインライン `<style>` 内のみ。他ページのフッター（group/note/fsqr 等は別ルールで横マージン適用済み）には影響しません。
- `.top-footer` は他のどこからも参照されていないデッドコードであることを確認済み。

## 検証
- 当環境ではブラウザ描画に必要なシステムライブラリ（libnspr4 等）が sudo 無しで導入できず、スクリーンショットによる確認は未実施です。CSS の適用関係（インラインの `.service-footer` が外部 CSS より後勝ちで適用、白文字でコントラスト確保）を確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)