### PR TITLE
Harden search scalability

### DIFF
--- a/FSQR/fsqr_data.py
+++ b/FSQR/fsqr_data.py
@@ -33,6 +33,14 @@ def hash_share_token(share_token: str) -> str:
     return hashlib.sha256(share_token.encode("utf-8")).hexdigest()
 
 
+def hash_password_lookup(id_val: str, password: str) -> str:
+    payload = f"fsqr:{id_val}:{password}".encode("utf-8")
+    secret = (SECRET_KEY or "").encode("utf-8")
+    if secret:
+        return hmac.new(secret, payload, hashlib.sha256).hexdigest()
+    return hashlib.sha256(payload).hexdigest()
+
+
 # ファイルを保存
 async def save_file(
     uid,
@@ -46,15 +54,18 @@ async def save_file(
 ):
     try:
         hashed_password = hash_password(password)
+        password_lookup_hash = hash_password_lookup(id, password)
         share_token_hash = hash_share_token(share_token) if share_token else None
         query = text("""
             INSERT INTO fsqr (
-                time, uuid, id, password, secure_id, share_token_hash,
-                file_type, original_filename, retention_days
+                time, uuid, id, password, password_lookup_hash,
+                secure_id, share_token_hash, file_type, original_filename,
+                retention_days, expires_at
             )
             VALUES (
-                NOW(), :uid, :id, :password, :secure_id, :share_token_hash,
-                :file_type, :original_filename, :retention_days
+                NOW(), :uid, :id, :password, :password_lookup_hash,
+                :secure_id, :share_token_hash, :file_type, :original_filename,
+                :retention_days, DATE_ADD(NOW(), INTERVAL :retention_days DAY)
             )
         """)
         await execute_query(
@@ -63,6 +74,7 @@ async def save_file(
                 "uid": uid,
                 "id": id,
                 "password": hashed_password,
+                "password_lookup_hash": password_lookup_hash,
                 "secure_id": secure_id,
                 "share_token_hash": share_token_hash,
                 "file_type": file_type,
@@ -98,7 +110,7 @@ async def try_login(id, password) -> Optional[str]:
 
 
 # 資格情報でデータを取得
-@cache_data(ttl=60, strip_keys=("password",))
+@cache_data(ttl=60, strip_keys=("password", "password_lookup_hash"))
 async def get_data_by_credentials(id, password):
     try:
         record = await _find_record_by_credentials(id, password)
@@ -121,12 +133,12 @@ async def get_data_direct(secure_id):
         raise
 
 
-@cache_data(ttl=60, strip_keys=("password", "share_token_hash"))
+@cache_data(ttl=60, strip_keys=("password", "password_lookup_hash", "share_token_hash"))
 async def get_data(secure_id):
     return await get_data_direct(secure_id)
 
 
-@cache_data(ttl=60, strip_keys=("password", "share_token_hash"))
+@cache_data(ttl=60, strip_keys=("password", "password_lookup_hash", "share_token_hash"))
 async def get_data_by_share_token(share_token):
     try:
         token_hash = hash_share_token(share_token)
@@ -143,7 +155,9 @@ async def get_data_by_share_token(share_token):
 
 
 # 全てのデータを取得する
-@cache_data(ttl=300, strip_keys=("password", "share_token_hash"))
+@cache_data(
+    ttl=300, strip_keys=("password", "password_lookup_hash", "share_token_hash")
+)
 async def get_all():
     return await get_all_direct()
 
@@ -253,13 +267,11 @@ async def remove_expired_files():
         "ran_at": datetime.now(timezone.utc).isoformat(),
     }
     try:
-        query = text(
-            """
+        query = text("""
             SELECT secure_id
             FROM fsqr
-            WHERE DATE_ADD(time, INTERVAL retention_days DAY) <= NOW()
-            """
-        )
+            WHERE expires_at <= NOW()
+            """)
         expired_records = await execute_query(query, fetch=True)
         stats["checked"] = len(expired_records)
         for record in expired_records:
@@ -299,13 +311,34 @@ async def record_expiration_cleanup_status(stats):
 
 
 async def _find_record_by_credentials(id_val: str, password: str):
+    lookup_hash = hash_password_lookup(id_val, password)
     query = text("""
-        SELECT * FROM fsqr WHERE id = :id
+        SELECT * FROM fsqr
+        WHERE id = :id
+          AND password_lookup_hash = :password_lookup_hash
+        LIMIT 1
     """)
-    rows = await execute_query(query, {"id": id_val}, fetch=True)
-    for row in rows:
-        stored_password = row.get("password")
-        if not verify_password(stored_password, password):
+    rows = await execute_query(
+        query,
+        {"id": id_val, "password_lookup_hash": lookup_hash},
+        fetch=True,
+    )
+    if rows:
+        row = rows[0]
+        if verify_password(row.get("password"), password):
+            return row
+
+    legacy_rows = await execute_query(
+        text("""
+            SELECT * FROM fsqr
+            WHERE id = :id
+              AND password_lookup_hash IS NULL
+        """),
+        {"id": id_val},
+        fetch=True,
+    )
+    for row in legacy_rows:
+        if not verify_password(row.get("password"), password):
             continue
         return row
     return None

--- a/Group/group_data.py
+++ b/Group/group_data.py
@@ -25,8 +25,11 @@ STATIC = os.path.join(BASE_DIR, "static/upload")
 async def create_room(id, password, room_id, retention_days=7):
     hashed_password = hash_password(password)
     query = text("""
-        INSERT INTO room (time, id, password, room_id, retention_days)
-        VALUES (NOW(), :id, :password, :room_id, :retention_days)
+        INSERT INTO room (time, id, password, room_id, retention_days, expires_at)
+        VALUES (
+            NOW(), :id, :password, :room_id, :retention_days,
+            DATE_ADD(NOW(), INTERVAL :retention_days DAY)
+        )
     """)
     await execute_query(
         query,
@@ -181,13 +184,11 @@ async def all_remove():
 # 1週間以上経過したルームを削除する関数
 async def remove_expired_rooms():
     # 1週間以上前のルームを取得するクエリ（MySQLの場合）
-    query = text(
-        """
+    query = text("""
         SELECT room_id
         FROM room
-        WHERE DATE_ADD(time, INTERVAL retention_days DAY) <= NOW()
-    """
-    )
+        WHERE expires_at <= NOW()
+    """)
     expired_rooms = await execute_query(query, fetch=True)
     for room in expired_rooms:
         room_id = room.get("room_id")

--- a/alembic/versions/20260710_0008_search_scalability.py
+++ b/alembic/versions/20260710_0008_search_scalability.py
@@ -1,0 +1,143 @@
+"""add scalable search lookup columns
+
+Revision ID: 20260710_0008
+Revises: 20260611_0007
+Create Date: 2026-07-10 00:00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260710_0008"
+down_revision = "20260611_0007"
+branch_labels = None
+depends_on = None
+
+_ALLOWED_TABLES = {"fsqr", "room"}
+
+
+def upgrade() -> None:
+    if _table_exists("fsqr"):
+        _add_column_if_missing(
+            "fsqr",
+            "password_lookup_hash",
+            "ALTER TABLE fsqr ADD COLUMN password_lookup_hash VARCHAR(64) NULL",
+        )
+        _add_column_if_missing(
+            "fsqr",
+            "expires_at",
+            "ALTER TABLE fsqr ADD COLUMN expires_at DATETIME NULL",
+        )
+        op.execute("""
+            UPDATE fsqr
+            SET expires_at = DATE_ADD(time, INTERVAL retention_days DAY)
+            WHERE expires_at IS NULL
+            """)
+        op.execute("ALTER TABLE fsqr MODIFY expires_at DATETIME NOT NULL")
+        _add_index_if_missing(
+            "fsqr",
+            "idx_fsqr_id_password_lookup",
+            "ALTER TABLE fsqr ADD INDEX idx_fsqr_id_password_lookup (id, password_lookup_hash)",
+        )
+        _add_index_if_missing(
+            "fsqr",
+            "idx_fsqr_expires_at",
+            "ALTER TABLE fsqr ADD INDEX idx_fsqr_expires_at (expires_at)",
+        )
+
+    if _table_exists("room"):
+        _add_column_if_missing(
+            "room",
+            "expires_at",
+            "ALTER TABLE room ADD COLUMN expires_at DATETIME NULL",
+        )
+        op.execute("""
+            UPDATE room
+            SET expires_at = DATE_ADD(time, INTERVAL retention_days DAY)
+            WHERE expires_at IS NULL
+            """)
+        op.execute("ALTER TABLE room MODIFY expires_at DATETIME NOT NULL")
+        _add_index_if_missing(
+            "room",
+            "idx_room_expires_at",
+            "ALTER TABLE room ADD INDEX idx_room_expires_at (expires_at)",
+        )
+
+
+def downgrade() -> None:
+    _drop_index_if_exists("room", "idx_room_expires_at")
+    _drop_column_if_exists("room", "expires_at")
+    _drop_index_if_exists("fsqr", "idx_fsqr_expires_at")
+    _drop_index_if_exists("fsqr", "idx_fsqr_id_password_lookup")
+    _drop_column_if_exists("fsqr", "expires_at")
+    _drop_column_if_exists("fsqr", "password_lookup_hash")
+
+
+def _table_exists(table_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.TABLES
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+          AND COLUMN_NAME = '{column_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    query = f"""
+        SELECT COUNT(*)
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{table_name}'
+          AND INDEX_NAME = '{index_name}'
+    """
+    return bool(op.get_bind().exec_driver_sql(query).scalar())
+
+
+def _add_column_if_missing(table_name: str, column_name: str, ddl: str) -> None:
+    if not _table_exists(table_name):
+        return
+    if _column_exists(table_name, column_name):
+        return
+    op.execute(ddl)
+
+
+def _drop_column_if_exists(table_name: str, column_name: str) -> None:
+    if not _table_exists(table_name):
+        return
+    if not _column_exists(table_name, column_name):
+        return
+    op.execute(f"ALTER TABLE {table_name} DROP COLUMN {column_name}")
+
+
+def _add_index_if_missing(table_name: str, index_name: str, ddl: str) -> None:
+    if not _table_exists(table_name):
+        return
+    if _index_exists(table_name, index_name):
+        return
+    op.execute(ddl)
+
+
+def _drop_index_if_exists(table_name: str, index_name: str) -> None:
+    if not _table_exists(table_name):
+        return
+    if not _index_exists(table_name, index_name):
+        return
+    op.execute(f"ALTER TABLE {table_name} DROP INDEX {index_name}")

--- a/db_init/create_tables.sql
+++ b/db_init/create_tables.sql
@@ -4,16 +4,19 @@ CREATE TABLE fsqr (
     uuid VARCHAR(255) NOT NULL,           -- ユニークな識別子
     id VARCHAR(255) NOT NULL,             -- ユーザーID
     password VARCHAR(255) NOT NULL,       -- パスワード
+    password_lookup_hash VARCHAR(64) NOT NULL, -- 検索用パスワードHMAC
     secure_id VARCHAR(255) NOT NULL,      -- ファイルのセキュアID
     share_token_hash VARCHAR(64) DEFAULT NULL, -- 共有URLトークンのハッシュ
     file_type VARCHAR(20) DEFAULT 'multiple', -- ファイルタイプ: single or multiple
     original_filename VARCHAR(255) DEFAULT NULL, -- 単一ファイルの元のファイル名
     retention_days INT NOT NULL DEFAULT 7, -- 自動削除までの日数
+    expires_at DATETIME NOT NULL,         -- 自動削除対象日時
     UNIQUE KEY uq_fsqr_uuid (uuid),
     UNIQUE KEY uq_fsqr_share_token_hash (share_token_hash),
-    INDEX idx_fsqr_id_password (id, password),
+    INDEX idx_fsqr_id_password_lookup (id, password_lookup_hash),
     INDEX idx_fsqr_secure_id (secure_id),
-    INDEX idx_fsqr_time (time)
+    INDEX idx_fsqr_time (time),
+    INDEX idx_fsqr_expires_at (expires_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE share_links (
@@ -39,10 +42,12 @@ CREATE TABLE room (
     password VARCHAR(255) NOT NULL,       -- パスワード
     room_id VARCHAR(255) NOT NULL,        -- 部屋ID
     retention_days INT NOT NULL DEFAULT 7, -- 自動削除までの日数
+    expires_at DATETIME NOT NULL,         -- 自動削除対象日時
     UNIQUE KEY uq_room_room_id (room_id),
     INDEX idx_room_id_password (id, password),
     INDEX idx_room_room_id (room_id),
-    INDEX idx_room_time (time)
+    INDEX idx_room_time (time),
+    INDEX idx_room_expires_at (expires_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 

--- a/db_init/migrate_search_scalability.sql
+++ b/db_init/migrate_search_scalability.sql
@@ -1,0 +1,157 @@
+-- Migration to add scalable search and expiration indexes.
+-- New rows write password_lookup_hash; legacy rows keep NULL and are handled
+-- by the application fallback until they expire.
+
+SET @db := DATABASE();
+
+SET @has_fsqr_table := (
+    SELECT COUNT(*)
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'fsqr'
+);
+
+SET @has_fsqr_password_lookup_hash := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'fsqr'
+      AND COLUMN_NAME = 'password_lookup_hash'
+);
+
+SET @sql := IF(
+    @has_fsqr_table = 1 AND @has_fsqr_password_lookup_hash = 0,
+    'ALTER TABLE fsqr ADD COLUMN password_lookup_hash VARCHAR(64) NULL',
+    'SELECT ''skip add fsqr.password_lookup_hash'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_fsqr_expires_at := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'fsqr'
+      AND COLUMN_NAME = 'expires_at'
+);
+
+SET @sql := IF(
+    @has_fsqr_table = 1 AND @has_fsqr_expires_at = 0,
+    'ALTER TABLE fsqr ADD COLUMN expires_at DATETIME NULL',
+    'SELECT ''skip add fsqr.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_fsqr_table = 1,
+    'UPDATE fsqr SET expires_at = DATE_ADD(time, INTERVAL retention_days DAY) WHERE expires_at IS NULL',
+    'SELECT ''skip backfill fsqr.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_fsqr_table = 1,
+    'ALTER TABLE fsqr MODIFY expires_at DATETIME NOT NULL',
+    'SELECT ''skip modify fsqr.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx_fsqr_id_password_lookup := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'fsqr'
+      AND INDEX_NAME = 'idx_fsqr_id_password_lookup'
+);
+
+SET @sql := IF(
+    @has_fsqr_table = 1 AND @has_idx_fsqr_id_password_lookup = 0,
+    'ALTER TABLE fsqr ADD INDEX idx_fsqr_id_password_lookup (id, password_lookup_hash)',
+    'SELECT ''skip add fsqr.idx_fsqr_id_password_lookup'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx_fsqr_expires_at := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'fsqr'
+      AND INDEX_NAME = 'idx_fsqr_expires_at'
+);
+
+SET @sql := IF(
+    @has_fsqr_table = 1 AND @has_idx_fsqr_expires_at = 0,
+    'ALTER TABLE fsqr ADD INDEX idx_fsqr_expires_at (expires_at)',
+    'SELECT ''skip add fsqr.idx_fsqr_expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_room_table := (
+    SELECT COUNT(*)
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'room'
+);
+
+SET @has_room_expires_at := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'room'
+      AND COLUMN_NAME = 'expires_at'
+);
+
+SET @sql := IF(
+    @has_room_table = 1 AND @has_room_expires_at = 0,
+    'ALTER TABLE room ADD COLUMN expires_at DATETIME NULL',
+    'SELECT ''skip add room.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_room_table = 1,
+    'UPDATE room SET expires_at = DATE_ADD(time, INTERVAL retention_days DAY) WHERE expires_at IS NULL',
+    'SELECT ''skip backfill room.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_room_table = 1,
+    'ALTER TABLE room MODIFY expires_at DATETIME NOT NULL',
+    'SELECT ''skip modify room.expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx_room_expires_at := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db
+      AND TABLE_NAME = 'room'
+      AND INDEX_NAME = 'idx_room_expires_at'
+);
+
+SET @sql := IF(
+    @has_room_table = 1 AND @has_idx_room_expires_at = 0,
+    'ALTER TABLE room ADD INDEX idx_room_expires_at (expires_at)',
+    'SELECT ''skip add room.idx_room_expires_at'''
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/models.py
+++ b/models.py
@@ -30,10 +30,8 @@ class RoomSearchInput(BaseModel):
     @classmethod
     def validate_room_id(cls, v: str) -> str:
         v = v.strip()
-        if not _ALNUM_RE.match(v):
-            raise ValueError(
-                "IDに無効な文字が含まれています。半角英数字のみ使用してください。"
-            )
+        if not _ROOM_ID_RE.match(v):
+            raise ValueError("IDは6文字の半角英数字で入力してください。")
         return v
 
     @field_validator("password")

--- a/tests/test_data_layers.py
+++ b/tests/test_data_layers.py
@@ -20,7 +20,7 @@ def test_fsqr_data_save_lookup_remove_and_expiration(tmp_path):
             return data_rows
         if fetch and "WHERE secure_id" in str(query):
             return data_rows
-        if fetch and "DATE_ADD" in str(query):
+        if fetch and "expires_at <= NOW" in str(query):
             return [{"secure_id": "secure1"}]
         if fetch:
             return [{"secure_id": "secure1"}, {"secure_id": ""}]
@@ -70,6 +70,11 @@ def test_fsqr_data_save_lookup_remove_and_expiration(tmp_path):
 
     run(scenario())
     assert any("INSERT INTO fsqr" in query for query, _, _ in calls)
+    assert any(
+        "password_lookup_hash" in query and "WHERE id" in query
+        for query, _, fetch in calls
+        if fetch
+    )
     assert any("DELETE FROM fsqr" in query for query, _, _ in calls)
 
 
@@ -86,7 +91,7 @@ def test_group_data_room_lifecycle_and_expiration(tmp_path):
             return [{"room_id": "roomA", "password": hashed}]
         if fetch and "WHERE room_id" in str(query):
             return [{"room_id": "roomA", "password": hashed}]
-        if fetch and "DATE_ADD" in str(query):
+        if fetch and "expires_at <= NOW" in str(query):
             return [{"room_id": "roomA"}, {"room_id": ""}]
         if fetch:
             return [{"room_id": "roomA"}, {"room_id": "roomB"}]

--- a/tests/test_fsqr.py
+++ b/tests/test_fsqr.py
@@ -605,6 +605,12 @@ def test_try_login_invalid_id_chars(test_client: TestClient):
     assert "text/html" in response.headers["content-type"]
 
 
+def test_try_login_invalid_id_length(test_client: TestClient):
+    response = test_client.post("/try_login", data={"name": "abc12", "pw": "123456"})
+    assert response.status_code == 400
+    assert "6文字" in response.text
+
+
 def test_try_login_invalid_pw_chars(test_client: TestClient):
     response = test_client.post("/try_login", data={"name": "abc123", "pw": "abc"})
     assert response.status_code == 400

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -187,6 +187,15 @@ def test_search_group_invalid_id_chars(test_client: TestClient):
     assert "ID" in response.text
 
 
+def test_search_group_invalid_id_length(test_client: TestClient):
+    response = test_client.post(
+        "/search_group_process",
+        data={"id": "abc12", "password": "123456"},
+    )
+    assert response.status_code == 400
+    assert "6文字" in response.text
+
+
 def test_search_group_invalid_password_chars(test_client: TestClient):
     response = test_client.post(
         "/search_group_process",

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -75,6 +75,15 @@ def test_search_note_invalid_id_chars(test_client: TestClient):
     assert response.status_code == 400
 
 
+def test_search_note_invalid_id_length(test_client: TestClient):
+    response = test_client.post(
+        "/search_note_process",
+        data={"id": "abc12", "password": "123456"},
+    )
+    assert response.status_code == 400
+    assert "6文字" in response.text
+
+
 def test_search_note_invalid_password_chars(test_client: TestClient):
     response = test_client.post(
         "/search_note_process",


### PR DESCRIPTION
## Summary

- Add an indexed FSQR credential lookup hash so ID/password search does not scan every matching ID row.
- Add `expires_at` columns and indexes for FSQR and Group cleanup queries, replacing per-row `DATE_ADD(...)` filters.
- Tighten search ID validation to the documented 6-character alphanumeric format and cover it with tests.

## Why

FSQR search previously selected every row for a shared ID and verified each password hash in Python. As duplicate IDs or total data grew, a single search could turn into many expensive scrypt checks. Expiration cleanup for FSQR and Group also computed expiry per row, which does not scale well with larger tables.

## Notes

Existing FSQR rows cannot have the new lookup hash fully backfilled because their original password is intentionally not recoverable from the stored scrypt hash. They remain supported through a legacy `password_lookup_hash IS NULL` fallback until they expire; new rows use the indexed lookup path.

## Validation

- `python3 -m black --check FSQR/fsqr_data.py Group/group_data.py models.py tests/test_data_layers.py tests/test_fsqr.py tests/test_group.py tests/test_note.py alembic/versions/20260710_0008_search_scalability.py`
- `python3 -m pytest`