### PR TITLE
プロダクトLPの意匠を刷新（FS!QR / Note / Group） / Refresh product landing page design

### DIFF
--- a/FSQR/templates/fsqr_landing.html
+++ b/FSQR/templates/fsqr_landing.html
@@ -141,7 +141,7 @@
           </p>
           <h1 id="hero-title" class="lp-hero__title">
             ファイル共有を、<br>
-            <span>QRコードでもっと軽やかに。</span>
+            <span>QRコードで<wbr>もっと軽やかに。</span>
           </h1>
           <p class="lp-hero__lead">
             FS!QRは、送りたいファイルをブラウザで暗号化し、QRコードですぐに一時共有できるWebサービスです。アカウントも専用アプリも必要ありません。
@@ -195,25 +195,48 @@
       <div class="lp-container">
         <div class="lp-section__heading">
           <p class="lp-section__eyebrow">HOW IT WORKS</p>
-          <h2 id="steps-title" class="lp-section__title">QRコードでのファイル共有は、わずか3ステップ</h2>
+          <h2 id="steps-title" class="lp-section__title">QRコードでのファイル共有は、<wbr>わずか3ステップ</h2>
           <p class="lp-section__description">複雑な設定や連絡先の交換は不要。ブラウザを開けば、その場で共有を始められます。</p>
         </div>
         <ol class="lp-grid lp-grid--three lp-steps">
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">01</span>
-            <div class="lp-step-card__icon lp-step-card__icon--upload" aria-hidden="true"><span></span></div>
+            <div class="lp-step-card__icon lp-step-card__icon--upload" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 3v4a1 1 0 0 0 1 1h4"/>
+                <path d="M6 21h12a1 1 0 0 0 1-1V8l-5-5H6a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1Z"/>
+                <path d="M12 17.5V11"/>
+                <path d="M9.5 13.5 12 11l2.5 2.5"/>
+              </svg>
+            </div>
             <h3>ファイルを選ぶ</h3>
             <p>共有したいファイルと保存期間を選択します。ファイルはブラウザ上で暗号化されます。</p>
           </li>
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">02</span>
-            <div class="lp-step-card__icon lp-step-card__icon--qr" aria-hidden="true"><span></span></div>
+            <div class="lp-step-card__icon lp-step-card__icon--qr" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="7" height="7" rx="1.2"/>
+                <rect x="14" y="3" width="7" height="7" rx="1.2"/>
+                <rect x="3" y="14" width="7" height="7" rx="1.2"/>
+                <path d="M14 14h3v3"/>
+                <path d="M21 14v7h-4"/>
+                <path d="M14 21v-3"/>
+              </svg>
+            </div>
             <h3>QRコードを発行</h3>
             <p>アップロードが完了すると、受け取りページへつながるQRコードと共有情報が発行されます。</p>
           </li>
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">03</span>
-            <div class="lp-step-card__icon lp-step-card__icon--receive" aria-hidden="true"><span></span></div>
+            <div class="lp-step-card__icon lp-step-card__icon--receive" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="6.5" y="2.5" width="11" height="19" rx="2.5"/>
+                <path d="M10.5 5.5h3"/>
+                <rect x="9.5" y="8.5" width="5" height="5" rx="1"/>
+                <path d="M10.5 17.5h3"/>
+              </svg>
+            </div>
             <h3>読み取って受け取る</h3>
             <p>相手はQRコードをスマートフォンで読み取り、ブラウザからファイルを受け取れます。</p>
           </li>
@@ -228,37 +251,67 @@
       <div class="lp-container">
         <div class="lp-section__heading lp-section__heading--left">
           <p class="lp-section__eyebrow">DESIGNED FOR EASY SHARING</p>
-          <h2 id="features-title" class="lp-section__title">「送りたい」に、迷わない仕組みを。</h2>
+          <h2 id="features-title" class="lp-section__title">「送りたい」に、<wbr>迷わない仕組みを。</h2>
           <p class="lp-section__description">メール添付やアプリの登録に手間取る場面でも、FS!QRなら共有に必要な操作をひとつの画面で進められます。</p>
         </div>
         <div class="lp-grid lp-grid--features">
           <article class="lp-card lp-feature-card lp-feature-card--wide">
-            <div class="lp-feature-card__icon" aria-hidden="true">⌁</div>
+            <div class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 8h13"/>
+                <path d="M13 4l4 4-4 4"/>
+                <path d="M20 16H7"/>
+                <path d="M11 20l-4-4 4-4"/>
+              </svg>
+            </div>
             <h3>端末をまたいで、QRコードで受け渡し</h3>
             <p>PCで発行したQRコードをスマートフォンで読み取るなど、端末間のファイル移動にも利用できます。</p>
             <div class="lp-device-bridge" aria-hidden="true">
               <span class="lp-device lp-device--desktop"></span>
