### PR TITLE
ノートのPDF・TXT出力を追加 / Add PDF and TXT exports for notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
+# Docker では自動設定不要。独自フォントを使う場合のみ絶対パスを指定する。
+NOTE_PDF_FONT_PATH=
 
 # --- ファイル配信オフロード (nginx X-Accel-Redirect) ---
 # 本番（nginx 経由）では true 推奨。ダウンロードの実体転送を nginx に委譲する。

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PATH="/opt/venv/bin:$PATH" \
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
+        fonts-noto-cjk \
         libmagic1 \
         libmariadb3 \
     && rm -rf /var/lib/apt/lists/*

--- a/Note/note_api.py
+++ b/Note/note_api.py
@@ -2,11 +2,15 @@ import logging
 
 from fastapi import APIRouter, Request
 from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
+from starlette.responses import Response
 
 from api_response import api_error_response, api_ok_response
-from models import NoteSyncInput
+from file_validation import build_content_disposition_attachment
+from models import NoteExportInput, NoteSyncInput
 from . import note_data as nd
 from .note_access import has_note_room_access
+from .note_export import NotePdfFontUnavailableError, build_note_pdf
 from .note_sync import sync_note_content
 from web import enforce_csrf
 
@@ -18,6 +22,66 @@ router = APIRouter(prefix="/api")
 def _format_updated_at(updated_at):
     return (
         updated_at.isoformat(sep=" ", timespec="microseconds") if updated_at else None
+    )
+
+
+@router.post("/note/{room_id}/export/{export_format}", name="note.note_export")
+async def note_export(request: Request, room_id: str, export_format: str):
+    """現在のエディタ内容を TXT または PDF として返す。"""
+    await enforce_csrf(request)
+
+    if export_format not in {"txt", "pdf"}:
+        return api_error_response("unsupported export format", status_code=404)
+    if not has_note_room_access(request, room_id):
+        return api_error_response("room access is not established", status_code=404)
+
+    meta = await nd.get_room_meta_direct(room_id)
+    if not meta:
+        return api_error_response("room expired or deleted", status_code=410)
+    row = await nd.get_row(room_id)
+    if not row:
+        return api_error_response("room expired or not initialized", status_code=410)
+
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    try:
+        export_input = NoteExportInput.model_validate(
+            data if isinstance(data, dict) else {}
+        )
+    except ValidationError:
+        return api_error_response("Invalid request body", status_code=400)
+
+    filename = f"note-{room_id}.{export_format}"
+    headers = {
+        "Content-Disposition": build_content_disposition_attachment(filename),
+        "Cache-Control": "private, no-store",
+    }
+    if export_format == "txt":
+        return Response(
+            content=export_input.content.encode("utf-8"),
+            media_type="text/plain; charset=utf-8",
+            headers=headers,
+        )
+
+    try:
+        pdf_content = await run_in_threadpool(
+            build_note_pdf, export_input.content, room_id
+        )
+    except NotePdfFontUnavailableError:
+        logger.exception("PDF font is unavailable for note room %s", room_id)
+        return api_error_response(
+            "PDF export is temporarily unavailable", status_code=503
+        )
+    except Exception:
+        logger.exception("PDF export failed for note room %s", room_id)
+        return api_error_response("PDF export failed", status_code=500)
+
+    return Response(
+        content=pdf_content,
+        media_type="application/pdf",
+        headers=headers,
     )
 
 

--- a/Note/note_export.py
+++ b/Note/note_export.py
@@ -1,0 +1,75 @@
+"""ノート本文の PDF エクスポート処理。"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fpdf import FPDF
+
+
+class NotePdfFontUnavailableError(RuntimeError):
+    """PDF 用の日本語フォントが見つからない場合の例外。"""
+
+
+def _font_candidates() -> tuple[Path, ...]:
+    """Return portable Noto CJK font locations. / Noto CJK の候補を返す。"""
+    configured = os.getenv("NOTE_PDF_FONT_PATH", "").strip()
+    project_font = Path(__file__).resolve().parents[1] / "static" / "fonts"
+    home_font = Path.home() / ".fonts"
+    candidates = [
+        project_font / "NotoSansCJK-Regular.ttc",
+        project_font / "NotoSansJP-Regular.ttf",
+        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
+        Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc"),
+        Path("/usr/local/share/fonts/NotoSansCJK-Regular.ttc"),
+        home_font / "NotoSansCJK-Regular.ttc",
+    ]
+    if configured:
+        candidates.insert(0, Path(configured).expanduser())
+    return tuple(candidates)
+
+
+def find_note_pdf_font() -> Path:
+    """利用可能な日本語フォントを探す。"""
+    for candidate in _font_candidates():
+        if candidate.is_file():
+            return candidate.resolve()
+    raise NotePdfFontUnavailableError(
+        "Noto Sans CJK font is unavailable. Install fonts-noto-cjk or set "
+        "NOTE_PDF_FONT_PATH."
+    )
+
+
+def build_note_pdf(
+    content: str,
+    room_id: str,
+    *,
+    font_path: Path | None = None,
+) -> bytes:
+    """ノート本文を検索・コピー可能な PDF に変換する。"""
+    selected_font = (font_path or find_note_pdf_font()).resolve()
+    pdf = FPDF(format="A4")
+    pdf.set_margins(18, 18, 18)
+    pdf.set_auto_page_break(auto=True, margin=18)
+    pdf.set_title(f"FS!QR Note {room_id}")
+    pdf.set_author("FS!QR")
+    pdf.add_page()
+    # TTC files contain multiple regional faces; index 0 is the Japanese face.
+    # TTC は複数地域の書体を含み、index 0 が日本語書体です。
+    pdf.add_font(
+        "NotoSansCJK",
+        fname=selected_font,
+        collection_font_number=0,
+    )
+    pdf.set_font("NotoSansCJK", size=10.5)
+    # HarfBuzz handles complex scripts and bidirectional text when present.
+    # 複雑な文字体系や右横書きが含まれる場合も HarfBuzz で字形処理します。
+    pdf.set_text_shaping(True)
+    pdf.multi_cell(
+        w=0,
+        h=6.5,
+        text=content.replace("\t", "    ") or " ",
+        wrapmode="CHAR",
+    )
+    return bytes(pdf.output())

--- a/Note/templates/note_room_partials/_content.html
+++ b/Note/templates/note_room_partials/_content.html
@@ -110,6 +110,12 @@
                 <div class="note-editor-toolbar">
                     <span id="charCount" class="note-char-count" aria-live="polite">0 / {{ note_max_content_length }}文字</span>
                     <div class="note-editor-actions">
+                        <button type="button" id="txtDownloadButton" class="note-action-button note-export-button" aria-label="TXTとしてダウンロード" data-tooltip="TXTとしてダウンロード" data-tooltip-skip>
+                            <span aria-hidden="true">TXT</span>
+                        </button>
+                        <button type="button" id="pdfDownloadButton" class="note-action-button note-export-button" aria-label="PDFとしてダウンロード" data-tooltip="PDFとしてダウンロード" data-tooltip-skip>
+                            <span aria-hidden="true">PDF</span>
+                        </button>
                         <button type="button" id="pasteButton" class="note-action-button" aria-label="ペースト" data-tooltip="ペースト" data-tooltip-skip>
                             <svg class="note-action-icon-default" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
                             <svg class="note-action-icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>

--- a/Note/templates/note_room_partials/_scripts.html
+++ b/Note/templates/note_room_partials/_scripts.html
@@ -167,5 +167,6 @@
 <script src="{{staticfile('js/note_room_realtime/self-edit.js')}}"></script>
 <script src="{{staticfile('js/note_room_realtime/sync.js')}}"></script>
 <script src="{{staticfile('js/note_room_realtime/clipboard.js')}}"></script>
+<script src="{{staticfile('js/note_room_realtime/export.js')}}"></script>
 <script src="{{staticfile('js/note_room_realtime/socket.js')}}"></script>
 <script src="{{staticfile('js/note_room_realtime/main.js')}}"></script>

--- a/Note/templates/note_room_partials/_styles.html
+++ b/Note/templates/note_room_partials/_styles.html
@@ -374,4 +374,18 @@ footer.simple-footer {
 .note-action-button.copied .note-action-icon-check {
   display: inline-flex;
 }
+
+.note-export-button {
+  width: auto;
+  min-width: 2.8rem;
+  padding-inline: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.note-action-button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
 </style>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
+# Optional path to a Noto Sans CJK-compatible TTF/TTC font for PDF exports.
+NOTE_PDF_FONT_PATH=
 ```
 
 ### 3) Run the stack
@@ -201,6 +203,11 @@ The ACK timeout is not a fixed value either — it adapts to the communication R
 For Note / Group WebSocket connections, a CSRF token tied to the HTTP session is validated during the handshake.
 If the token passed from the page rendered in the same session does not match, the handshake is rejected.
 
+The Note page can export the current editor content as UTF-8 TXT or PDF. Docker
+installs Noto Sans CJK automatically so Japanese text is embedded in the PDF. For
+a native non-Docker installation, install a Noto Sans CJK font or set
+`NOTE_PDF_FONT_PATH` to a compatible `.ttf` / `.ttc` file.
+
 ## 🧰 Tech Stack
 - **FastAPI** (Python 3.14 / Debian 13 trixie)
 - **MySQL 8.4.10 LTS**
@@ -307,6 +314,8 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
+# PDF出力へ使用する Noto Sans CJK 互換フォントのパス（通常は未指定で可）
+NOTE_PDF_FONT_PATH=
 ```
 
 ### 3) 起動
@@ -440,6 +449,11 @@ ACK タイムアウトは固定ではなく、`NOTE_SELF_EDIT_TIMEOUT_MS` を下
 
 Note / Group の WebSocket 接続では、HTTP セッションと紐づく CSRF トークンをハンドシェイク時に検証します。
 同一セッションで生成されたトークンが一致しない接続は拒否されます。
+
+ノートページでは、現在のエディタ内容を UTF-8 のTXTまたはPDFとして出力できます。
+Docker環境では Noto Sans CJK を自動インストールし、日本語フォントをPDFへ埋め込みます。
+Dockerを使わない環境では Noto Sans CJK をインストールするか、互換性のある
+`.ttf` / `.ttc` ファイルを `NOTE_PDF_FONT_PATH` に指定してください。
 
 ## 🧰 技術スタック
 - **FastAPI** (Python 3.14 / Debian 13 trixie)

--- a/models.py
+++ b/models.py
@@ -140,3 +140,9 @@ class NoteSyncInput(BaseModel):
     content: str = Field(default="", max_length=NOTE_MAX_CONTENT_LENGTH)
     base_version: int = Field(ge=0)
     original_content: str = Field(max_length=NOTE_MAX_CONTENT_LENGTH)
+
+
+class NoteExportInput(BaseModel):
+    """ノートの TXT / PDF 出力 API の POST ボディ。"""
+
+    content: str = Field(default="", max_length=NOTE_MAX_CONTENT_LENGTH)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,12 @@ APScheduler==3.11.3
 async-timeout==5.0.1
 click==8.4.2
 cryptography==49.0.0
+defusedxml==0.7.1
 diff-match-patch==20241021
 exceptiongroup==1.3.1
 fastapi==0.139.0
+fonttools==4.63.0
+fpdf2==2.8.7
 greenlet==3.5.3
 gunicorn==26.0.0
 h11==0.16.0
@@ -19,6 +22,7 @@ Jinja2==3.1.6
 MarkupSafe==3.0.3
 maxminddb==3.1.1
 mysqlclient==2.2.8
+Pillow==12.3.0
 packaging==26.2
 pydantic==2.13.4
 pydantic_core==2.46.4
@@ -33,6 +37,7 @@ starsessions==2.2.1
 typing-inspection==0.4.2
 typing_extensions==4.16.0
 tzlocal==5.4.4
+uharfbuzz==0.55.0
 uvicorn==0.51.0
 websockets==16.1
 Werkzeug==3.1.8

--- a/static/js/note_room_realtime/core.js
+++ b/static/js/note_room_realtime/core.js
@@ -104,6 +104,8 @@
       charCount: document.getElementById("charCount"),
       pasteButton: document.getElementById("pasteButton"),
       copyAllButton: document.getElementById("copyAllButton"),
+      txtDownloadButton: document.getElementById("txtDownloadButton"),
+      pdfDownloadButton: document.getElementById("pdfDownloadButton"),
       MAX_LENGTH: maxLength,
       selfEditTimeoutMs: selfEditTimeoutMs,
 	      lastStamp: "",

--- a/static/js/note_room_realtime/export.js
+++ b/static/js/note_room_realtime/export.js
@@ -1,0 +1,88 @@
+(function (window) {
+  const appNamespace = window.__FSQR_APP__;
+  if (!appNamespace || !appNamespace.api) {
+    throw new Error("App namespace is not initialized.");
+  }
+  const modules = appNamespace.api.getModuleNamespace("noteRoomRealtime");
+
+  function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? (meta.getAttribute("content") || "") : "";
+  }
+
+  function showFeedback(message, kind) {
+    if (typeof window.setShareFeedback === "function") {
+      window.setShareFeedback(message, kind);
+      return;
+    }
+    if (kind === "error") {
+      window.alert(message);
+    }
+  }
+
+  function saveBlob(blob, filename) {
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = filename;
+    link.hidden = true;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(function () {
+      URL.revokeObjectURL(objectUrl);
+    }, 0);
+  }
+
+  function createExportHandlers(context) {
+    const core = modules.core;
+
+    async function download(format, button) {
+      if (!button || button.disabled) {
+        return;
+      }
+      button.disabled = true;
+      try {
+        const response = await fetch(
+          `/api/note/${encodeURIComponent(context.room)}/export/${format}`,
+          {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRF-Token": getCsrfToken()
+            },
+            body: JSON.stringify({ content: context.editor.value })
+          }
+        );
+        if (!response.ok) {
+          throw new Error(`Export failed with status ${response.status}`);
+        }
+        saveBlob(await response.blob(), `note-${context.room}.${format}`);
+        showFeedback(core.translate("download.complete", "Download complete!"), "success");
+      } catch (error) {
+        context.logger.error("Note export failed.", error);
+        showFeedback(core.translate("download.error", "An error occurred during the download."), "error");
+      } finally {
+        button.disabled = false;
+      }
+    }
+
+    function bindButtons() {
+      if (context.txtDownloadButton) {
+        context.txtDownloadButton.addEventListener("click", function () {
+          download("txt", context.txtDownloadButton);
+        });
+      }
+      if (context.pdfDownloadButton) {
+        context.pdfDownloadButton.addEventListener("click", function () {
+          download("pdf", context.pdfDownloadButton);
+        });
+      }
+    }
+
+    return { bindButtons: bindButtons };
+  }
+
+  modules.export = { createExportHandlers: createExportHandlers };
+})(window);

--- a/static/js/note_room_realtime/main.js
+++ b/static/js/note_room_realtime/main.js
@@ -10,10 +10,12 @@
   context.logger = modules.core.createLogger(Boolean(config.debug));
   const syncHandlers = modules.sync.createSyncHandlers(context);
   const clipboardHandlers = modules.clipboard.createClipboardHandlers(context);
+  const exportHandlers = modules.export.createExportHandlers(context);
   const socketHandlers = modules.socket.createSocketHandlers(context, syncHandlers);
 
   syncHandlers.bindEditorInput();
   clipboardHandlers.bindButtons();
+  exportHandlers.bindButtons();
   modules.ui.updateCharCount(context, context.editor.value);
   socketHandlers.connectWebSocket();
 })(window);

--- a/tests/test_note_export.py
+++ b/tests/test_note_export.py
@@ -1,0 +1,156 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from Note.note_export import build_note_pdf
+from settings import NOTE_MAX_CONTENT_LENGTH
+
+
+ROOM_ID = "abc123"
+ROOM_META = {"id": ROOM_ID, "retention_days": 7, "expires_at": None}
+ROOM_ROW = {"content": "saved", "updated_at": object(), "version": 1}
+
+
+def _export_patches(*, has_access=True, meta=ROOM_META, row=ROOM_ROW):
+    return (
+        patch("Note.note_api.has_note_room_access", return_value=has_access),
+        patch(
+            "Note.note_api.nd.get_room_meta_direct",
+            new_callable=AsyncMock,
+            return_value=meta,
+        ),
+        patch(
+            "Note.note_api.nd.get_row",
+            new_callable=AsyncMock,
+            return_value=row,
+        ),
+    )
+
+
+def test_note_export_txt_returns_current_editor_content(test_client):
+    content = "現在の本文\nsecond line"
+    access_patch, meta_patch, row_patch = _export_patches()
+    with access_patch, meta_patch, row_patch:
+        response = test_client.post(
+            f"/api/note/{ROOM_ID}/export/txt",
+            json={"content": content},
+        )
+
+    assert response.status_code == 200
+    assert response.content == content.encode("utf-8")
+    assert response.headers["content-type"].startswith("text/plain; charset=utf-8")
+    assert response.headers["cache-control"] == "private, no-store"
+    assert f'filename="note-{ROOM_ID}.txt"' in response.headers["content-disposition"]
+
+
+def test_note_export_pdf_returns_attachment(test_client):
+    access_patch, meta_patch, row_patch = _export_patches()
+    with (
+        access_patch,
+        meta_patch,
+        row_patch,
+        patch("Note.note_api.build_note_pdf", return_value=b"%PDF-test") as build,
+    ):
+        response = test_client.post(
+            f"/api/note/{ROOM_ID}/export/pdf",
+            json={"content": "未保存の本文"},
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"%PDF-test"
+    assert response.headers["content-type"] == "application/pdf"
+    assert response.headers["cache-control"] == "private, no-store"
+    assert f'filename="note-{ROOM_ID}.pdf"' in response.headers["content-disposition"]
+    build.assert_called_once_with("未保存の本文", ROOM_ID)
+
+
+def test_note_export_requires_room_access(test_client):
+    access_patch, meta_patch, row_patch = _export_patches(has_access=False)
+    with access_patch, meta_patch as get_meta, row_patch as get_row:
+        response = test_client.post(
+            f"/api/note/{ROOM_ID}/export/txt", json={"content": "secret"}
+        )
+
+    assert response.status_code == 404
+    get_meta.assert_not_awaited()
+    get_row.assert_not_awaited()
+
+
+def test_note_export_requires_csrf_token(test_client):
+    response = asyncio.run(
+        test_client._raw_request(
+            "POST",
+            f"/api/note/{ROOM_ID}/export/txt",
+            json={"content": "secret"},
+        )
+    )
+
+    assert response.status_code == 403
+
+
+def test_note_export_rejects_expired_room(test_client):
+    access_patch, meta_patch, row_patch = _export_patches(meta=None)
+    with access_patch, meta_patch, row_patch as get_row:
+        response = test_client.post(
+            f"/api/note/{ROOM_ID}/export/txt", json={"content": "secret"}
+        )
+
+    assert response.status_code == 410
+    get_row.assert_not_awaited()
+
+
+def test_note_export_rejects_missing_content_row(test_client):
+    access_patch, meta_patch, row_patch = _export_patches(row=None)
+    with access_patch, meta_patch, row_patch:
+        response = test_client.post(
+            f"/api/note/{ROOM_ID}/export/txt", json={"content": "secret"}
+        )
+
+    assert response.status_code == 410
+
+
+def test_note_export_validates_format_and_content_length(test_client):
+    access_patch, meta_patch, row_patch = _export_patches()
+    with access_patch, meta_patch, row_patch:
+        invalid_format = test_client.post(
+            f"/api/note/{ROOM_ID}/export/docx", json={"content": "text"}
+        )
+        too_long = test_client.post(
+            f"/api/note/{ROOM_ID}/export/txt",
+            json={"content": "a" * (NOTE_MAX_CONTENT_LENGTH + 1)},
+        )
+
+    assert invalid_format.status_code == 404
+    assert too_long.status_code == 400
+
+
+def test_note_export_buttons_are_rendered(test_client):
+    with (
+        patch("Note.note_app.has_note_room_access", return_value=True),
+        patch(
+            "Note.note_app._get_room_if_valid",
+            new_callable=AsyncMock,
+            return_value=ROOM_META,
+        ),
+        patch(
+            "Note.note_app.nd.get_row",
+            new_callable=AsyncMock,
+            return_value=ROOM_ROW,
+        ),
+    ):
+        response = test_client.get(f"/note/r/{ROOM_ID}")
+
+    assert response.status_code == 200
+    assert 'id="txtDownloadButton"' in response.text
+    assert 'id="pdfDownloadButton"' in response.text
+    assert "/static/js/note_room_realtime/export.js" in response.text
+
+
+def test_build_note_pdf_preserves_plain_text_safely():
+    font_path = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+    content = "first line\n<tag> & second line\n" + ("long-word " * 500)
+
+    pdf = build_note_pdf(content, ROOM_ID, font_path=font_path)
+
+    assert pdf.startswith(b"%PDF-")
+    assert len(pdf) > 1_000


### PR DESCRIPTION
## 日本語

### 概要
- ノート画面のエディターツールバーへ TXT / PDF ダウンロードボタンを追加しました。
- ボタン押下時の現在のエディター内容を送信するため、約1秒の自動保存前の入力も出力に含まれます。
- ルームセッション認可、CSRF、本文長上限、有効期限を確認するエクスポートAPIを追加しました。
- TXTはUTF-8、PDFは日本語対応フォントを部分埋め込みして返し、レスポンスは `private, no-store` としています。

### 依存関係・設定
- Web検索で公式情報を確認し、最新安定版 `fpdf2==2.8.7`、`fonttools==4.63.0`、`Pillow==12.3.0`、`uharfbuzz==0.55.0` を固定しました。
- Dockerイメージへ `fonts-noto-cjk` を追加しました。
- Docker以外では必要に応じて `NOTE_PDF_FONT_PATH` で互換TTF/TTCを指定できます。
- DBスキーマ変更・マイグレーション・停止時間はありません。
- ロールバックはこのコミットを戻してDockerイメージを再ビルドします。データ変更はないためデータ復旧は不要です。

### 自動テスト
- `.venv/bin/python3 -m pytest -q`: 618 passed
- `.venv/bin/python3 -m ruff check .`: passed
- `.venv/bin/python3 -m ruff format --check .`: passed
- `.venv/bin/python3 -m mypy --config-file pyproject.toml`: passed
- `.venv/bin/python3 scripts/validate_locales.py --strict-phrases`: passed
- `.venv/bin/pip-audit -r requirements.txt --no-deps --disable-pip`: vulnerabilities not found
- `docker build --tag fs-qr-note-export-test .`: passed

### 手動確認
- Dockerコンテナ内のPython 3.14で `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc` を読み込み、日本語・改行・長い行を含むPDF 1.6を生成し、フォント埋め込みを確認しました。
- 確認対象URL: `/note/r/{room_id}`
- UIスクリーンショットは、ローカル環境にヘッドレスブラウザがないため未取得です。
- Redis停止時の手動確認は未実施です。エクスポート処理はRedis/WebSocketを変更せず、HTTPセッションとDBのルーム有効性のみを参照します。
- 関連Issue: なし

## English

### Summary
- Added TXT and PDF download buttons to the editor toolbar on the Note room page.
- The current editor value is submitted on click, so edits made before the roughly one-second autosave are included.
- Added an export API that validates the room session, CSRF token, content-length limit, and room expiration.
- TXT is returned as UTF-8. PDF embeds a Japanese-capable font subset, and both responses use `private, no-store`.

### Dependencies and configuration
- Verified official sources via web search and pinned the latest stable versions: `fpdf2==2.8.7`, `fonttools==4.63.0`, `Pillow==12.3.0`, and `uharfbuzz==0.55.0`.
- Added `fonts-noto-cjk` to the Docker image.
- Native non-Docker installations may set `NOTE_PDF_FONT_PATH` to a compatible TTF/TTC file.
- No database schema change, migration, or downtime is required.
- Roll back by reverting this commit and rebuilding the Docker image. No data recovery is needed because no stored data is changed.

### Automated validation
- `.venv/bin/python3 -m pytest -q`: 618 passed
- `.venv/bin/python3 -m ruff check .`: passed
- `.venv/bin/python3 -m ruff format --check .`: passed
- `.venv/bin/python3 -m mypy --config-file pyproject.toml`: passed
- `.venv/bin/python3 scripts/validate_locales.py --strict-phrases`: passed
- `.venv/bin/pip-audit -r requirements.txt --no-deps --disable-pip`: no known vulnerabilities
- `docker build --tag fs-qr-note-export-test .`: passed

### Manual validation
- In the Python 3.14 Docker container, generated a PDF 1.6 containing Japanese text, line breaks, and a long line using `/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc`, and confirmed font embedding.
- URL checked: `/note/r/{room_id}`
- A UI screenshot was not captured because no headless browser is available in the local environment.
- Redis-unavailable behavior was not manually tested. The export path does not change Redis/WebSocket code and only reads the HTTP session and database room validity.
- Related issue: none
