### PR TITLE
READMEを実装に合わせて修正 / Fix README to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ TRUSTED_PROXY_HOSTS=127.0.0.1,::1
 RUN_MIGRATIONS_ON_STARTUP=true
 ALLOW_START_WITHOUT_DB=false
 FRONTEND_DEBUG=false
-UPLOAD_MAX_FILES=10
+UPLOAD_MAX_FILES=30
 UPLOAD_MAX_TOTAL_SIZE_MB=500
 GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
@@ -74,8 +74,13 @@ preflight first when changing images or reusing an existing volume:
 ./scripts/docker_preflight.sh
 ```
 
+The web app runs as Blue-Green slots (`web-blue` / `web-green`) that are gated behind
+Compose profiles, so a bare `docker compose up` starts only `db`, `redis`, and
+`scheduler`. For local use, start the `blue` slot explicitly so the app is served on
+`127.0.0.1:5000`:
+
 ```bash
-docker-compose up --build
+docker compose --profile blue up --build
 ```
 
 ### 4) Open in your browser
@@ -214,7 +219,11 @@ If the token passed from the page rendered in the same session does not match, t
   `pytest` suite on Python 3.13 and 3.14 for every push, pull request, and manual dispatch.
 - The deploy job runs only on pushes to `main` after the CI job succeeds.
 - If deployment secrets are not configured yet, the deploy phase is skipped so regular CI stays green.
-- Deployment connects over SSH, updates the server checkout, rebuilds with `docker compose up -d --build`, and rolls back to the previous Git commit if deployment fails.
+- Deployment connects over SSH, updates the server checkout, brings up `db`/`redis`,
+  and performs a zero-downtime Blue-Green switch via `scripts/deploy_bluegreen.sh`
+  (build the inactive color → wait for `/healthz` → switch the nginx backend → drain
+  the old color). If the switch cannot complete, the previous color stays live and the
+  Git tree is rolled back to the previous commit.
 
 ### Required GitHub Secrets
 - `SERVER_HOST`: deployment server hostname or IP
@@ -288,10 +297,11 @@ ADMIN_KEY=admin
 MANAGEMENT_PASSWORD=manage
 DB_ADMIN_PASSWORD=db-admin
 REDIS_URL=redis://redis:6379/0
+TRUSTED_PROXY_HOSTS=127.0.0.1,::1
 RUN_MIGRATIONS_ON_STARTUP=true
 ALLOW_START_WITHOUT_DB=false
 FRONTEND_DEBUG=false
-UPLOAD_MAX_FILES=10
+UPLOAD_MAX_FILES=30
 UPLOAD_MAX_TOTAL_SIZE_MB=500
 GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
@@ -308,8 +318,13 @@ NOTE_SELF_EDIT_TIMEOUT_MS=12000
 ./scripts/docker_preflight.sh
 ```
 
+web アプリは Compose profiles でゲートされた Blue-Green スロット（`web-blue` /
+`web-green`）として動くため、素の `docker compose up` では `db`・`redis`・`scheduler`
+のみが起動します。ローカルで利用する場合は `blue` スロットを明示的に起動し、
+`127.0.0.1:5000` でアプリを配信します。
+
 ```bash
-docker-compose up --build
+docker compose --profile blue up --build
 ```
 
 ### 4) ブラウザでアクセス
@@ -444,7 +459,7 @@ Note / Group の WebSocket 接続では、HTTP セッションと紐づく CSRF 
   イメージ検査、および Python 3.13/3.14 の完全な `pytest` を実行します。
 - `main` への push 時のみ、CI 成功後に SSH 経由で本番デプロイを行います。
 - デプロイ用 secrets が未設定の間は deploy を skip するため、通常の CI は失敗しません。
-- デプロイではサーバー上の checkout を更新し、`docker compose up -d --build` を実行し、失敗時は直前コミットへロールバックします。
+- デプロイではサーバー上の checkout を更新し、`db`/`redis` を起動したうえで、`scripts/deploy_bluegreen.sh` による無停止 Blue-Green 切替（非アクティブ色をビルド → `/healthz` を待機 → nginx の backend を切替 → 旧色を drain）を実行します。切替が完了できない場合は旧色を生かしたまま、Git ツリーを直前コミットへロールバックします。
 
 ### 必要な GitHub Secrets
 - `SERVER_HOST`: デプロイ先サーバーのホスト名またはIP


### PR DESCRIPTION
## 日本語

READMEの記載と実装の照合で見つかった矛盾を修正しました。

### 修正内容
1. **`UPLOAD_MAX_FILES` の値**（英語版・日本語版）
   - README `10` → 実装値 `30` に修正。`.env.example:21` および `settings.py:62`（`default=30`）と一致させました。AGENTS.md の「上限変更時は README / .env.example / 検証を一貫させる」方針に沿った修正です。
2. **Quick Start の起動コマンド**（英語版・日本語版）
   - `docker-compose.yml` では web サービス（`web-blue` / `web-green`）が Compose profiles でゲートされているため、素の `docker compose up --build` では `db` / `redis` / `scheduler` のみが起動し、`localhost:5000` に到達できませんでした。
   - `docker compose --profile blue up --build` に修正し、profiles 構成の説明を追記しました。
3. **デプロイ説明**（英語版・日本語版）
   - 「`docker compose up -d --build` で再ビルド」という記述を、実際の `.github/workflows/tests.yml` deploy ジョブが行う `scripts/deploy_bluegreen.sh` による無停止 Blue-Green 切替の説明へ修正しました。
4. **英日の整合**
   - 日本語版の `.env` 例に、英語版のみにあった `TRUSTED_PROXY_HOSTS` を追加しました。

### 検証
- ドキュメントのみの変更のため自動テストは未実行。
- 各記述を実装ファイル（`docker-compose.yml`、`.env.example`、`settings.py`、`.github/workflows/tests.yml`、`scripts/deploy_bluegreen.sh`）と突き合わせて確認済み。

### 補足（本PR対象外）
- `AGENTS.md` L15 にも「`docker-compose up --build` で FastAPI アプリと MySQL を起動」という同種の記述があります。必要であれば別途修正します。

## English

Fixes contradictions found between the README and the actual implementation.

### Changes
1. **`UPLOAD_MAX_FILES` value** (EN & JP): `10` → `30` to match `.env.example:21` and `settings.py:62` (`default=30`).
2. **Quick Start command** (EN & JP): the web service (`web-blue` / `web-green`) is gated behind Compose profiles, so a bare `docker compose up --build` never serves the app on `localhost:5000`. Changed to `docker compose --profile blue up --build` and documented the profiles behavior.
3. **Deploy description** (EN & JP): replaced the inaccurate `docker compose up -d --build` wording with the actual zero-downtime Blue-Green switch performed by `scripts/deploy_bluegreen.sh`.
4. **EN/JP consistency**: added `TRUSTED_PROXY_HOSTS` to the JP `.env` example.

### Verification
- Docs-only change; automated tests not run.
- Cross-checked each statement against `docker-compose.yml`, `.env.example`, `settings.py`, `.github/workflows/tests.yml`, and `scripts/deploy_bluegreen.sh`.

### Note (out of scope)
- `AGENTS.md` L15 contains a similar outdated claim about `docker-compose up --build`; can be fixed separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)