-              <span class="lp-device-bridge__flow">··· → ···</span>
+              <span class="lp-device-bridge__flow"></span>
               <span class="lp-device lp-device--phone"></span>
             </div>
           </article>
           <article class="lp-card lp-feature-card">
-            <div class="lp-feature-card__icon" aria-hidden="true">◇</div>
+            <div class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="10" cy="8" r="3.4"/>
+                <path d="M4 20c0-3.3 2.7-6 6-6 1.1 0 2.2.3 3.1.85"/>
+                <path d="M16.4 15.6l4 4"/>
+                <path d="M20.4 15.6l-4 4"/>
+              </svg>
+            </div>
             <h3>アカウント作成なし</h3>
             <p>メールアドレスやプロフィールの登録は不要。共有したいときにすぐ使い始められます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <div class="lp-feature-card__icon" aria-hidden="true">⌾</div>
+            <div class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 3l7 3v5c0 4.4-3 7.7-7 9-4-1.3-7-4.6-7-9V6l7-3Z"/>
+                <path d="M9 12l2 2 4-4"/>
+              </svg>
+            </div>
             <h3>ブラウザで暗号化</h3>
             <p>ファイルをブラウザ内で暗号化してからアップロードし、暗号化された状態で一時保管します。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <div class="lp-feature-card__icon" aria-hidden="true">◷</div>
+            <div class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="13" r="8"/>
+                <path d="M12 9.5V13l2.5 1.8"/>
+                <path d="M9.5 3h5"/>
+              </svg>
+            </div>
             <h3>保存期間を選択</h3>
             <p>1時間・6時間・12時間・24時間から選択。期間が終了したファイルは自動で削除されます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <div class="lp-feature-card__icon" aria-hidden="true">↗</div>
+            <div class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.5 13.5a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7l-1.6 1.6"/>
+                <path d="M14.5 10.5a4 4 0 0 0-5.7 0l-3 3a4 4 0 0 0 5.7 5.7l1.6-1.6"/>
+              </svg>
+            </div>
             <h3>QR以外でも共有</h3>
             <p>同じ画面に発行される共有ページや共有情報を伝えて、離れた相手にも届けられます。</p>
           </article>
@@ -270,7 +323,7 @@
       <div class="lp-container">
         <div class="lp-section__heading">
           <p class="lp-section__eyebrow">USE CASES</p>
-          <h2 id="use-cases-title" class="lp-section__title">こんなファイル共有を、すっきり解決</h2>
+          <h2 id="use-cases-title" class="lp-section__title">こんなファイル共有を、<wbr>すっきり解決</h2>
         </div>
         <div class="lp-grid lp-grid--three lp-use-cases">
           <article class="lp-card lp-use-case-card">
@@ -329,7 +382,7 @@
       <div class="lp-container">
         <div class="lp-final-cta__inner">
           <p class="lp-section__eyebrow">READY WHEN YOU ARE</p>
-          <h2 id="final-cta-title">ファイルを送りたい、その瞬間に。</h2>
+          <h2 id="final-cta-title">ファイルを送りたい、<wbr>その瞬間に。</h2>
           <p>登録不要。ブラウザからファイルを選んで、QRコードで共有を始めましょう。</p>
           <div class="lp-final-cta__actions">
             <a class="lp-button lp-button--primary lp-button--large" href="/fs-qr">無料でファイルを共有する <span aria-hidden="true">→</span></a>

--- a/Group/templates/group_landing.html
+++ b/Group/templates/group_landing.html
@@ -139,7 +139,7 @@
     <section class="lp-hero" aria-labelledby="hero-title">
       <div class="lp-container lp-hero__grid">
         <div class="lp-hero__content">
-          <p class="lp-eyebrow"><span aria-hidden="true">●</span> 登録不要のグループファイル共有</p>
+          <p class="lp-eyebrow"><span aria-hidden="true"></span> 登録不要のグループファイル共有</p>
           <h1 id="hero-title">チームのファイルを、<br><span>ひとつのルームへ。</span></h1>
           <p class="lp-hero__lead">メンバー登録や招待設定に時間をかけず、必要な人とファイルをまとめて共有。ルームを作り、URLやQRコードを渡すだけで共同作業を始められます。</p>
           <div class="lp-actions">
@@ -149,7 +149,7 @@
             </a>
             <a class="lp-button lp-button--secondary" href="/group">IDでルームに参加</a>
           </div>
-          <ul class="lp-hero__checks" aria-label="サービスの概要">
+          <ul class="lp-check-list lp-hero__checks" aria-label="サービスの概要">
             <li><span aria-hidden="true">✓</span> アカウント登録なし</li>
             <li><span aria-hidden="true">✓</span> ブラウザで完結</li>
             <li><span aria-hidden="true">✓</span> 保存期間を選択</li>
@@ -184,25 +184,43 @@
       <div class="lp-container">
         <div class="lp-section__heading">
           <p class="lp-section__eyebrow">HOW IT WORKS</p>
