### PR TITLE
トップ＆メニューで広告・GAタグを読み込むよう修正

### DIFF
--- a/FSQR/templates/fs-qr.html
+++ b/FSQR/templates/fs-qr.html
@@ -47,6 +47,12 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <script>
+      window.FSQR_TAGS = Object.freeze({
+        googleAnalyticsId: {{ google_analytics_id | tojson }},
+        adsenseClientId: {{ google_adsense_client_id | tojson }}
+      });
+    </script>
     <title>QRコードでファイル共有｜アプリ不要・無料でPC/スマホに送信 - FS!QR</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">

--- a/Group/templates/group.html
+++ b/Group/templates/group.html
@@ -46,6 +46,12 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <script>
+      window.FSQR_TAGS = Object.freeze({
+        googleAnalyticsId: {{ google_analytics_id | tojson }},
+        adsenseClientId: {{ google_adsense_client_id | tojson }}
+      });
+    </script>
     <title>グループでファイル共有｜アカウント不要・無料でチームに共有 - FS!QR Group</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">

--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -47,6 +47,12 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <script>
+      window.FSQR_TAGS = Object.freeze({
+        googleAnalyticsId: {{ google_analytics_id | tojson }},
+        adsenseClientId: {{ google_adsense_client_id | tojson }}
+      });
+    </script>
     <title>リアルタイム同時編集ノート｜登録不要・無料で共同作業 - FS!QR Note</title>
     <link rel="icon" href="{{staticfile('favicon.ico')}}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon.png')}}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,12 @@
   <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
   <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
   
+  <script>
+    window.FSQR_TAGS = Object.freeze({
+      googleAnalyticsId: {{ google_analytics_id | tojson }},
+      adsenseClientId: {{ google_adsense_client_id | tojson }}
+    });
+  </script>
   <title>無料QRコードファイル共有サービス｜アプリ不要でPC・スマホ間転送 - FS!QR</title>
   <link rel="icon" href="{{staticfile('favicon3.ico')}}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{staticfile('apple-touch-icon3.png')}}">


### PR DESCRIPTION
## 概要

トップページ（`/`）と各メニューページ（`/fs-qr_menu`・`/group_menu`・`/note_menu`）で、**Google AdSense と Google Analytics のタグが実際には一切読み込まれていなかった**問題を修正します。

## 原因

- 広告/計測ローダー `static/cookie-consent.js` は `window.FSQR_TAGS` からIDを読み取ってタグを差し込む。
- `window.FSQR_TAGS` を出力しているのは `layout.html` / `group_layout.html` / `note_layout.html` のみ。
- しかしトップ・各メニューは **layout を extends しない独立テンプレート**で `FSQR_TAGS` を出力しておらず、`getTagConfig()` が空になり `loadAdsense()` / `loadGoogleAnalytics()` が早期 return していた。
- `web.py` の `ADSENSE_ALLOWED_STATIC_PATHS` には `/`・`/fs-qr_menu`・`/group_menu` が含まれ**広告を出す意図**だったため、意図と実装が食い違っていた。

結果として、サイトで最もアクセスの多いトップ＆メニューで広告収益もアクセス解析も欠落していた。

## 変更内容

4つの独立テンプレートの `<head>`（`<title>` 直前）に、`layout.html` と同一の `window.FSQR_TAGS` 定義を追加：

- `templates/index.html`（`/`）
- `FSQR/templates/fs-qr.html`（`/fs-qr_menu`）
- `Group/templates/group.html`（`/group_menu`）
- `Note/templates/note_menu.html`（`/note_menu`）

サーバー側のロジック（許可リスト・変数注入）は変更なし。

## 挙動（実レンダリングで検証）

| ページ | adsenseClientId | googleAnalyticsId |
|---|---|---|
| `/` | `ca-pub-...`（広告あり） | `G-D26D8ZXKNV` |
| `/fs-qr_menu` | `ca-pub-...`（広告あり） | `G-D26D8ZXKNV` |
| `/group_menu` | `ca-pub-...`（広告あり） | `G-D26D8ZXKNV` |
| `/note_menu` | `null`（許可リスト外＝広告なし） | `G-D26D8ZXKNV` |

- 広告は許可リストにあるページでのみロード（`/note_menu` は従来どおり広告なし）。
- GA は同意後に全4ページで計測されるようになる。
- 広告・GAともに従来どおり Cookie 同意（marketing / analytics）を前提にロード。

## テスト

- `tests/test_basic_routes.py` + `tests/test_seo.py` … **50 passed**（デグレなし）
- 追加の実出力チェックで上表のとおり期待どおりであることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)