### PR TITLE
Add copy button to ID field on download page

### DIFF
--- a/FSQR/templates/fs_qr_info/_content.html
+++ b/FSQR/templates/fs_qr_info/_content.html
@@ -157,7 +157,13 @@
               <div class="room-info-row">
                 <span class="room-info-label">ID</span>
                 <span class="room-info-value">
-                  <span class="room-info-value-text">{{ id | e }}</span>
+                  <span class="room-info-value-row">
+                    <span class="room-info-value-text">{{ id | e }}</span>
+                    <button type="button" class="copy-inline-btn copy-url-button" data-copy-value="{{ id | e }}" data-default-label="コピー" data-copied-label="コピー済み" aria-label="IDをコピー">
+                      <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1Zm4 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h12v14Z"/></svg>
+                      <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>
+                    </button>
+                  </span>
                 </span>
               </div>
               {% if password %}


### PR DESCRIPTION
## Summary
- The `/download/{secure_id}` page's ID row was missing a copy button, while the password row directly below it already had one.
- Added a copy button to the ID row matching the existing password row's markup/behavior (same `.copy-inline-btn.copy-url-button` pattern, wired up by the existing generic copy handler in `_scripts.html`).

## Test plan
- [x] Verified the Jinja template renders without errors and produces the expected `<button class="copy-inline-btn copy-url-button" data-copy-value="...">` markup for the ID field in `mode="download"`.
- [ ] Manually click the new copy button on the download page and confirm the ID is copied to clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)