-          <h2 id="how-title" class="lp-section__title">共有開始まで、わずか3ステップ</h2>
+          <h2 id="how-title" class="lp-section__title">共有開始まで、<wbr>わずか3ステップ</h2>
           <p class="lp-section__lead">専用アプリのインストールも、参加メンバーのアカウント作成も必要ありません。</p>
         </div>
         <ol class="lp-steps">
           <li class="lp-step">
             <span class="lp-step__number">01</span>
-            <div class="lp-step__icon" aria-hidden="true">＋</div>
+            <div class="lp-step__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"/>
+                <path d="M12 11v5"/>
+                <path d="M9.5 13.5h5"/>
+              </svg>
+            </div>
             <h3>ルームを作成</h3>
             <p>ルームIDと保存期間を設定。6桁のパスワードが自動で発行されます。</p>
           </li>
           <li class="lp-step">
             <span class="lp-step__number">02</span>
-            <div class="lp-step__icon" aria-hidden="true">↗</div>
+            <div class="lp-step__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.5 13.5a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7l-1.6 1.6"/>
+                <path d="M14.5 10.5a4 4 0 0 0-5.7 0l-3 3a4 4 0 0 0 5.7 5.7l1.6-1.6"/>
+              </svg>
+            </div>
             <h3>参加情報を共有</h3>
             <p>共有URLやQRコード、またはルームIDとパスワードを必要な相手へ伝えます。</p>
           </li>
           <li class="lp-step">
             <span class="lp-step__number">03</span>
-            <div class="lp-step__icon" aria-hidden="true">⇅</div>
+            <div class="lp-step__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M8 4v14"/>
+                <path d="M4.5 7.5 8 4l3.5 3.5"/>
+                <path d="M16 20V6"/>
+                <path d="M12.5 16.5 16 20l3.5-3.5"/>
+              </svg>
+            </div>
             <h3>みんなで共有</h3>
             <p>参加者がファイルをアップロード。ルーム内の一覧から必要なファイルを受け取れます。</p>
           </li>
@@ -218,7 +236,16 @@
         </div>
         <div class="lp-grid lp-grid--features">
           <article class="lp-card lp-feature-card lp-feature-card--wide">
-            <span class="lp-card__icon" aria-hidden="true">⌁</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="7" height="7" rx="1.2"/>
+                <rect x="14" y="3" width="7" height="7" rx="1.2"/>
+                <rect x="3" y="14" width="7" height="7" rx="1.2"/>
+                <path d="M14 14h3v3"/>
+                <path d="M21 14v7h-4"/>
+                <path d="M14 21v-3"/>
+              </svg>
+            </span>
             <h3>URL・QRコードですぐ招待</h3>
             <p>共有URLをメッセージで送る。対面ならQRコードを見せる。状況に合う渡し方を選べます。</p>
             <div class="lp-card__visual lp-share-visual" aria-hidden="true">
@@ -227,27 +254,60 @@
             </div>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-card__icon" aria-hidden="true">◎</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="8.5" cy="9.5" r="4"/>
+                <path d="M11.3 12.3 20 21"/>
+                <path d="M18.5 19.5l2-2"/>
+                <path d="M15.6 16.6l1.6 1.6"/>
+              </svg>
+            </span>
             <h3>IDとパスワードで参加</h3>
             <p>共有URLが手元になくても、6文字のルームIDと6桁のパスワードから参加できます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-card__icon" aria-hidden="true">◷</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="13" r="8"/>
+                <path d="M12 9.5V13l2.5 1.8"/>
+                <path d="M9.5 3h5"/>
+              </svg>
+            </span>
             <h3>保存期限を選んで自動削除</h3>
             <p>保存期間は1・6・12・24時間。期限を過ぎるとルームと保存ファイルが自動削除されます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-card__icon" aria-hidden="true">⇅</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M8 4v14"/>
+                <path d="M4.5 7.5 8 4l3.5 3.5"/>
+                <path d="M16 20V6"/>
+                <path d="M12.5 16.5 16 20l3.5-3.5"/>
+              </svg>
+            </span>
             <h3>メンバーも追加・受け取り</h3>
             <p>参加者は同じルームでファイルをアップロードし、一覧からダウンロードできます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-card__icon" aria-hidden="true">▣</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="4.5" width="18" height="15" rx="2"/>
+                <path d="M3 9h18"/>
+                <path d="M6.4 6.7h.01M9 6.7h.01"/>
+              </svg>
+            </span>
             <h3>ブラウザだけで完結</h3>
             <p>専用アプリを増やさず、PCやスマートフォンのブラウザからアクセスできます。</p>
           </article>
           <article class="lp-card lp-feature-card lp-feature-card--accent">
-            <span class="lp-card__icon" aria-hidden="true">⌂</span>
+            <span class="lp-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 7h16"/>
+                <path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                <path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12"/>
+                <path d="M10 11v6M14 11v6"/>
+              </svg>
+            </span>
             <h3>作成者はルームを削除可能</h3>
             <p>共有を早く終えたい場合、作成者は保存期間を待たずにルームを削除できます。</p>
           </article>
