### PR TITLE
Recover from optional tag load failures

### DIFF
--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -79,17 +79,38 @@
     return window.FSQR_TAGS || {};
   }
 
-  function loadScriptOnce(src, attrs) {
-    if (!src || document.querySelector(`script[src="${src}"]`)) {
-      return;
+  function loadScriptOnce(src, attrs, onError) {
+    if (!src) {
+      return null;
     }
+
+    // Compare resolved URLs instead of interpolating the URL into a CSS
+    // selector. This also keeps a second consent action from adding a second
+    // copy of an optional third-party tag.
+    const existingScript = Array.from(document.scripts).find(
+      (script) => script.src === src
+    );
+    if (existingScript) {
+      return existingScript;
+    }
+
     const script = document.createElement('script');
     script.async = true;
     script.src = src;
     Object.keys(attrs || {}).forEach((key) => {
       script.setAttribute(key, attrs[key]);
     });
+    script.addEventListener('error', () => {
+      // Network errors and content blockers must not leave the consent UI in
+      // a permanently "loaded" state. The next explicit consent update can
+      // retry the optional tag without producing an unhandled Promise.
+      script.remove();
+      if (typeof onError === 'function') {
+        onError();
+      }
+    }, { once: true });
     document.head.appendChild(script);
+    return script;
   }
 
   function loadGoogleAnalytics() {
@@ -104,7 +125,13 @@
     };
     window.gtag('js', new Date());
     window.gtag('config', measurementId);
-    loadScriptOnce(`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`);
+    loadScriptOnce(
+      `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`,
+      null,
+      () => {
+        analyticsLoaded = false;
+      }
+    );
   }
 
   function loadAdsense() {
@@ -115,7 +142,10 @@
     adsLoaded = true;
     loadScriptOnce(
       `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${encodeURIComponent(clientId)}`,
-      { crossorigin: 'anonymous' }
+      { crossorigin: 'anonymous' },
+      () => {
+        adsLoaded = false;
+      }
     );
   }
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -314,6 +314,16 @@ def test_cookie_consent_script_uses_rendered_supported_language_list():
     assert "['ja', 'en', 'zh-CN', 'zh-TW', 'ko']" not in source
 
 
+def test_optional_tag_loader_recovers_from_external_script_errors():
+    source = Path("static/cookie-consent.js").read_text(encoding="utf-8")
+
+    assert "Array.from(document.scripts)" in source
+    assert "script.addEventListener('error'" in source
+    assert "script.remove();" in source
+    assert "analyticsLoaded = false;" in source
+    assert "adsLoaded = false;" in source
+
+
 def test_language_options_never_expose_translation_keys():
     import i18n
 


### PR DESCRIPTION
## Summary

- Remove failed optional third-party tag scripts and reset their load state.
- Prevent duplicate AdSense and Analytics script insertion after consent changes.
- Add a regression test for external-script error recovery.

## Root cause

A failed AdSense or Analytics request could leave the client-side loader marked as loaded for the rest of the page session, preventing a later consent update from retrying it.

## Validation

- `node --check static/cookie-consent.js`
- `python3 -m pytest tests/test_i18n.py tests/test_basic_routes.py -q` (60 passed)
- `git diff --check`