### PR TITLE
Fix note action hover jitter

### DIFF
--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -308,41 +308,13 @@ footer.simple-footer {
   color: var(--theme-note-char-count-text);
   line-height: 1;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.note-action-button::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  bottom: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.75);
-  color: #fff;
-  font-size: 0.75rem;
-  font-weight: 600;
-  white-space: nowrap;
-  padding: 0.25rem 0.55rem;
-  border-radius: 4px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.note-action-button:hover::after,
-.note-action-button:focus-visible::after {
-  opacity: 1;
+  transition: box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .note-action-button:hover,
 .note-action-button:focus-visible {
-  transform: translateY(-1px);
   box-shadow: var(--theme-note-action-shadow);
   background: var(--theme-note-action-background-hover);
-}
-
-.note-action-button:active {
-  transform: translateY(0);
 }
 
 .note-action-button .note-action-icon-check {


### PR DESCRIPTION
## Summary
- stop moving the note editor paste and copy buttons on hover
- remove the duplicate local tooltip, using the shared fixed-position tooltip instead

## Root cause
The action buttons rendered an in-flow local tooltip in addition to the shared global tooltip, while also shifting upward on hover. This could change the scrollable area and make the page jump vertically.

## Validation
- `python3 -m pytest tests/test_note.py` (29 passed)

## Manual verification
- In a note room, hover the paste and full-copy buttons at the lower right of the editor.
- Confirm the tooltip appears and the page does not move vertically.