@@ -306,23 +366,23 @@
         </div>
         <div class="lp-faq-list">
           <details class="lp-faq-item">
-            <summary>アカウント登録は必要ですか？<span aria-hidden="true">＋</span></summary>
+            <summary>アカウント登録は必要ですか？<span aria-hidden="true"></span></summary>
             <p>必要ありません。ブラウザからルームを作成し、参加に必要な情報をメンバーへ共有すれば使い始められます。</p>
           </details>
           <details class="lp-faq-item">
-            <summary>メンバーはどのようにルームへ参加しますか？<span aria-hidden="true">＋</span></summary>
+            <summary>メンバーはどのようにルームへ参加しますか？<span aria-hidden="true"></span></summary>
             <p>共有URLまたはQRコードを開くか、参加画面でルームIDとパスワードを入力します。参加情報は必要な相手だけに共有してください。</p>
           </details>
           <details class="lp-faq-item">
-            <summary>ファイルはいつまで保存されますか？<span aria-hidden="true">＋</span></summary>
+            <summary>ファイルはいつまで保存されますか？<span aria-hidden="true"></span></summary>
             <p>ルーム作成時に1時間、6時間、12時間、24時間から保存期間を選べます。期間を過ぎるとルームとファイルは自動削除されます。</p>
           </details>
           <details class="lp-faq-item">
-            <summary>アップロードできるファイル数や容量に上限はありますか？<span aria-hidden="true">＋</span></summary>
+            <summary>アップロードできるファイル数や容量に上限はありますか？<span aria-hidden="true"></span></summary>
             <p>上限があります。現在のファイル数と容量の上限は、アップロード画面に表示される案内をご確認ください。</p>
           </details>
           <details class="lp-faq-item">
-            <summary>機密性の高いファイルにも使えますか？<span aria-hidden="true">＋</span></summary>
+            <summary>機密性の高いファイルにも使えますか？<span aria-hidden="true"></span></summary>
             <p>ルームへの参加には共有情報が必要ですが、ファイルはサーバー上で暗号化されない状態で保管されます。機密性の高いファイルの共有は、所属組織のルールを確認したうえで慎重に判断してください。</p>
           </details>
         </div>

--- a/Note/templates/note_landing.html
+++ b/Note/templates/note_landing.html
@@ -163,25 +163,42 @@
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
           <p class="lp-kicker lp-section__eyebrow">HOW IT WORKS</p>
-          <h2 class="lp-section__title" id="steps-title">3ステップで、共同編集を開始</h2>
+          <h2 class="lp-section__title" id="steps-title">3ステップで、<wbr>共同編集を開始</h2>
           <p>複雑な共有設定はありません。必要なときにノートを開いて、相手を招待できます。</p>
         </div>
         <ol class="lp-grid lp-steps">
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">01</span>
-            <div class="lp-step-card__icon" aria-hidden="true"><span>＋</span></div>
+            <div class="lp-step-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 3v4a1 1 0 0 0 1 1h4"/>
+                <path d="M6 21h12a1 1 0 0 0 1-1V8l-5-5H6a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1Z"/>
+                <path d="M12 12.5v5"/>
+                <path d="M9.5 15h5"/>
+              </svg>
+            </div>
             <h3>ノートを作る</h3>
             <p>ルーム情報を設定して、共同編集用のノートを作成します。</p>
           </li>
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">02</span>
-            <div class="lp-step-card__icon" aria-hidden="true"><span>↗</span></div>
+            <div class="lp-step-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.5 13.5a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7l-1.6 1.6"/>
+                <path d="M14.5 10.5a4 4 0 0 0-5.7 0l-3 3a4 4 0 0 0 5.7 5.7l1.6-1.6"/>
+              </svg>
+            </div>
             <h3>URLを共有する</h3>
             <p>発行された共有URLを、参加してほしい相手に送ります。</p>
           </li>
           <li class="lp-card lp-step-card">
             <span class="lp-step-card__number">03</span>
-            <div class="lp-step-card__icon" aria-hidden="true"><span>⌁</span></div>
+            <div class="lp-step-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.8-2.8L5 17.2 4 20Z"/>
+                <path d="M14 8l2.8 2.8"/>
+              </svg>
+            </div>
             <h3>一緒に書く</h3>
             <p>同じノートを開き、リアルタイムでテキストを編集します。</p>
           </li>
@@ -193,28 +210,50 @@
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
           <p class="lp-kicker lp-section__eyebrow">FEATURES</p>
-          <h2 class="lp-section__title" id="features-title">速く、迷わず、ひとつにまとまる</h2>
+          <h2 class="lp-section__title" id="features-title">速く、迷わず、<wbr>ひとつにまとまる</h2>
           <p>共同メモに必要な機能を、シンプルな画面にまとめました。</p>
         </div>
         <div class="lp-grid lp-feature-grid">
           <article class="lp-card lp-feature-card lp-feature-card--wide">
