### PR TITLE
PDFの日本語表示崩れを修正 / Fix Japanese PDF rendering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
-# Docker では自動設定不要。独自フォントを使う場合のみ絶対パスを指定する。
+# Docker では自動設定不要。TrueTypeアウトラインの日本語TTF/TTCのみ指定可能。
 NOTE_PDF_FONT_PATH=
 
 # --- ファイル配信オフロード (nginx X-Accel-Redirect) ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH="/opt/venv/bin:$PATH" \
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        fonts-noto-cjk \
+        fonts-ipafont-gothic \
         libmagic1 \
         libmariadb3 \
     && rm -rf /var/lib/apt/lists/*

--- a/Note/note_export.py
+++ b/Note/note_export.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from fpdf import FPDF
+from fontTools.ttLib import TTFont as FontToolsTTFont
 
 
 class NotePdfFontUnavailableError(RuntimeError):
@@ -13,31 +14,45 @@ class NotePdfFontUnavailableError(RuntimeError):
 
 
 def _font_candidates() -> tuple[Path, ...]:
-    """Return portable Noto CJK font locations. / Noto CJK の候補を返す。"""
+    """Return Japanese TrueType font locations. / 日本語TTFの候補を返す。"""
     configured = os.getenv("NOTE_PDF_FONT_PATH", "").strip()
     project_font = Path(__file__).resolve().parents[1] / "static" / "fonts"
     home_font = Path.home() / ".fonts"
     candidates = [
-        project_font / "NotoSansCJK-Regular.ttc",
-        project_font / "NotoSansJP-Regular.ttf",
-        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
-        Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc"),
-        Path("/usr/local/share/fonts/NotoSansCJK-Regular.ttc"),
-        home_font / "NotoSansCJK-Regular.ttc",
+        project_font / "ipagp.ttf",
+        project_font / "ipag.ttf",
+        Path("/usr/share/fonts/opentype/ipafont-gothic/ipagp.ttf"),
+        Path("/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf"),
+        Path("/usr/local/share/fonts/ipagp.ttf"),
+        Path("/usr/local/share/fonts/ipag.ttf"),
+        home_font / "ipagp.ttf",
+        home_font / "ipag.ttf",
     ]
     if configured:
         candidates.insert(0, Path(configured).expanduser())
     return tuple(candidates)
 
 
+def _has_truetype_outlines(font_path: Path) -> bool:
+    """Reject viewer-sensitive CFF fonts. / 表示差が出るCFFを除外する。"""
+    try:
+        font = FontToolsTTFont(font_path, fontNumber=0, lazy=True)
+    except Exception:
+        return False
+    try:
+        return "glyf" in font
+    finally:
+        font.close()
+
+
 def find_note_pdf_font() -> Path:
     """利用可能な日本語フォントを探す。"""
     for candidate in _font_candidates():
-        if candidate.is_file():
+        if candidate.is_file() and _has_truetype_outlines(candidate):
             return candidate.resolve()
     raise NotePdfFontUnavailableError(
-        "Noto Sans CJK font is unavailable. Install fonts-noto-cjk or set "
-        "NOTE_PDF_FONT_PATH."
+        "A Japanese TrueType-outline font is unavailable. Install "
+        "fonts-ipafont-gothic or set NOTE_PDF_FONT_PATH."
     )
 
 
@@ -49,6 +64,10 @@ def build_note_pdf(
 ) -> bytes:
     """ノート本文を検索・コピー可能な PDF に変換する。"""
     selected_font = (font_path or find_note_pdf_font()).resolve()
+    if not _has_truetype_outlines(selected_font):
+        raise NotePdfFontUnavailableError(
+            "The configured PDF font must use TrueType outlines."
+        )
     pdf = FPDF(format="A4")
     pdf.set_margins(18, 18, 18)
     pdf.set_auto_page_break(auto=True, margin=18)
@@ -58,11 +77,11 @@ def build_note_pdf(
     # TTC files contain multiple regional faces; index 0 is the Japanese face.
     # TTC は複数地域の書体を含み、index 0 が日本語書体です。
     pdf.add_font(
-        "NotoSansCJK",
+        "JapaneseText",
         fname=selected_font,
         collection_font_number=0,
     )
-    pdf.set_font("NotoSansCJK", size=10.5)
+    pdf.set_font("JapaneseText", size=10.5)
     # HarfBuzz handles complex scripts and bidirectional text when present.
     # 複雑な文字体系や右横書きが含まれる場合も HarfBuzz で字形処理します。
     pdf.set_text_shaping(True)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
-# Optional path to a Noto Sans CJK-compatible TTF/TTC font for PDF exports.
+# Optional path to a Japanese TTF/TTC font with TrueType outlines for PDF exports.
 NOTE_PDF_FONT_PATH=
 ```
 
@@ -204,9 +204,11 @@ For Note / Group WebSocket connections, a CSRF token tied to the HTTP session is
 If the token passed from the page rendered in the same session does not match, the handshake is rejected.
 
 The Note page can export the current editor content as UTF-8 TXT or PDF. Docker
-installs Noto Sans CJK automatically so Japanese text is embedded in the PDF. For
-a native non-Docker installation, install a Noto Sans CJK font or set
-`NOTE_PDF_FONT_PATH` to a compatible `.ttf` / `.ttc` file.
+installs IPA P Gothic automatically so a TrueType Japanese font is embedded in
+the PDF. For a native non-Docker installation, install `fonts-ipafont-gothic` or
+set `NOTE_PDF_FONT_PATH` to a Japanese `.ttf` / `.ttc` file with TrueType
+outlines. CFF fonts are rejected because they render inconsistently in some PDF
+viewers.
 
 ## 🧰 Tech Stack
 - **FastAPI** (Python 3.14 / Debian 13 trixie)
@@ -314,7 +316,7 @@ GROUP_UPLOAD_DIR=/app/storage/group_uploads
 GROUP_FILE_LIST_REQUEST_TIMEOUT_MS=10000
 NOTE_MAX_CONTENT_LENGTH=10000
 NOTE_SELF_EDIT_TIMEOUT_MS=12000
-# PDF出力へ使用する Noto Sans CJK 互換フォントのパス（通常は未指定で可）
+# PDF出力へ使用するTrueTypeアウトラインの日本語TTF/TTC（通常は未指定で可）
 NOTE_PDF_FONT_PATH=
 ```
 
@@ -451,9 +453,10 @@ Note / Group の WebSocket 接続では、HTTP セッションと紐づく CSRF 
 同一セッションで生成されたトークンが一致しない接続は拒否されます。
 
 ノートページでは、現在のエディタ内容を UTF-8 のTXTまたはPDFとして出力できます。
-Docker環境では Noto Sans CJK を自動インストールし、日本語フォントをPDFへ埋め込みます。
-Dockerを使わない環境では Noto Sans CJK をインストールするか、互換性のある
-`.ttf` / `.ttc` ファイルを `NOTE_PDF_FONT_PATH` に指定してください。
+Docker環境では IPA Pゴシックを自動インストールし、TrueType形式の日本語フォントを
+PDFへ埋め込みます。Dockerを使わない環境では `fonts-ipafont-gothic` をインストールするか、
+TrueTypeアウトラインの日本語 `.ttf` / `.ttc` を `NOTE_PDF_FONT_PATH` に指定してください。
+一部PDFビューアで表示が崩れるCFF形式のフォントは使用できません。
 
 ## 🧰 技術スタック
 - **FastAPI** (Python 3.14 / Debian 13 trixie)

--- a/tests/test_note_export.py
+++ b/tests/test_note_export.py
@@ -2,7 +2,9 @@ import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
-from Note.note_export import build_note_pdf
+import pytest
+
+from Note.note_export import NotePdfFontUnavailableError, build_note_pdf
 from settings import NOTE_MAX_CONTENT_LENGTH
 
 
@@ -154,3 +156,15 @@ def test_build_note_pdf_preserves_plain_text_safely():
 
     assert pdf.startswith(b"%PDF-")
     assert len(pdf) > 1_000
+    assert b"/CIDFontType2" in pdf
+    assert b"/CIDFontType0" not in pdf
+
+
+def test_build_note_pdf_rejects_non_truetype_outlines():
+    font_path = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+
+    with (
+        patch("Note.note_export._has_truetype_outlines", return_value=False),
+        pytest.raises(NotePdfFontUnavailableError),
+    ):
+        build_note_pdf("text", ROOM_ID, font_path=font_path)


### PR DESCRIPTION
## 日本語

### 概要
- ノートPDFの埋め込みフォントを Noto Sans CJK（CFF）から IPA Pゴシック（TrueType）へ変更しました。
- `NOTE_PDF_FONT_PATH` で指定したフォントもTrueTypeアウトライン（`glyf` テーブル）か検証し、表示互換性に問題があるCFFフォントを拒否します。
- Docker、`.env.example`、README、回帰テストを新しい要件に合わせて更新しました。

### 原因と利用者への影響
従来のPDFはCID-keyed CFFフォントを `CIDFontType0` として埋め込んでいました。一部のPDFビューアではテキスト抽出は正常でも字形描画が大きく崩れます。本修正ではTrueTypeフォントを `CIDFontType2` として埋め込み、表示とコピーの両方を正常にします。

### 設定・移行・ロールバック
- データベース変更、スキーマ移行、停止時間はありません。
- Dockerイメージの再ビルドが必要です。
- Docker外では `fonts-ipafont-gothic` を導入するか、TrueTypeアウトラインの日本語TTF/TTCを `NOTE_PDF_FONT_PATH` に設定してください。
- ロールバックはこのコミットをrevertし、従来の `fonts-noto-cjk` を含むイメージを再ビルドします。

### 自動テスト
- `python3 -m pytest -q`: 619 passed
- `python3 -m ruff check .`: passed
- `python3 -m ruff format --check .`: passed
- `python3 -m mypy --config-file pyproject.toml`: passed
- `python3 scripts/validate_locales.py --strict-phrases`: passed
- `pip-audit -r requirements.txt --no-deps --disable-pip`: no known vulnerabilities
- `docker build -t fs-qr-note-pdf-rendering-test .`: passed

### 手動確認
- Dockerイメージ内の `/usr/share/fonts/opentype/ipafont-gothic/ipagp.ttf` で日本語・英数字・記号を含むPDFを生成しました。
- PDFを画像化して字形が明瞭に表示されること、抽出文字列が入力内容と完全一致すること、`/CIDFontType2` を使用し `/CIDFontType0` を含まないことを確認しました。
- Web UI自体の変更はないためスクリーンショットは添付していません。

### 未実施・関連Issue
- 報告元と同一のPDFビューア名・バージョンが不明なため、その実機での確認は未実施です。TrueType埋め込みへの変更により、問題となるCFF描画経路を回避しています。
- 関連Issue: なし

## English

### Summary
- Replaced the embedded Note PDF font from Noto Sans CJK (CFF) with IPA P Gothic (TrueType).
- Added validation for fonts configured through `NOTE_PDF_FONT_PATH`, accepting TrueType outlines (a `glyf` table) and rejecting CFF fonts with problematic viewer compatibility.
- Updated Docker, `.env.example`, README, and regression tests for the new requirement.

### Root cause and user impact
The previous PDF embedded a CID-keyed CFF font as `CIDFontType0`. Some PDF viewers extract its text correctly but render the glyphs severely distorted. This fix embeds a TrueType font as `CIDFontType2`, preserving both clean display and text copying.

### Configuration, migration, and rollback
- No database change, schema migration, downtime, or data migration is required.
- The Docker image must be rebuilt.
- Outside Docker, install `fonts-ipafont-gothic` or configure a Japanese TTF/TTC with TrueType outlines through `NOTE_PDF_FONT_PATH`.
- To roll back, revert this commit and rebuild the image with the previous `fonts-noto-cjk` package.

### Automated tests
- `python3 -m pytest -q`: 619 passed
- `python3 -m ruff check .`: passed
- `python3 -m ruff format --check .`: passed
- `python3 -m mypy --config-file pyproject.toml`: passed
- `python3 scripts/validate_locales.py --strict-phrases`: passed
- `pip-audit -r requirements.txt --no-deps --disable-pip`: no known vulnerabilities
- `docker build -t fs-qr-note-pdf-rendering-test .`: passed

### Manual verification
- Generated a PDF containing Japanese text, ASCII, and punctuation with `/usr/share/fonts/opentype/ipafont-gothic/ipagp.ttf` inside the Docker image.
- Rasterized the PDF and verified clean glyph rendering, confirmed extracted text exactly matched the input, and verified that the PDF uses `/CIDFontType2` without `/CIDFontType0`.
- No screenshot is attached because the web UI itself is unchanged.

### Not performed and related issue
- The exact viewer and version from the original report are unknown, so verification on that exact client was not possible. Switching to TrueType embedding bypasses the affected CFF rendering path.
- Related issue: none
