### PR TITLE
ノート操作ボタンのツールチップを修正 / Fix note action button tooltips

### DIFF
--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -110,11 +110,11 @@
                 <div class="note-editor-toolbar">
                     <span id="charCount" class="note-char-count" aria-live="polite">0 / {{ note_max_content_length }}文字</span>
                     <div class="note-editor-actions">
-                        <button type="button" id="pasteButton" class="note-action-button" aria-label="ペースト" data-tooltip="ペースト">
+                        <button type="button" id="pasteButton" class="note-action-button" aria-label="ペースト" data-tooltip="ペースト" data-tooltip-skip>
                             <svg class="note-action-icon-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
                             <svg class="note-action-icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                         </button>
-                        <button type="button" id="copyAllButton" class="note-action-button" aria-label="全文コピー" data-tooltip="全文コピー">
+                        <button type="button" id="copyAllButton" class="note-action-button" aria-label="全文コピー" data-tooltip="全文コピー" data-tooltip-skip>
                             <svg class="note-action-icon-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                             <svg class="note-action-icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                         </button>

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -311,6 +311,47 @@ footer.simple-footer {
   transition: box-shadow 0.2s ease, background 0.2s ease;
 }
 
+/* Local tooltip / ボタンを動かさず、ホバー時の揺れを防ぐ専用ツールチップ */
+.note-action-button::before,
+.note-action-button::after {
+  position: absolute;
+  left: 50%;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.note-action-button::before {
+  content: "";
+  bottom: calc(100% + 2px);
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: rgba(15, 23, 42, 0.96);
+}
+
+.note-action-button::after {
+  content: attr(data-tooltip);
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%);
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.96);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.22);
+}
+
+.note-action-button:hover::before,
+.note-action-button:hover::after,
+.note-action-button:focus-visible::before,
+.note-action-button:focus-visible::after {
+  opacity: 1;
+}
+
 .note-action-button:hover,
 .note-action-button:focus-visible {
   box-shadow: var(--theme-note-action-shadow);

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -146,6 +146,15 @@ def test_note_room_injects_realtime_limits_into_config(test_client: TestClient):
     assert 'data-share-url=""' in html
     assert "/static/qrcode.min.js" in html
     assert "api.qrserver.com" not in html
+    # Local tooltips remain available without reintroducing hover movement.
+    # 専用ツールチップがホバー移動を復活させずに描画されることを確認する。
+    assert 'id="pasteButton"' in html
+    assert 'data-tooltip="ペースト" data-tooltip-skip' in html
+    assert 'id="copyAllButton"' in html
+    assert 'data-tooltip="全文コピー" data-tooltip-skip' in html
+    assert ".note-action-button::after" in html
+    assert "content: attr(data-tooltip);" in html
+    assert ".note-action-button:hover::after" in html
 
 
 def test_note_share_entry_renders_room_without_redirect(test_client: TestClient):


### PR DESCRIPTION
## 日本語

### 概要
ノートルーム右下の「ペースト」「全文コピー」アイコンボタンで、ツールチップが表示されない不具合を修正します。

### 原因と変更内容
- ホバー時の揺れを直した過去の変更で、ボタンの移動効果と一緒に専用ツールチップCSSも削除されていました。
- ボタン自体を移動させず、マウスホバーとキーボードフォーカスで表示される専用ツールチップを復元しました。
- 共通ツールチップ処理との二重表示を防止しました。
- ツールチップ用の属性とCSSがレンダリングされることを確認する回帰テストを追加しました。

### 利用者への影響
ペースト／全文コピーの各アイコンへマウスを重ねるか、キーボードでフォーカスすると、操作名を確認できます。コピー／ペースト機能そのものの動作には変更ありません。

### 設定・マイグレーション
設定変更、データベースマイグレーション、ロールバック手順の追加は不要です。ロールバックはこのコミットのrevertで行えます。

### 自動テスト
- `python3 -m pytest tests/test_note.py -q`（29 passed）
- `python3 -m pytest -q`（609 passed）
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m mypy --config-file pyproject.toml`

### 手動確認
実ブラウザを利用できる実行環境がないため、画面操作とスクリーンショット取得は未実施です。レンダリング結果と回帰テストで、対象属性およびホバー／フォーカス用CSSの出力を確認しました。

### 関連Issue・レビュー
- 関連Issue: なし
- レビュー依頼先: Noteモジュール担当メンテナー

## English

### Summary
Fixes missing tooltips on the Paste and Copy all icon buttons at the bottom-right of the note room editor.

### Root cause and changes
- A previous hover-jitter fix removed the local tooltip CSS together with the button movement effect.
- Restored local tooltips that appear on mouse hover and keyboard focus without moving the buttons.
- Prevented duplicate rendering by the global tooltip handler.
- Added a regression test verifying that the tooltip attributes and CSS are rendered.

### User impact
Hovering over or keyboard-focusing the Paste and Copy all icons now reveals their action names. Clipboard behavior itself is unchanged.

### Configuration and migrations
No configuration changes, database migrations, or additional rollback steps are required. The change can be rolled back by reverting this commit.

### Automated checks
- `python3 -m pytest tests/test_note.py -q` (29 passed)
- `python3 -m pytest -q` (609 passed)
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m mypy --config-file pyproject.toml`

### Manual verification
Interactive browser verification and screenshots were not produced because this environment has no usable browser. The rendered output and regression test verify the target attributes and hover/focus CSS.

### Related issue and review
- Related issue: None
- Requested reviewer: Maintainer responsible for the Note module