-            <span class="lp-feature-card__icon" aria-hidden="true">⌁</span>
+            <span class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="9" cy="8" r="3"/>
+                <path d="M3.5 19a5.5 5.5 0 0 1 11 0"/>
+                <path d="M16 5.2a3 3 0 0 1 0 5.6"/>
+                <path d="M17.4 13.6A5.6 5.6 0 0 1 20.5 18.6"/>
+              </svg>
+            </span>
             <h3>リアルタイム共同編集</h3>
             <p>同じノートに参加したメンバーの入力をリアルタイムに反映。会話の流れを止めずに、全員で記録を育てられます。</p>
             <div class="lp-feature-card__demo lp-live-lines" aria-hidden="true"><span></span><span></span><i></i></div>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-feature-card__icon" aria-hidden="true">↗</span>
+            <span class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.5 13.5a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7l-1.6 1.6"/>
+                <path d="M14.5 10.5a4 4 0 0 0-5.7 0l-3 3a4 4 0 0 0 5.7 5.7l1.6-1.6"/>
+              </svg>
+            </span>
             <h3>URLひとつで共有</h3>
             <p>共有URLを送れば、離れた相手も同じノートに参加できます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-feature-card__icon" aria-hidden="true">✓</span>
+            <span class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 5a2 2 0 0 1 2-2h9l3 3v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5Z"/>
+                <path d="M8 3v4h6V3"/>
+                <path d="M8.5 13.5l2 2 3.5-3.5"/>
+              </svg>
+            </span>
             <h3>自動保存</h3>
             <p>編集内容は自動で保存。保存ボタンを押す手間なく、書くことに集中できます。</p>
           </article>
           <article class="lp-card lp-feature-card">
-            <span class="lp-feature-card__icon" aria-hidden="true">○</span>
+            <span class="lp-feature-card__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M13 3 5 13h5l-1 8 8-10h-5l1-8Z"/>
+              </svg>
+            </span>
             <h3>登録不要ですぐ開始</h3>
             <p>アカウントを作らずに利用可能。急な打ち合わせにも、その場でノートを用意できます。</p>
           </article>
@@ -226,7 +265,7 @@
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
           <p class="lp-kicker lp-section__eyebrow">USE CASES</p>
-          <h2 class="lp-section__title" id="use-cases-title">「今、一緒に書きたい」場面に</h2>
+          <h2 class="lp-section__title" id="use-cases-title">「今、一緒に書きたい」<wbr>場面に</h2>
         </div>
         <div class="lp-grid lp-use-case-grid">
           <article class="lp-card lp-use-case-card">
@@ -278,7 +317,7 @@
       <div class="lp-final-cta__glow" aria-hidden="true"></div>
       <div class="lp-container lp-final-cta__inner">
         <p class="lp-kicker lp-section__eyebrow">START WRITING TOGETHER</p>
-        <h2 id="cta-title">次のメモは、みんなで書こう。</h2>
+        <h2 id="cta-title">次のメモは、<wbr>みんなで書こう。</h2>
         <p>登録は不要です。共有ノートを作って、リアルタイム共同編集を始めましょう。</p>
         <div class="lp-actions lp-actions--center">
           <a class="lp-button lp-button--light" href="/create_note_room">共有ノートを作る <span aria-hidden="true">→</span></a>

--- a/static/css/15-product-landing.css
+++ b/static/css/15-product-landing.css
@@ -2500,3 +2500,352 @@ body.product-lp {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ================================================================
+   FS!QR landing refinements / FS!QR ランディングページの意匠調整
+   すべて .product-lp--fsqr にスコープし、Note / Group には影響させない。
+   目的：日本語見出しの字面を整え、余白と影を落ち着かせ、QRを主役にした
+   一貫した記号（ファインダーパターン）で「作り込まれた」印象へ引き上げる。
+   ================================================================ */
+
+/* Grounded shadows / 影を軽く近づけ、浮遊感の強い大ぼかしを避ける */
+.product-lp--fsqr {
+  --lp-shadow-sm: 0 2px 6px rgba(16, 32, 48, 0.05),
+    0 14px 30px -18px rgba(16, 32, 48, 0.22);
+  --lp-shadow-lg: 0 4px 14px rgba(16, 32, 48, 0.06),
+    0 30px 60px -30px rgba(16, 32, 48, 0.28);
+}
+
+/* Typography / 日本語見出しの詰めすぎを解消し、読みやすい字面へ */
+.product-lp--fsqr h1,
+.product-lp--fsqr h2,
+.product-lp--fsqr h3 {
+  letter-spacing: -0.01em;
+  line-height: 1.36;
+}
+
+.product-lp--fsqr .lp-hero h1 {
+  max-width: 12em;
+  font-size: clamp(40px, 4.4vw, 58px);
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  line-height: 1.32;
+}
+
+.product-lp--fsqr .lp-section__title {
+  font-size: clamp(25px, 3.4vw, 44px);
+  font-weight: 800;
+  line-height: 1.32;
+}
+
+/* 見出しの改行制御 / 単語の途中で折り返さない。<wbr> を句点の後に置き、
+   keep-all で不用意な分割を抑えつつ、狭い画面では anywhere で溢れを防ぐ。 */
+.product-lp--fsqr .lp-hero h1,
+.product-lp--fsqr .lp-section__title,
+.product-lp--fsqr .lp-final-cta h2 {
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.product-lp--fsqr .lp-card h3 {
+  font-size: 20px;
+  line-height: 1.5;
+}
+
+.product-lp--fsqr .lp-hero__lead,
+.product-lp--fsqr .lp-section__description {
+  line-height: 1.9;
+}
+
+/* Signature marker / QRのファインダーパターンを模した共通の目印。
+   見出しラベル・特長・ユースケースに一貫して添え、ブランドの記号にする。 */
+.product-lp--fsqr .lp-section__eyebrow,
+.product-lp--fsqr .lp-use-case-card__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.product-lp--fsqr .lp-section__eyebrow::before,
+.product-lp--fsqr .lp-use-case-card__label::before,
+.product-lp--fsqr .lp-trust__items .lp-trust__item strong::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border: 2px solid currentColor;
+  border-radius: 2.5px;
+  background: radial-gradient(circle at center, currentColor 0 1.3px, transparent 1.7px);
+}
+
+/* Hero / 抽象的なリングと二重の放射グラデーションを整理し、静かな光へ */
+.product-lp--fsqr .lp-hero {
+  padding: 88px 0 84px;
+  background:
+    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.10), transparent 56%),
+    linear-gradient(180deg, #fbfcff 0%, var(--lp-canvas) 100%);
+}
+
+.product-lp--fsqr .lp-hero::before {
+  display: none;
+}
+
+.product-lp--fsqr .lp-hero__title span {
+  color: var(--lp-accent);
+}
+
+.product-lp--fsqr .lp-page-shot {
+  border-color: rgba(16, 32, 48, 0.08);
+  border-radius: 24px;
+  box-shadow: var(--lp-shadow-lg);
+  transform: rotate(0.8deg);
+}
+
+/* Trust band / 目印を添え、行間と区切りを整えて情報の帯として自立させる */
+.product-lp--fsqr .lp-trust__items {
+  overflow: hidden;
+  border: 1px solid var(--lp-line);
+  border-radius: var(--lp-radius-sm);
+}
+
+.product-lp--fsqr .lp-trust__items .lp-trust__item {
+  gap: 6px;
+  padding: 18px 20px;
+  border-right: 1px solid var(--lp-line);
+}
+
+.product-lp--fsqr .lp-trust__items .lp-trust__item:last-child {
+  border-right: 0;
+}
+
+.product-lp--fsqr .lp-trust__items .lp-trust__item strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--lp-ink);
+  font-size: 15px;
+}
+
+/* Step & feature icons / 空箱・記号だった箇所を線画アイコンに置き換える */
+.product-lp--fsqr .lp-step-card__icon svg,
+.product-lp--fsqr .lp-feature-card__icon svg {
+  width: 26px;
+  height: 26px;
+}
+
+.product-lp--fsqr .lp-step-card__icon {
+  margin-bottom: 30px;
+}
+
+/* Feature cards / 白背景の淡い青みを抑え、暗色カードを青系のインクへ寄せる */
+.product-lp--fsqr .lp-feature-card--wide {
+  background: linear-gradient(165deg, #16233f 0%, #0f1a30 100%);
+}
+
+.product-lp--fsqr .lp-device-bridge__flow {
+  position: relative;
+  width: 46px;
+  height: 0;
+  border-top: 1.5px dashed rgba(255, 255, 255, 0.5);
+}
+
+.product-lp--fsqr .lp-device-bridge__flow::after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  right: -1px;
+  width: 7px;
+  height: 7px;
+  border-top: 1.5px solid rgba(255, 255, 255, 0.6);
+  border-right: 1.5px solid rgba(255, 255, 255, 0.6);
+  transform: rotate(45deg);
+}
+
+/* Use cases / 装飾リングを弱め、カードの青みを控えめにして上質に */
+.product-lp--fsqr .lp-use-case-card {
+  background: linear-gradient(160deg, #ffffff 0%, #fafbff 100%);
+}
+
+.product-lp--fsqr .lp-use-case-card::after {
+  box-shadow: none;
+  opacity: 0.65;
+}
+
+/* Cool-neutral cohesion / 緑みのある無彩色を青のブランドへ寄せて統一する */
+.product-lp--fsqr .lp-section--faq {
+  background: #eef2f8;
+}
+
+.product-lp--fsqr .lp-final-cta {
+  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 68%, #123a9e 100%);
+}
+
+.product-lp--fsqr .lp-footer {
+  background: #101827;
+}
+
+/* ================================================================
+   Note & Group landing refinements / Note・Group LP の意匠調整
+   FS!QR LP と同じ方針を、Note（紫）・Group（緑）へブランド別に適用する。
+   構造的な調整は両者共通、色はブランドごとに分けて記述する。
+   ================================================================ */
+
+/* Grounded shadows / 影を落ち着かせる（両ブランド共通） */
+.product-lp--note,
+.product-lp--group {
+  --lp-shadow-sm: 0 2px 6px rgba(16, 24, 40, 0.05),
+    0 14px 30px -18px rgba(16, 24, 40, 0.22);
+  --lp-shadow-lg: 0 4px 14px rgba(16, 24, 40, 0.06),
+    0 30px 60px -30px rgba(16, 24, 40, 0.28);
+}
+
+/* Typography / 和文見出しの字間・行間を整える */
+.product-lp--note h1,
+.product-lp--note h2,
+.product-lp--note h3,
+.product-lp--group h1,
+.product-lp--group h2,
+.product-lp--group h3 {
+  letter-spacing: -0.01em;
+  line-height: 1.36;
+}
+
+.product-lp--note .lp-hero h1 {
+  max-width: 12em;
+  font-size: clamp(40px, 4.4vw, 58px);
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+
+.product-lp--group .lp-hero h1 {
+  max-width: 13em;
+  font-size: clamp(32px, 3.4vw, 46px);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.34;
+}
+
+.product-lp--note .lp-section__title,
+.product-lp--group .lp-section__title {
+  font-size: clamp(25px, 3.4vw, 44px);
+  font-weight: 800;
+  line-height: 1.32;
+}
+
+.product-lp--note .lp-card h3,
+.product-lp--group .lp-card h3 {
+  font-size: 20px;
+  line-height: 1.5;
+}
+
+/* 見出しの改行制御 / 単語の途中で折り返さない（<wbr> と keep-all の併用） */
+.product-lp--note .lp-hero h1,
+.product-lp--note .lp-section__title,
+.product-lp--note .lp-final-cta h2,
+.product-lp--group .lp-hero h1,
+.product-lp--group .lp-section__title,
+.product-lp--group .lp-final-cta h2 {
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+/* Signature marker / 見出しラベルと活用例タグに共通の目印を添える */
+.product-lp--note .lp-section__eyebrow,
+.product-lp--note .lp-use-case-card__tag,
+.product-lp--group .lp-section__eyebrow,
+.product-lp--group .lp-use-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.product-lp--note .lp-section__eyebrow::before,
+.product-lp--note .lp-use-case-card__tag::before,
+.product-lp--group .lp-section__eyebrow::before,
+.product-lp--group .lp-use-card__tag::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border: 2px solid currentColor;
+  border-radius: 2.5px;
+  background: radial-gradient(circle at center, currentColor 0 1.3px, transparent 1.7px);
+}
+
+/* Hero / 抽象的なリングと放射グラデーションを整理して静かな光へ */
+.product-lp--note .lp-hero,
+.product-lp--group .lp-hero {
+  padding: 88px 0 84px;
+}
+
+.product-lp--note .lp-hero::before,
+.product-lp--group .lp-hero::before {
+  display: none;
+}
+
+.product-lp--note .lp-page-shot,
+.product-lp--group .lp-page-shot {
+  border-radius: 24px;
+  box-shadow: var(--lp-shadow-lg);
+  transform: rotate(0.8deg);
+}
+
+/* Icons / 空箱・記号だった箇所を線画アイコンに置き換える */
+.product-lp--note .lp-step-card__icon svg,
+.product-lp--note .lp-feature-card__icon svg,
+.product-lp--group .lp-step__icon svg,
+.product-lp--group .lp-card__icon svg {
+  width: 26px;
+  height: 26px;
+}
+
+.product-lp--note .lp-step-card__icon {
+  margin-bottom: 30px;
+}
+
+/* ---- Note color cohesion / Note は紫系へ寄せる ---- */
+.product-lp--note .lp-hero {
+  background:
+    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.12), transparent 56%),
+    linear-gradient(180deg, #fcfbff 0%, var(--lp-canvas) 100%);
+}
+
+.product-lp--note .lp-feature-card--wide {
+  background: linear-gradient(165deg, #2a1f45 0%, #1c1533 100%);
+}
+
+.product-lp--note .lp-section--faq {
+  background: #efecf8;
+}
+
+.product-lp--note .lp-final-cta {
+  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 66%, #3f2593 100%);
+}
+
+.product-lp--note .lp-footer {
+  background: #171226;
+}
+
+/* ---- Group color cohesion / Group は緑系で深みを与える ---- */
+.product-lp--group .lp-hero {
+  background:
+    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.12), transparent 56%),
+    linear-gradient(180deg, #f9fdfb 0%, var(--lp-canvas) 100%);
+}
+
+.product-lp--group .lp-feature-card--wide {
+  background: linear-gradient(165deg, #123b2e 0%, #0c2a20 100%);
+}
+
+.product-lp--group .lp-section--faq {
+  background: #eaf1ed;
+}
+
+.product-lp--group .lp-final-cta {
+  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 68%, #06442f 100%);
+}
+
+.product-lp--group .lp-footer {
+  background: #0f1a15;
+}


### PR DESCRIPTION
## 日本語

3つのプロダクトLP（`/file-sharing`・`/shared-note`・`/group-file-sharing`）のデザインを、**大枠を保ったまま**、より美しく・見やすく・モダンで、テンプレート然としない見た目へ調整しました。

### 主な変更
- **和文タイポグラフィの是正**：見出しの過度な負トラッキング（`-0.065em`）を自然な字間・行間へ。`<wbr>` ＋ `word-break: keep-all` で単語途中の折り返し（「すっきり解**決**」等）を解消し、狭い画面では `overflow-wrap: anywhere` で横スクロールを防止。ヒーロー見出しは大味さを抑えたサイズへ。
- **アイコンの刷新**：空箱だった手順アイコンと、フォント依存で不揃いな記号（`⌁ ◇ ⌾ ◷ ↗ ＋ ✓ ○ ◎ ▣ ⌂ ⇅`）を、意味の伝わる線画SVGに置き換え。
- **共通マーカー**：QRのファインダーパターンを模した小さな目印を、各セクションの見出しラベル・活用例タグに一貫して付与。
- **質感・配色の統一**：浮遊感の強い大ぼかしの影を近い多層影へ。抽象的なヒーローのリング／二重放射グラデを整理。緑みの無彩色（暗色カード・フッター・FAQ背景・最終CTA）を各ブランド色（青／紫／緑）へ寄せて統一。
- **不具合修正**：Group のヒーロー箇条書きが素の黒丸（`•`）で表示されていた（`lp-hero__checks` 未スタイル）のを、既存の `lp-check-list` を適用して修正。Group の FAQ トグルで literal `＋` と CSS描画の＋が重なっていた点も整理。

### スコープと安全性
CSSの追加はすべて `.product-lp--fsqr` / `.product-lp--note` / `.product-lp--group` にスコープしており、LP間で影響が混ざりません。既存ルールは変更せず、ファイル末尾に追記しています。

### 検証
- 自動テスト：`python3 -m pytest`（**全646件成功**）。うち `tests/test_product_landing_pages.py`・`tests/test_i18n.py` を重点確認。
- 目視：ヘッドレスChromiumでPC（1440px）・モバイル（390/360px）を描画し、見出し折り返し・横スクロール無し・アイコン表示・配色を確認。
- Python は未変更のため Ruff / mypy への影響なし。
- ヒーローのイラスト画像はローカルのヘッドレス撮影ではデコードが間に合わず空表示になる場合がありますが、HTTP 200 で取得でき、実サーバーでは表示されます。

## English

Redesigned the three product landing pages (`/file-sharing`, `/shared-note`, `/group-file-sharing`) to look more polished, readable, modern, and less templated, **while keeping the overall structure**.

### Highlights
- **Japanese typography fix**: relaxed the overly tight heading tracking (`-0.065em`) to natural spacing; `<wbr>` + `word-break: keep-all` stop mid-word line breaks, with `overflow-wrap: anywhere` preventing horizontal scroll on narrow screens; toned-down hero size.
- **Real icons**: replaced empty step-icon boxes and font-dependent glyphs (`⌁ ◇ ⌾ ◷ ↗ ＋ ✓ ○ ◎ ▣ ⌂ ⇅`) with crafted inline SVG line icons.
- **Signature marker**: a small QR finder-pattern marker applied consistently to section eyebrows and use-case tags.
- **Cohesion**: grounded, layered shadows instead of floaty 80px blurs; simplified abstract hero rings; shifted green-ish neutrals (dark cards, footer, FAQ background, final CTA) toward each brand color (blue / purple / green).
- **Bug fixes**: Group's hero checklist was rendering default disc bullets (`lp-hero__checks` had no styling) — fixed by applying the existing `lp-check-list`. Also removed a doubled `＋` glyph in Group's FAQ toggle.

### Scope & safety
All new CSS is scoped under `.product-lp--fsqr` / `--note` / `--group`, so the pages never affect each other; existing rules are untouched (additions appended at end of file).

### Verification
- `python3 -m pytest` — **all 646 tests pass** (focused on `tests/test_product_landing_pages.py` and `tests/test_i18n.py`).
- Manual: rendered desktop (1440px) and mobile (390/360px) via headless Chromium; verified heading wrapping, no horizontal scroll, icon rendering, and color cohesion.
- No Python changed, so Ruff / mypy are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)