### PR TITLE
3つのプロダクトLPのデザインを刷新 / Modernize the product landing pages

### DIFF
--- a/FSQR/templates/fsqr_landing.html
+++ b/FSQR/templates/fsqr_landing.html
@@ -137,14 +137,14 @@
         <div class="lp-hero__content">
           <p class="lp-hero__eyebrow">
             <span class="lp-status-dot" aria-hidden="true"></span>
-            登録不要・ブラウザで完結
+            登録不要。ブラウザですぐに使えます
           </p>
           <h1 id="hero-title" class="lp-hero__title">
-            ファイル共有を、<br>
-            <span>QRコードで<wbr>もっと軽やかに。</span>
+            ファイルを、<br>
+            <span>迷わず渡せる。</span>
           </h1>
           <p class="lp-hero__lead">
-            FS!QRは、送りたいファイルをブラウザで暗号化し、QRコードですぐに一時共有できるWebサービスです。アカウントも専用アプリも必要ありません。
+            送りたいファイルを選んだら、表示されたQRコードを相手に見せるだけ。FS!QRなら、アカウントも専用アプリも使わずに、端末をまたいで一時共有できます。
           </p>
           <div class="lp-hero__actions">
             <a class="lp-button lp-button--primary lp-button--large" href="/fs-qr">
@@ -194,7 +194,7 @@
     <section id="how-it-works" class="lp-section lp-section--steps" aria-labelledby="steps-title">
       <div class="lp-container">
         <div class="lp-section__heading">
-          <p class="lp-section__eyebrow">HOW IT WORKS</p>
+          <p class="lp-section__eyebrow">01&nbsp;&nbsp;使い方</p>
           <h2 id="steps-title" class="lp-section__title">QRコードでのファイル共有は、<wbr>わずか3ステップ</h2>
           <p class="lp-section__description">複雑な設定や連絡先の交換は不要。ブラウザを開けば、その場で共有を始められます。</p>
         </div>
@@ -241,6 +241,49 @@
             <p>相手はQRコードをスマートフォンで読み取り、ブラウザからファイルを受け取れます。</p>
           </li>
         </ol>
+        <div class="lp-mockup lp-mockup--fsqr lp-process-preview" role="img" aria-label="ファイルを暗号化してアップロードし、共有用QRコードが発行されるFS!QRの画面イメージ">
+          <div class="lp-browser">
+            <div class="lp-browser__bar" aria-hidden="true">
+              <span class="lp-browser__dots"><i></i><i></i><i></i></span>
+              <span class="lp-browser__address">fs-qr.net / file-sharing</span>
+              <span class="lp-browser__secure">暗号化通信</span>
+            </div>
+            <div class="lp-browser__content">
+              <div class="lp-upload-card">
+                <div class="lp-upload-card__icon" aria-hidden="true"><span></span></div>
+                <div class="lp-upload-card__body">
+                  <span class="lp-ui-label">選択したファイル</span>
+                  <strong>meeting-notes.pdf</strong>
+                  <span class="lp-ui-meta">ブラウザで暗号化してアップロード</span>
+                </div>
+                <span class="lp-upload-card__done" aria-hidden="true">✓</span>
+              </div>
+              <div class="lp-transfer-line" aria-hidden="true">
+                <span></span><i>共有の準備ができました</i><span></span>
+              </div>
+              <div class="lp-share-card">
+                <div class="lp-share-card__copy">
+                  <span class="lp-ui-label">受け取り方法</span>
+                  <strong>カメラで読み取る</strong>
+                  <p>スマートフォンの標準カメラから受け取りページへ進めます。</p>
+                  <div class="lp-expiry-chip"><span aria-hidden="true">◷</span>24時間後に自動削除</div>
+                </div>
+                <div class="lp-qr" aria-hidden="true">
+                  <div class="lp-qr__pattern">
+                    <i class="lp-qr__finder lp-qr__finder--one"></i>
+                    <i class="lp-qr__finder lp-qr__finder--two"></i>
+                    <i class="lp-qr__finder lp-qr__finder--three"></i>
+                    <span></span><span></span><span></span><span></span><span></span>
+                    <span></span><span></span><span></span><span></span><span></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="lp-floating-badge lp-floating-badge--lock" aria-hidden="true">
+            <span>✓</span>ブラウザで暗号化
+          </div>
+        </div>
         <div class="lp-section__action">
           <a class="lp-button lp-button--primary" href="/fs-qr">今すぐファイルを共有する <span aria-hidden="true">→</span></a>
         </div>
@@ -250,7 +293,7 @@
     <section id="features" class="lp-section lp-section--tinted" aria-labelledby="features-title">
       <div class="lp-container">
         <div class="lp-section__heading lp-section__heading--left">
-          <p class="lp-section__eyebrow">DESIGNED FOR EASY SHARING</p>
+          <p class="lp-section__eyebrow">02&nbsp;&nbsp;FS!QRの特長</p>
           <h2 id="features-title" class="lp-section__title">「送りたい」に、<wbr>迷わない仕組みを。</h2>
           <p class="lp-section__description">メール添付やアプリの登録に手間取る場面でも、FS!QRなら共有に必要な操作をひとつの画面で進められます。</p>
         </div>
@@ -322,22 +365,22 @@
     <section class="lp-section lp-section--use-cases" aria-labelledby="use-cases-title">
       <div class="lp-container">
         <div class="lp-section__heading">
-          <p class="lp-section__eyebrow">USE CASES</p>
+          <p class="lp-section__eyebrow">03&nbsp;&nbsp;利用シーン</p>
           <h2 id="use-cases-title" class="lp-section__title">こんなファイル共有を、<wbr>すっきり解決</h2>
         </div>
         <div class="lp-grid lp-grid--three lp-use-cases">
           <article class="lp-card lp-use-case-card">
-            <p class="lp-use-case-card__label">DEVICE TO DEVICE</p>
+            <p class="lp-use-case-card__label">端末間の移動</p>
             <h3>PCからスマホへ</h3>
             <p>PCにある資料や画像を、自分のスマートフォンへ。ケーブルをつながずQRコードから受け取れます。</p>
           </article>
           <article class="lp-card lp-use-case-card">
-            <p class="lp-use-case-card__label">IN PERSON</p>
+            <p class="lp-use-case-card__label">対面での共有</p>
             <h3>その場で相手へ</h3>
             <p>対面の打ち合わせや授業でQRコードを見せて共有。連絡先を交換する必要はありません。</p>
           </article>
           <article class="lp-card lp-use-case-card">
-            <p class="lp-use-case-card__label">REMOTE</p>
+            <p class="lp-use-case-card__label">メッセージで共有</p>
             <h3>離れた相手へ</h3>
             <p>共有ページや共有情報をメッセージで送り、相手のブラウザからファイルを受け取ってもらえます。</p>
           </article>
@@ -348,7 +391,7 @@
     <section id="faq" class="lp-section lp-section--faq" aria-labelledby="faq-title">
       <div class="lp-container lp-faq-layout">
         <div class="lp-section__heading lp-section__heading--left lp-faq-layout__intro">
-          <p class="lp-section__eyebrow">FAQ</p>
+          <p class="lp-section__eyebrow">04&nbsp;&nbsp;よくある質問</p>
           <h2 id="faq-title" class="lp-section__title">よくある質問</h2>
           <p class="lp-section__description">利用前に気になるポイントをまとめました。</p>
           <a class="lp-text-link" href="/fs-qr_menu">FS!QRの詳しい案内を見る <span aria-hidden="true">→</span></a>
@@ -381,7 +424,7 @@
     <section class="lp-final-cta" aria-labelledby="final-cta-title">
       <div class="lp-container">
         <div class="lp-final-cta__inner">
-          <p class="lp-section__eyebrow">READY WHEN YOU ARE</p>
+          <p class="lp-section__eyebrow">いますぐ共有</p>
           <h2 id="final-cta-title">ファイルを送りたい、<wbr>その瞬間に。</h2>
           <p>登録不要。ブラウザからファイルを選んで、QRコードで共有を始めましょう。</p>
           <div class="lp-final-cta__actions">

--- a/Group/templates/group_landing.html
+++ b/Group/templates/group_landing.html
@@ -164,18 +164,13 @@
     </section>
 
     <section class="lp-trust" aria-label="FS!QR Groupの利用ポイント">
-      <div class="lp-container lp-trust__grid">
-        <div class="lp-trust__item">
-          <strong>0</strong>
-          <span>アカウント登録の手間</span>
-        </div>
-        <div class="lp-trust__item">
-          <strong>4通り</strong>
-          <span>1・6・12・24時間から保存期間を選択</span>
-        </div>
-        <div class="lp-trust__item">
-          <strong>1 ROOM</strong>
-          <span>チームのファイルを一か所に集約</span>
+      <div class="lp-container">
+        <p class="lp-trust__lead">チーム共有に必要なことだけ</p>
+        <div class="lp-trust__items">
+          <div class="lp-trust__item"><strong>登録不要</strong><span>メンバーのアカウント作成なし</span></div>
+          <div class="lp-trust__item"><strong>保存期間を選択</strong><span>1・6・12・24時間</span></div>
+          <div class="lp-trust__item"><strong>ひとつのルーム</strong><span>ファイルを一か所に集約</span></div>
+          <div class="lp-trust__item"><strong>ブラウザ完結</strong><span>PC・スマートフォンに対応</span></div>
         </div>
       </div>
     </section>
@@ -183,7 +178,7 @@
     <section id="how-it-works" class="lp-section lp-section--steps" aria-labelledby="how-title">
       <div class="lp-container">
         <div class="lp-section__heading">
-          <p class="lp-section__eyebrow">HOW IT WORKS</p>
+          <p class="lp-section__eyebrow">01&nbsp;&nbsp;使い方</p>
           <h2 id="how-title" class="lp-section__title">共有開始まで、<wbr>わずか3ステップ</h2>
           <p class="lp-section__lead">専用アプリのインストールも、参加メンバーのアカウント作成も必要ありません。</p>
         </div>
@@ -225,13 +220,67 @@
             <p>参加者がファイルをアップロード。ルーム内の一覧から必要なファイルを受け取れます。</p>
           </li>
         </ol>
+        <div class="lp-mockup lp-room-mockup lp-process-preview--group" role="img" aria-label="FS!QR Groupのファイルルーム画面イメージ。ルーム情報、共有中のファイル一覧、アップロード領域が表示されています。">
+          <div class="lp-mockup__bar" aria-hidden="true">
+            <span></span><span></span><span></span>
+            <p>fs-qr.net/group/r/team24</p>
+          </div>
+          <div class="lp-room-mockup__body">
+            <aside class="lp-room-mockup__sidebar">
+              <div class="lp-room-mockup__logo" aria-hidden="true">G</div>
+              <p class="lp-room-mockup__label">CURRENT ROOM</p>
+              <p class="lp-room-mockup__room">TEAM24</p>
+              <div class="lp-room-mockup__status"><span aria-hidden="true"></span> 共有中</div>
+              <dl>
+                <div><dt>ファイル</dt><dd>4</dd></div>
+                <div><dt>保存期限</dt><dd>残り 23時間</dd></div>
+              </dl>
+              <div class="lp-room-mockup__members" aria-hidden="true">
+                <span>AK</span><span>MN</span><span>+</span>
+              </div>
+            </aside>
+            <div class="lp-room-mockup__main">
+              <div class="lp-room-mockup__heading">
+                <div>
+                  <p>Project workspace</p>
+                  <strong>共有ファイル</strong>
+                </div>
+                <span class="lp-room-mockup__upload">＋ アップロード</span>
+              </div>
+              <div class="lp-room-mockup__files" aria-hidden="true">
+                <div class="lp-room-file">
+                  <span class="lp-room-file__icon lp-room-file__icon--pdf">PDF</span>
+                  <span><strong>提案資料_最新版.pdf</strong><small>2.4 MB ・ たった今</small></span>
+                  <i>•••</i>
+                </div>
+                <div class="lp-room-file">
+                  <span class="lp-room-file__icon lp-room-file__icon--sheet">XLS</span>
+                  <span><strong>進行スケジュール.xlsx</strong><small>840 KB ・ 12分前</small></span>
+                  <i>•••</i>
+                </div>
+                <div class="lp-room-file">
+                  <span class="lp-room-file__icon lp-room-file__icon--image">JPG</span>
+                  <span><strong>イベント写真_01.jpg</strong><small>5.1 MB ・ 1時間前</small></span>
+                  <i>•••</i>
+                </div>
+              </div>
+              <div class="lp-room-mockup__drop" aria-hidden="true">
+                <span>↑</span>
+                <p><strong>ファイルをここに追加</strong><small>チームのメンバーとすぐ共有</small></p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="lp-section__action">
+          <a class="lp-button lp-button--primary" href="/create_room">グループルームを作る <span aria-hidden="true">→</span></a>
+        </div>
       </div>
     </section>
 
     <section id="features" class="lp-section lp-section--tint" aria-labelledby="features-title">
       <div class="lp-container">
         <div class="lp-section__heading lp-section__heading--left">
-          <p class="lp-section__eyebrow">BUILT FOR QUICK SHARING</p>
+          <p class="lp-section__eyebrow">02&nbsp;&nbsp;Groupの特長</p>
           <h2 id="features-title" class="lp-section__title">チームの一時共有に、<br>ちょうどいい仕組み。</h2>
         </div>
         <div class="lp-grid lp-grid--features">
@@ -318,7 +367,7 @@
     <section id="use-cases" class="lp-section" aria-labelledby="use-cases-title">
       <div class="lp-container">
         <div class="lp-section__heading">
-          <p class="lp-section__eyebrow">USE CASES</p>
+          <p class="lp-section__eyebrow">03&nbsp;&nbsp;利用シーン</p>
           <h2 id="use-cases-title" class="lp-section__title">仕事、学び、イベント。<br>人が集まる場のファイル共有に。</h2>
         </div>
         <div class="lp-grid lp-grid--use-cases">
@@ -327,7 +376,7 @@
               <span></span><span></span><span></span>
             </div>
             <div class="lp-use-card__content">
-              <p class="lp-use-card__tag">PROJECT TEAM</p>
+              <p class="lp-use-card__tag">プロジェクトチーム</p>
               <h3>プロジェクト資料の集約</h3>
               <p>提案書や画像、進行資料をひとつのルームへ。メール添付が複数のスレッドに散らばるのを防ぎます。</p>
             </div>
@@ -337,7 +386,7 @@
               <span></span><span></span><span></span>
             </div>
             <div class="lp-use-card__content">
-              <p class="lp-use-card__tag">CLASS &amp; EVENT</p>
+              <p class="lp-use-card__tag">授業・イベント</p>
               <h3>授業・研修・イベント</h3>
               <p>会場にQRコードを掲示し、資料や写真を共有。参加者ごとのアカウント準備は不要です。</p>
             </div>
@@ -347,7 +396,7 @@
               <span></span><span></span><span></span>
             </div>
             <div class="lp-use-card__content">
-              <p class="lp-use-card__tag">EXTERNAL PARTNERS</p>
+              <p class="lp-use-card__tag">社外との連携</p>
               <h3>社外メンバーとの受け渡し</h3>
               <p>取引先や協力メンバーと必要な期間だけ共有。相手に新しいサービスへの登録を依頼せず始められます。</p>
             </div>
@@ -359,7 +408,7 @@
     <section id="faq" class="lp-section lp-section--faq" aria-labelledby="faq-title">
       <div class="lp-container lp-faq-layout">
         <div class="lp-faq-layout__intro">
-          <p class="lp-section__eyebrow">FAQ</p>
+          <p class="lp-section__eyebrow">04&nbsp;&nbsp;よくある質問</p>
           <h2 id="faq-title" class="lp-section__title">よくある質問</h2>
           <p>使い始める前に知っておきたい内容をまとめました。</p>
           <a class="lp-text-link" href="/group_menu">Groupの既存メニューを見る <span aria-hidden="true">→</span></a>
@@ -391,7 +440,7 @@
 
     <section class="lp-final-cta" aria-labelledby="final-cta-title">
       <div class="lp-container lp-final-cta__inner">
-        <p class="lp-section__eyebrow">READY TO SHARE?</p>
+        <p class="lp-section__eyebrow">いますぐルームを作成</p>
         <h2 id="final-cta-title">次のファイル共有を、<br>もっと軽やかに。</h2>
         <p>アカウント登録は不要です。まずは保存期間を選び、チームのルームを作成してください。</p>
         <div class="lp-actions lp-actions--center">

--- a/Note/templates/note_landing.html
+++ b/Note/templates/note_landing.html
@@ -117,6 +117,7 @@
         <span class="lp-brand__text"><strong>FS!QR</strong> Note</span>
       </a>
       <nav class="lp-nav" aria-label="メインナビゲーション">
+        <a href="#how-it-works">使い方</a>
         <a href="#features">特長</a>
         <a href="#use-cases">活用例</a>
         <a href="#faq">よくある質問</a>
@@ -152,17 +153,21 @@
     </section>
 
     <section class="lp-trust" aria-label="FS!QR Noteをすぐに使える理由">
-      <div class="lp-container lp-trust__grid">
-        <div class="lp-trust__item"><span class="lp-trust__icon" aria-hidden="true">01</span><p><strong>登録なし</strong><br>名前やメールアドレスの入力なし</p></div>
-        <div class="lp-trust__item"><span class="lp-trust__icon" aria-hidden="true">02</span><p><strong>ブラウザで完結</strong><br>専用アプリの準備なし</p></div>
-        <div class="lp-trust__item"><span class="lp-trust__icon" aria-hidden="true">03</span><p><strong>URLで共有</strong><br>いつもの連絡手段で送るだけ</p></div>
+      <div class="lp-container">
+        <p class="lp-trust__lead">書き始めるまでを、シンプルに</p>
+        <div class="lp-trust__items">
+          <div class="lp-trust__item"><strong>登録不要</strong><span>個人情報の入力なし</span></div>
+          <div class="lp-trust__item"><strong>ブラウザ完結</strong><span>専用アプリの準備なし</span></div>
+          <div class="lp-trust__item"><strong>リアルタイム同期</strong><span>同じノートへすぐ反映</span></div>
+          <div class="lp-trust__item"><strong>自動保存</strong><span>保存操作を気にせず編集</span></div>
+        </div>
       </div>
     </section>
 
     <section class="lp-section lp-section--steps" id="how-it-works" aria-labelledby="steps-title">
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
-          <p class="lp-kicker lp-section__eyebrow">HOW IT WORKS</p>
+          <p class="lp-kicker lp-section__eyebrow">01&nbsp;&nbsp;使い方</p>
           <h2 class="lp-section__title" id="steps-title">3ステップで、<wbr>共同編集を開始</h2>
           <p>複雑な共有設定はありません。必要なときにノートを開いて、相手を招待できます。</p>
         </div>
@@ -203,13 +208,46 @@
             <p>同じノートを開き、リアルタイムでテキストを編集します。</p>
           </li>
         </ol>
+        <figure class="lp-mockup lp-product-visual lp-note-mock lp-process-preview--note" aria-labelledby="note-mock-caption">
+          <div class="lp-note-mock__window">
+            <div class="lp-note-mock__topbar">
+              <div class="lp-window-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+              <span class="lp-note-mock__room">チーム定例ノート</span>
+              <div class="lp-note-mock__people" aria-label="3人が参加中">
+                <span aria-hidden="true">A</span><span aria-hidden="true">M</span><span aria-hidden="true">K</span>
+              </div>
+            </div>
+            <div class="lp-note-mock__body">
+              <aside class="lp-note-mock__rail" aria-hidden="true">
+                <span class="is-active"></span><span></span><span></span><span></span>
+              </aside>
+              <div class="lp-note-mock__editor">
+                <div class="lp-note-mock__meta"><span>7月20日 チーム定例</span><span class="lp-save-state">● 保存済み</span></div>
+                <div class="lp-note-mock__title">今日決めること</div>
+                <div class="lp-note-mock__line lp-note-mock__line--long"></div>
+                <div class="lp-note-mock__line lp-note-mock__line--medium"></div>
+                <div class="lp-note-mock__line lp-note-mock__line--short"></div>
+                <div class="lp-note-mock__section">次のアクション</div>
+                <div class="lp-note-mock__task"><span aria-hidden="true">✓</span><span>公開前の最終確認</span></div>
+                <div class="lp-note-mock__task"><span aria-hidden="true"></span><span>フィードバックを反映</span></div>
+                <span class="lp-cursor lp-cursor--one" aria-hidden="true"><i></i><b>Akira</b></span>
+                <span class="lp-cursor lp-cursor--two" aria-hidden="true"><i></i><b>Mio</b></span>
+              </div>
+            </div>
+          </div>
+          <div class="lp-floating-status" aria-hidden="true"><span>✓</span><strong>リアルタイム同期</strong></div>
+          <figcaption id="note-mock-caption" class="lp-visually-hidden">複数人が同じノートをリアルタイムで編集している画面イメージ</figcaption>
+        </figure>
+        <div class="lp-section__action">
+          <a class="lp-button lp-button--primary" href="/create_note_room">共有ノートを作る <span aria-hidden="true">→</span></a>
+        </div>
       </div>
     </section>
 
     <section class="lp-section lp-section--tint" id="features" aria-labelledby="features-title">
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
-          <p class="lp-kicker lp-section__eyebrow">FEATURES</p>
+          <p class="lp-kicker lp-section__eyebrow">02&nbsp;&nbsp;Noteの特長</p>
           <h2 class="lp-section__title" id="features-title">速く、迷わず、<wbr>ひとつにまとまる</h2>
           <p>共同メモに必要な機能を、シンプルな画面にまとめました。</p>
         </div>
@@ -264,21 +302,21 @@
     <section class="lp-section" id="use-cases" aria-labelledby="use-cases-title">
       <div class="lp-container">
         <div class="lp-section-heading lp-section__heading">
-          <p class="lp-kicker lp-section__eyebrow">USE CASES</p>
+          <p class="lp-kicker lp-section__eyebrow">03&nbsp;&nbsp;利用シーン</p>
           <h2 class="lp-section__title" id="use-cases-title">「今、一緒に書きたい」<wbr>場面に</h2>
         </div>
         <div class="lp-grid lp-use-case-grid">
           <article class="lp-card lp-use-case-card">
             <div class="lp-use-case-card__visual lp-use-case-card__visual--meeting" aria-hidden="true"><span></span><span></span><span></span></div>
-            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">MEETING</p><h3>会議の議事録</h3><p>参加者が気づいたことをその場で追記。決定事項と次のアクションを、ひとつのノートにまとめます。</p></div>
+            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">会議・打ち合わせ</p><h3>会議の議事録</h3><p>参加者が気づいたことをその場で追記。決定事項と次のアクションを、ひとつのノートにまとめます。</p></div>
           </article>
           <article class="lp-card lp-use-case-card">
             <div class="lp-use-case-card__visual lp-use-case-card__visual--ideas" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">IDEATION</p><h3>アイデア出し</h3><p>思いついた言葉を全員で書き足し、対話しながら考えを広げます。</p></div>
+            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">発想を集める</p><h3>アイデア出し</h3><p>思いついた言葉を全員で書き足し、対話しながら考えを広げます。</p></div>
           </article>
           <article class="lp-card lp-use-case-card">
             <div class="lp-use-case-card__visual lp-use-case-card__visual--learning" aria-hidden="true"><span></span><i></i></div>
-            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">LEARNING</p><h3>授業・勉強会のメモ</h3><p>参加者それぞれの視点を集めて、あとから読み返しやすい共有ノートを作れます。</p></div>
+            <div class="lp-use-case-card__body"><p class="lp-use-case-card__tag">授業・学習</p><h3>授業・勉強会のメモ</h3><p>参加者それぞれの視点を集めて、あとから読み返しやすい共有ノートを作れます。</p></div>
           </article>
         </div>
       </div>
@@ -287,7 +325,7 @@
     <section class="lp-section lp-section--faq" id="faq" aria-labelledby="faq-title">
       <div class="lp-container lp-faq-layout">
         <div class="lp-faq-intro">
-          <p class="lp-kicker lp-section__eyebrow">FAQ</p>
+          <p class="lp-kicker lp-section__eyebrow">04&nbsp;&nbsp;よくある質問</p>
           <h2 class="lp-section__title" id="faq-title">よくある質問</h2>
           <p>FS!QR Noteの利用前に確認したいポイントをまとめました。</p>
           <a class="lp-text-link" href="/note_menu">既存のNoteメニューを見る <span aria-hidden="true">→</span></a>
@@ -316,7 +354,7 @@
     <section class="lp-final-cta" aria-labelledby="cta-title">
       <div class="lp-final-cta__glow" aria-hidden="true"></div>
       <div class="lp-container lp-final-cta__inner">
-        <p class="lp-kicker lp-section__eyebrow">START WRITING TOGETHER</p>
+        <p class="lp-kicker lp-section__eyebrow">いますぐ共同編集</p>
         <h2 id="cta-title">次のメモは、<wbr>みんなで書こう。</h2>
         <p>登録は不要です。共有ノートを作って、リアルタイム共同編集を始めましょう。</p>
         <div class="lp-actions lp-actions--center">

--- a/static/css/15-product-landing.css
+++ b/static/css/15-product-landing.css
@@ -2504,42 +2504,88 @@ body.product-lp {
 /* ================================================================
    FS!QR landing refinements / FS!QR ランディングページの意匠調整
    すべて .product-lp--fsqr にスコープし、Note / Group には影響させない。
-   目的：日本語見出しの字面を整え、余白と影を落ち着かせ、QRを主役にした
-   一貫した記号（ファインダーパターン）で「作り込まれた」印象へ引き上げる。
+   目的：生成イラストや過剰な装飾に頼らず、実際の操作を想像できるUI図解と
+   編集的な余白・タイポグラフィで、信頼感のあるファイル共有LPに整える。
    ================================================================ */
 
-/* Grounded shadows / 影を軽く近づけ、浮遊感の強い大ぼかしを避ける */
 .product-lp--fsqr {
-  --lp-shadow-sm: 0 2px 6px rgba(16, 32, 48, 0.05),
-    0 14px 30px -18px rgba(16, 32, 48, 0.22);
-  --lp-shadow-lg: 0 4px 14px rgba(16, 32, 48, 0.06),
-    0 30px 60px -30px rgba(16, 32, 48, 0.28);
+  --lp-ink: #172033;
+  --lp-muted: #5d6677;
+  --lp-line: rgba(23, 32, 51, 0.13);
+  --lp-canvas: #f6f6f3;
+  --lp-accent: #2858c7;
+  --lp-accent-dark: #1f469f;
+  --lp-accent-soft: #e9eef9;
+  --lp-accent-rgb: 40, 88, 199;
+  --lp-shadow-sm: 0 8px 22px rgba(23, 32, 51, 0.08);
+  --lp-shadow-lg: 0 24px 60px rgba(23, 32, 51, 0.13);
+  color: var(--lp-ink);
+  background: var(--lp-canvas);
 }
 
-/* Typography / 日本語見出しの詰めすぎを解消し、読みやすい字面へ */
+/* Header / 常に現在地が分かる、静かな固定ヘッダー */
+.product-lp--fsqr .lp-header {
+  position: sticky;
+  top: 0;
+  border-color: rgba(23, 32, 51, 0.1);
+  background: rgba(250, 250, 248, 0.94);
+  backdrop-filter: blur(12px);
+}
+
+.product-lp--fsqr .lp-brand__mark {
+  border: 1px solid rgba(23, 32, 51, 0.1);
+  border-radius: 9px;
+  box-shadow: none;
+}
+
+.product-lp--fsqr .lp-nav {
+  color: #525c6d;
+}
+
+.product-lp--fsqr .lp-button {
+  border-radius: 10px;
+  box-shadow: none;
+}
+
+.product-lp--fsqr .lp-button:hover {
+  box-shadow: 0 8px 18px rgba(31, 70, 159, 0.18);
+  transform: translateY(-1px);
+}
+
+.product-lp--fsqr .lp-button--secondary {
+  border-color: rgba(23, 32, 51, 0.18);
+  color: var(--lp-ink) !important;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.product-lp--fsqr .lp-button--secondary:hover {
+  border-color: rgba(23, 32, 51, 0.3);
+  background: #fff;
+}
+
+/* Typography / 和文を無理に詰めず、見出しと本文の差を明快にする */
 .product-lp--fsqr h1,
 .product-lp--fsqr h2,
 .product-lp--fsqr h3 {
-  letter-spacing: -0.01em;
-  line-height: 1.36;
+  letter-spacing: -0.025em;
+  line-height: 1.35;
 }
 
 .product-lp--fsqr .lp-hero h1 {
-  max-width: 12em;
-  font-size: clamp(40px, 4.4vw, 58px);
-  font-weight: 800;
-  letter-spacing: -0.015em;
-  line-height: 1.32;
+  max-width: 9em;
+  margin-bottom: 26px;
+  font-size: clamp(44px, 5vw, 68px);
+  font-weight: 780;
+  letter-spacing: -0.045em;
+  line-height: 1.18;
 }
 
 .product-lp--fsqr .lp-section__title {
-  font-size: clamp(25px, 3.4vw, 44px);
-  font-weight: 800;
-  line-height: 1.32;
+  font-size: clamp(29px, 3.4vw, 43px);
+  font-weight: 760;
+  line-height: 1.38;
 }
 
-/* 見出しの改行制御 / 単語の途中で折り返さない。<wbr> を句点の後に置き、
-   keep-all で不用意な分割を抑えつつ、狭い画面では anywhere で溢れを防ぐ。 */
 .product-lp--fsqr .lp-hero h1,
 .product-lp--fsqr .lp-section__title,
 .product-lp--fsqr .lp-final-cta h2 {
@@ -2549,68 +2595,222 @@ body.product-lp {
 
 .product-lp--fsqr .lp-card h3 {
   font-size: 20px;
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 .product-lp--fsqr .lp-hero__lead,
 .product-lp--fsqr .lp-section__description {
-  line-height: 1.9;
+  line-height: 1.85;
 }
 
-/* Signature marker / QRのファインダーパターンを模した共通の目印。
-   見出しラベル・特長・ユースケースに一貫して添え、ブランドの記号にする。 */
+/* Labels / 装飾的な英字ラベルを避け、短い罫線で章立てを示す */
 .product-lp--fsqr .lp-section__eyebrow,
 .product-lp--fsqr .lp-use-case-card__label {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
+  gap: 11px;
+  color: var(--lp-accent-dark);
+  letter-spacing: 0.04em;
 }
 
 .product-lp--fsqr .lp-section__eyebrow::before,
-.product-lp--fsqr .lp-use-case-card__label::before,
-.product-lp--fsqr .lp-trust__items .lp-trust__item strong::before {
+.product-lp--fsqr .lp-use-case-card__label::before {
   content: "";
   flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border: 2px solid currentColor;
-  border-radius: 2.5px;
-  background: radial-gradient(circle at center, currentColor 0 1.3px, transparent 1.7px);
+  width: 24px;
+  height: 1px;
+  background: currentColor;
 }
 
-/* Hero / 抽象的なリングと二重の放射グラデーションを整理し、静かな光へ */
+/* Hero / コピーと実際の利用フローを示すUI図解 */
 .product-lp--fsqr .lp-hero {
-  padding: 88px 0 84px;
-  background:
-    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.10), transparent 56%),
-    linear-gradient(180deg, #fbfcff 0%, var(--lp-canvas) 100%);
+  padding: 82px 0 92px;
+  border-bottom: 1px solid var(--lp-line);
+  background: #f6f6f3;
 }
 
 .product-lp--fsqr .lp-hero::before {
   display: none;
 }
 
+.product-lp--fsqr .lp-hero__grid {
+  grid-template-columns: minmax(0, 0.88fr) minmax(480px, 1.12fr);
+  gap: clamp(54px, 7vw, 96px);
+}
+
+.product-lp--fsqr .lp-hero__eyebrow {
+  margin-bottom: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-weight: 700;
+}
+
+.product-lp--fsqr .lp-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
 .product-lp--fsqr .lp-hero__title span {
   color: var(--lp-accent);
 }
 
-.product-lp--fsqr .lp-page-shot {
-  border-color: rgba(16, 32, 48, 0.08);
-  border-radius: 24px;
-  box-shadow: var(--lp-shadow-lg);
-  transform: rotate(0.8deg);
+.product-lp--fsqr .lp-hero__lead {
+  max-width: 34em;
+  font-size: 17px;
 }
 
-/* Trust band / 目印を添え、行間と区切りを整えて情報の帯として自立させる */
+.product-lp--fsqr .lp-page-shot {
+  padding: 10px;
+  border-color: rgba(23, 32, 51, 0.1);
+  border-radius: 22px;
+  background: #fff;
+  box-shadow: var(--lp-shadow-lg);
+  transform: none;
+}
+
+.product-lp--fsqr .lp-page-shot img {
+  border-radius: 13px;
+}
+
+.product-lp--fsqr .lp-check-list li::before {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border: 1px solid rgba(var(--lp-accent-rgb), 0.25);
+  border-radius: 50%;
+  color: var(--lp-accent-dark);
+  background: #fff;
+  content: "✓";
+  font-size: 10px;
+}
+
+.product-lp--fsqr .lp-mockup--fsqr {
+  padding: 10px;
+  border: 1px solid rgba(23, 32, 51, 0.1);
+  border-radius: 22px;
+  background: #fff;
+  box-shadow: var(--lp-shadow-lg);
+}
+
+.product-lp--fsqr .lp-browser {
+  overflow: hidden;
+  border: 1px solid rgba(23, 32, 51, 0.12);
+  border-radius: 14px;
+  box-shadow: none;
+  transform: none;
+}
+
+.product-lp--fsqr .lp-browser__bar {
+  min-height: 48px;
+  border-color: rgba(23, 32, 51, 0.1);
+  background: #f2f3f5;
+}
+
+.product-lp--fsqr .lp-browser__address {
+  border-color: rgba(23, 32, 51, 0.1);
+  border-radius: 6px;
+  color: #6f7785;
+}
+
+.product-lp--fsqr .lp-browser__secure {
+  color: #24705d;
+}
+
+.product-lp--fsqr .lp-browser__content {
+  min-height: 418px;
+  padding: 34px;
+  background: #f6f7f9;
+}
+
+.product-lp--fsqr .lp-upload-card,
+.product-lp--fsqr .lp-share-card {
+  border-color: rgba(23, 32, 51, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 5px 14px rgba(23, 32, 51, 0.06);
+}
+
+.product-lp--fsqr .lp-upload-card {
+  padding: 18px 20px;
+}
+
+.product-lp--fsqr .lp-upload-card__icon {
+  border-radius: 8px;
+}
+
+.product-lp--fsqr .lp-upload-card__body strong {
+  font-size: 13px;
+}
+
+.product-lp--fsqr .lp-ui-label,
+.product-lp--fsqr .lp-ui-meta {
+  font-size: 10px;
+}
+
+.product-lp--fsqr .lp-transfer-line {
+  padding-block: 19px;
+}
+
+.product-lp--fsqr .lp-transfer-line i {
+  font-size: 10px;
+}
+
+.product-lp--fsqr .lp-share-card {
+  padding: 26px;
+}
+
+.product-lp--fsqr .lp-share-card__copy strong {
+  font-size: 17px;
+}
+
+.product-lp--fsqr .lp-share-card__copy p {
+  max-width: 23em;
+  font-size: 10px;
+}
+
+.product-lp--fsqr .lp-qr {
+  border: 1px solid rgba(23, 32, 51, 0.08);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.product-lp--fsqr .lp-floating-badge {
+  right: -16px;
+  bottom: -18px;
+  border-color: rgba(23, 32, 51, 0.14);
+  border-radius: 9px;
+  box-shadow: var(--lp-shadow-sm);
+}
+
+.product-lp--fsqr .lp-process-preview {
+  width: min(100%, 760px);
+  margin: 54px auto 0;
+}
+
+/* Trust band / 事実を簡潔に並べる情報帯 */
+.product-lp--fsqr .lp-trust {
+  padding: 28px 0 34px;
+}
+
+.product-lp--fsqr .lp-trust__lead {
+  margin-bottom: 16px;
+  color: #697181;
+  letter-spacing: 0.04em;
+}
+
 .product-lp--fsqr .lp-trust__items {
   overflow: hidden;
   border: 1px solid var(--lp-line);
-  border-radius: var(--lp-radius-sm);
+  border-radius: 10px;
 }
 
 .product-lp--fsqr .lp-trust__items .lp-trust__item {
   gap: 6px;
-  padding: 18px 20px;
+  padding: 17px 20px;
   border-right: 1px solid var(--lp-line);
 }
 
@@ -2619,27 +2819,90 @@ body.product-lp {
 }
 
 .product-lp--fsqr .lp-trust__items .lp-trust__item strong {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
   color: var(--lp-ink);
   font-size: 15px;
 }
 
-/* Step & feature icons / 空箱・記号だった箇所を線画アイコンに置き換える */
+/* Sections and cards / 影よりも罫線と余白で情報を整理する */
+.product-lp--fsqr .lp-section {
+  padding: 104px 0;
+}
+
+.product-lp--fsqr .lp-section__heading {
+  margin-bottom: 50px;
+}
+
+.product-lp--fsqr .lp-section--steps {
+  background: #fff;
+}
+
+.product-lp--fsqr .lp-card {
+  border-color: rgba(23, 32, 51, 0.12);
+  border-radius: 14px;
+  box-shadow: none;
+}
+
 .product-lp--fsqr .lp-step-card__icon svg,
 .product-lp--fsqr .lp-feature-card__icon svg {
   width: 26px;
   height: 26px;
 }
 
-.product-lp--fsqr .lp-step-card__icon {
-  margin-bottom: 30px;
+.product-lp--fsqr .lp-step-card {
+  min-height: 286px;
+  padding: 30px;
+  border-top: 3px solid var(--lp-accent);
 }
 
-/* Feature cards / 白背景の淡い青みを抑え、暗色カードを青系のインクへ寄せる */
+.product-lp--fsqr .lp-step-card:hover {
+  box-shadow: var(--lp-shadow-sm);
+  transform: translateY(-2px);
+}
+
+.product-lp--fsqr .lp-step-card__icon {
+  margin-bottom: 32px;
+  border-radius: 10px;
+}
+
+/* Feature cards / 大きな価値と補足機能を明快な段組みで見せる */
+.product-lp--fsqr .lp-section--tinted {
+  background: #f0f2f5;
+}
+
 .product-lp--fsqr .lp-feature-card--wide {
-  background: linear-gradient(165deg, #16233f 0%, #0f1a30 100%);
+  min-height: 340px;
+  grid-column: 1 / -1;
+  grid-row: auto;
+  padding: 42px;
+  background: #172033;
+}
+
+.product-lp--fsqr .lp-feature-card--wide h3,
+.product-lp--fsqr .lp-feature-card--wide > p {
+  max-width: 45%;
+}
+
+.product-lp--fsqr .lp-feature-card {
+  min-height: 235px;
+}
+
+.product-lp--fsqr .lp-feature-card__icon {
+  border-radius: 10px;
+}
+
+.product-lp--fsqr .lp-feature-card--wide .lp-feature-card__icon {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.product-lp--fsqr .lp-device-bridge {
+  top: 42px;
+  right: 42px;
+  bottom: 42px;
+  left: auto;
+  width: 45%;
+  height: auto;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.055);
 }
 
 .product-lp--fsqr .lp-device-bridge__flow {
@@ -2661,27 +2924,155 @@ body.product-lp {
   transform: rotate(45deg);
 }
 
-/* Use cases / 装飾リングを弱め、カードの青みを控えめにして上質に */
+/* Use cases / 日常の場面を読み物のようなカードで見せる */
+.product-lp--fsqr .lp-section--use-cases {
+  background: #fff;
+}
+
 .product-lp--fsqr .lp-use-case-card {
-  background: linear-gradient(160deg, #ffffff 0%, #fafbff 100%);
+  min-height: 230px;
+  padding: 30px;
+  border-left: 3px solid var(--lp-accent);
+  background: #fff;
 }
 
 .product-lp--fsqr .lp-use-case-card::after {
-  box-shadow: none;
-  opacity: 0.65;
+  display: none;
 }
 
-/* Cool-neutral cohesion / 緑みのある無彩色を青のブランドへ寄せて統一する */
+/* FAQ and conversion / 装飾を抑え、質問と行動導線に集中させる */
 .product-lp--fsqr .lp-section--faq {
-  background: #eef2f8;
+  background: #f1f2f0;
+}
+
+.product-lp--fsqr .lp-faq-list {
+  border-color: rgba(23, 32, 51, 0.18);
+}
+
+.product-lp--fsqr .lp-faq-item {
+  border-color: rgba(23, 32, 51, 0.16);
+}
+
+.product-lp--fsqr .lp-faq-item summary {
+  font-weight: 700;
 }
 
 .product-lp--fsqr .lp-final-cta {
-  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 68%, #123a9e 100%);
+  padding: 96px 0;
+  background: #1a2740;
+}
+
+.product-lp--fsqr .lp-final-cta::before,
+.product-lp--fsqr .lp-final-cta::after {
+  display: none;
+}
+
+.product-lp--fsqr .lp-final-cta h2 {
+  font-weight: 760;
+}
+
+.product-lp--fsqr .lp-final-cta .lp-button--secondary {
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #fff !important;
+  background: transparent;
 }
 
 .product-lp--fsqr .lp-footer {
   background: #101827;
+}
+
+@media (max-width: 980px) {
+  .product-lp--fsqr .lp-hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .product-lp--fsqr .lp-mockup--fsqr,
+  .product-lp--fsqr .lp-page-shot {
+    width: min(100%, 680px);
+    margin-inline: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .product-lp--fsqr .lp-hero {
+    padding: 58px 0 72px;
+  }
+
+  .product-lp--fsqr .lp-hero h1 {
+    font-size: clamp(42px, 13vw, 58px);
+  }
+
+  .product-lp--fsqr .lp-browser__secure {
+    display: none;
+  }
+
+  .product-lp--fsqr .lp-browser__bar {
+    grid-template-columns: auto 1fr;
+    gap: 12px;
+  }
+
+  .product-lp--fsqr .lp-browser__content {
+    min-height: 378px;
+    padding: 20px;
+  }
+
+  .product-lp--fsqr .lp-floating-badge {
+    right: 8px;
+  }
+
+  .product-lp--fsqr .lp-trust__items .lp-trust__item:nth-child(even) {
+    border-right: 0;
+  }
+
+  .product-lp--fsqr .lp-section {
+    padding: 78px 0;
+  }
+
+  .product-lp--fsqr .lp-feature-card--wide {
+    min-height: 510px;
+    padding: 30px;
+  }
+
+  .product-lp--fsqr .lp-feature-card--wide h3,
+  .product-lp--fsqr .lp-feature-card--wide > p {
+    max-width: none;
+  }
+
+  .product-lp--fsqr .lp-device-bridge {
+    top: auto;
+    right: 30px;
+    bottom: 30px;
+    left: 30px;
+    width: auto;
+    height: 190px;
+  }
+}
+
+@media (max-width: 430px) {
+  .product-lp--fsqr .lp-mockup--fsqr {
+    padding: 6px;
+    border-radius: 16px;
+  }
+
+  .product-lp--fsqr .lp-browser__content {
+    padding: 14px;
+  }
+
+  .product-lp--fsqr .lp-upload-card {
+    padding: 14px;
+  }
+
+  .product-lp--fsqr .lp-share-card {
+    padding: 16px;
+  }
+
+  .product-lp--fsqr .lp-share-card__copy strong {
+    font-size: 14px;
+  }
+
+  .product-lp--fsqr .lp-floating-badge {
+    display: none;
+  }
 }
 
 /* ================================================================

--- a/static/css/15-product-landing.css
+++ b/static/css/15-product-landing.css
@@ -3077,60 +3077,110 @@ body.product-lp {
 
 /* ================================================================
    Note & Group landing refinements / Note・Group LP の意匠調整
-   FS!QR LP と同じ方針を、Note（紫）・Group（緑）へブランド別に適用する。
-   構造的な調整は両者共通、色はブランドごとに分けて記述する。
+   生成イラストを概念説明として残し、実利用UIの図解と編集的なレイアウトで
+   各サービスの用途と操作を具体的に伝える。
    ================================================================ */
 
-/* Grounded shadows / 影を落ち着かせる（両ブランド共通） */
-.product-lp--note,
-.product-lp--group {
-  --lp-shadow-sm: 0 2px 6px rgba(16, 24, 40, 0.05),
-    0 14px 30px -18px rgba(16, 24, 40, 0.22);
-  --lp-shadow-lg: 0 4px 14px rgba(16, 24, 40, 0.06),
-    0 30px 60px -30px rgba(16, 24, 40, 0.28);
+.product-lp--note {
+  --lp-ink: #211d2d;
+  --lp-muted: #696273;
+  --lp-line: rgba(33, 29, 45, 0.13);
+  --lp-canvas: #f7f5f3;
+  --lp-accent: #6852a3;
+  --lp-accent-dark: #4d3a80;
+  --lp-accent-soft: #eeeaf6;
+  --lp-accent-rgb: 104, 82, 163;
+  --lp-shadow-sm: 0 8px 22px rgba(33, 29, 45, 0.08);
+  --lp-shadow-lg: 0 24px 60px rgba(33, 29, 45, 0.13);
 }
 
-/* Typography / 和文見出しの字間・行間を整える */
+.product-lp--group {
+  --lp-ink: #17251f;
+  --lp-muted: #5e6b65;
+  --lp-line: rgba(23, 37, 31, 0.13);
+  --lp-canvas: #f4f6f3;
+  --lp-accent: #197654;
+  --lp-accent-dark: #115c40;
+  --lp-accent-soft: #e5f1eb;
+  --lp-accent-rgb: 25, 118, 84;
+  --lp-shadow-sm: 0 8px 22px rgba(23, 37, 31, 0.08);
+  --lp-shadow-lg: 0 24px 60px rgba(23, 37, 31, 0.13);
+}
+
+/* Header and controls / 影と丸みを抑えた固定ヘッダー */
+.product-lp--note .lp-header,
+.product-lp--group .lp-header {
+  position: sticky;
+  top: 0;
+  border-color: var(--lp-line);
+  background: rgba(250, 249, 247, 0.94);
+  backdrop-filter: blur(12px);
+}
+
+.product-lp--note .lp-brand__mark,
+.product-lp--group .lp-brand__mark {
+  border: 1px solid var(--lp-line);
+  border-radius: 9px;
+  box-shadow: none;
+}
+
+.product-lp--note .lp-button,
+.product-lp--group .lp-button {
+  border-radius: 10px;
+  box-shadow: none;
+}
+
+.product-lp--note .lp-button:hover,
+.product-lp--group .lp-button:hover {
+  box-shadow: 0 8px 18px rgba(var(--lp-accent-rgb), 0.18);
+  transform: translateY(-1px);
+}
+
+.product-lp--group .lp-button--secondary {
+  border-color: var(--lp-line);
+  color: var(--lp-ink) !important;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.product-lp--group .lp-button--secondary:hover {
+  border-color: rgba(var(--lp-accent-rgb), 0.32);
+  background: #fff;
+}
+
+/* Typography / 和文の読みやすさを優先した字間と行間 */
 .product-lp--note h1,
 .product-lp--note h2,
 .product-lp--note h3,
 .product-lp--group h1,
 .product-lp--group h2,
 .product-lp--group h3 {
-  letter-spacing: -0.01em;
-  line-height: 1.36;
+  letter-spacing: -0.025em;
+  line-height: 1.35;
 }
 
-.product-lp--note .lp-hero h1 {
-  max-width: 12em;
-  font-size: clamp(40px, 4.4vw, 58px);
-  font-weight: 800;
-  letter-spacing: -0.015em;
-  line-height: 1.3;
-}
-
+.product-lp--note .lp-hero h1,
 .product-lp--group .lp-hero h1 {
-  max-width: 13em;
-  font-size: clamp(32px, 3.4vw, 46px);
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  line-height: 1.34;
+  max-width: 10em;
+  margin-bottom: 26px;
+  font-size: clamp(42px, 4.8vw, 64px);
+  font-weight: 780;
+  letter-spacing: -0.045em;
+  line-height: 1.2;
 }
 
 .product-lp--note .lp-section__title,
 .product-lp--group .lp-section__title {
-  font-size: clamp(25px, 3.4vw, 44px);
-  font-weight: 800;
-  line-height: 1.32;
+  font-size: clamp(29px, 3.4vw, 43px);
+  font-weight: 760;
+  line-height: 1.38;
 }
 
 .product-lp--note .lp-card h3,
 .product-lp--group .lp-card h3 {
   font-size: 20px;
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
-/* 見出しの改行制御 / 単語の途中で折り返さない（<wbr> と keep-all の併用） */
 .product-lp--note .lp-hero h1,
 .product-lp--note .lp-section__title,
 .product-lp--note .lp-final-cta h2,
@@ -3141,14 +3191,16 @@ body.product-lp {
   overflow-wrap: anywhere;
 }
 
-/* Signature marker / 見出しラベルと活用例タグに共通の目印を添える */
+/* Labels / 英字の装飾ラベルを日本語の章立てへ置き換える */
 .product-lp--note .lp-section__eyebrow,
 .product-lp--note .lp-use-case-card__tag,
 .product-lp--group .lp-section__eyebrow,
 .product-lp--group .lp-use-card__tag {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
+  gap: 11px;
+  color: var(--lp-accent-dark);
+  letter-spacing: 0.04em;
 }
 
 .product-lp--note .lp-section__eyebrow::before,
@@ -3157,17 +3209,24 @@ body.product-lp {
 .product-lp--group .lp-use-card__tag::before {
   content: "";
   flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border: 2px solid currentColor;
-  border-radius: 2.5px;
-  background: radial-gradient(circle at center, currentColor 0 1.3px, transparent 1.7px);
+  width: 24px;
+  height: 1px;
+  background: currentColor;
 }
 
-/* Hero / 抽象的なリングと放射グラデーションを整理して静かな光へ */
+/* Hero / 生成イラストを白いフレーム内の概念図として扱う */
 .product-lp--note .lp-hero,
 .product-lp--group .lp-hero {
-  padding: 88px 0 84px;
+  padding: 82px 0 92px;
+  border-bottom: 1px solid var(--lp-line);
+}
+
+.product-lp--note .lp-hero {
+  background: #f7f5f3;
+}
+
+.product-lp--group .lp-hero {
+  background: #f4f6f3;
 }
 
 .product-lp--note .lp-hero::before,
@@ -3175,14 +3234,142 @@ body.product-lp {
   display: none;
 }
 
-.product-lp--note .lp-page-shot,
-.product-lp--group .lp-page-shot {
-  border-radius: 24px;
-  box-shadow: var(--lp-shadow-lg);
-  transform: rotate(0.8deg);
+.product-lp--note .lp-hero__grid,
+.product-lp--group .lp-hero__grid {
+  grid-template-columns: minmax(0, 0.88fr) minmax(480px, 1.12fr);
+  gap: clamp(54px, 7vw, 96px);
 }
 
-/* Icons / 空箱・記号だった箇所を線画アイコンに置き換える */
+.product-lp--note .lp-eyebrow,
+.product-lp--group .lp-eyebrow {
+  margin-bottom: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-weight: 700;
+}
+
+.product-lp--note .lp-eyebrow > span:first-child,
+.product-lp--group .lp-eyebrow > span:first-child {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
+.product-lp--note .lp-hero__lead,
+.product-lp--group .lp-hero__lead {
+  max-width: 34em;
+  font-size: 17px;
+}
+
+.product-lp--note .lp-page-shot,
+.product-lp--group .lp-page-shot {
+  padding: 10px;
+  border-color: var(--lp-line);
+  border-radius: 22px;
+  background: #fff;
+  box-shadow: var(--lp-shadow-lg);
+  transform: none;
+}
+
+.product-lp--note .lp-page-shot img,
+.product-lp--group .lp-page-shot img {
+  border-radius: 13px;
+}
+
+/* Trust band / 数値の演出ではなく利用上の事実を並べる */
+.product-lp--note .lp-trust,
+.product-lp--group .lp-trust {
+  padding: 28px 0 34px;
+}
+
+.product-lp--note .lp-trust__lead,
+.product-lp--group .lp-trust__lead {
+  margin-bottom: 16px;
+  color: var(--lp-muted);
+  letter-spacing: 0.04em;
+}
+
+.product-lp--note .lp-trust__items,
+.product-lp--group .lp-trust__items {
+  overflow: hidden;
+  border: 1px solid var(--lp-line);
+  border-radius: 10px;
+}
+
+.product-lp--note .lp-trust__items .lp-trust__item,
+.product-lp--group .lp-trust__items .lp-trust__item {
+  gap: 6px;
+  padding: 17px 20px;
+  border-right: 1px solid var(--lp-line);
+}
+
+.product-lp--note .lp-trust__items .lp-trust__item:last-child,
+.product-lp--group .lp-trust__items .lp-trust__item:last-child {
+  border-right: 0;
+}
+
+.product-lp--note .lp-trust__items .lp-trust__item strong,
+.product-lp--group .lp-trust__items .lp-trust__item strong {
+  color: var(--lp-ink);
+  font-size: 15px;
+}
+
+/* Sections and steps / 罫線と余白で情報の順序を明確にする */
+.product-lp--note .lp-section,
+.product-lp--group .lp-section {
+  padding: 104px 0;
+}
+
+.product-lp--note .lp-section__heading,
+.product-lp--group .lp-section__heading {
+  margin-bottom: 50px;
+}
+
+.product-lp--note .lp-section--steps,
+.product-lp--group .lp-section--steps {
+  background: #fff;
+}
+
+.product-lp--note .lp-card,
+.product-lp--group .lp-card {
+  border-color: var(--lp-line);
+  border-radius: 14px;
+  box-shadow: none;
+}
+
+.product-lp--note .lp-step-card,
+.product-lp--group .lp-step {
+  min-height: 286px;
+  padding: 30px;
+  border: 1px solid var(--lp-line);
+  border-top: 3px solid var(--lp-accent);
+  border-radius: 14px;
+  background: #fff;
+}
+
+.product-lp--note .lp-step-card:hover {
+  box-shadow: var(--lp-shadow-sm);
+  transform: translateY(-2px);
+}
+
+.product-lp--note .lp-step-card__number,
+.product-lp--group .lp-step__number {
+  top: 24px;
+  right: 26px;
+  left: auto;
+  color: rgba(var(--lp-accent-rgb), 0.26);
+  font-size: 27px;
+}
+
+.product-lp--note .lp-step-card__icon,
+.product-lp--group .lp-step__icon {
+  margin-bottom: 32px;
+  border-radius: 10px;
+}
+
 .product-lp--note .lp-step-card__icon svg,
 .product-lp--note .lp-feature-card__icon svg,
 .product-lp--group .lp-step__icon svg,
@@ -3191,52 +3378,277 @@ body.product-lp {
   height: 26px;
 }
 
-.product-lp--note .lp-step-card__icon {
-  margin-bottom: 30px;
+/* Product UI previews / 共同編集画面とファイルルームの利用イメージ */
+.product-lp--note .lp-process-preview--note,
+.product-lp--group .lp-process-preview--group {
+  width: min(100%, 760px);
+  margin: 54px auto 0;
 }
 
-/* ---- Note color cohesion / Note は紫系へ寄せる ---- */
-.product-lp--note .lp-hero {
-  background:
-    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.12), transparent 56%),
-    linear-gradient(180deg, #fcfbff 0%, var(--lp-canvas) 100%);
+.product-lp--note .lp-product-visual::before {
+  display: none;
+}
+
+.product-lp--note .lp-note-mock__window,
+.product-lp--group .lp-room-mockup {
+  border-color: var(--lp-line);
+  border-radius: 14px;
+  box-shadow: var(--lp-shadow-lg);
+  transform: none;
+}
+
+.product-lp--note .lp-floating-status {
+  right: -16px;
+  bottom: -18px;
+  border-color: var(--lp-line);
+  border-radius: 9px;
+}
+
+.product-lp--group .lp-room-mockup__sidebar {
+  background: #173b2f;
+}
+
+/* Features / 大きな価値を上段、補足機能を下段に整理する */
+.product-lp--note .lp-section--tint {
+  background: #f1eff4;
+}
+
+.product-lp--group .lp-section--tint {
+  background: #edf2ef;
+}
+
+.product-lp--note .lp-feature-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.product-lp--note .lp-feature-card--wide,
+.product-lp--group .lp-feature-card--wide {
+  min-height: 340px;
+  grid-column: 1 / -1;
+  grid-row: auto;
+  padding: 42px;
 }
 
 .product-lp--note .lp-feature-card--wide {
-  background: linear-gradient(165deg, #2a1f45 0%, #1c1533 100%);
-}
-
-.product-lp--note .lp-section--faq {
-  background: #efecf8;
-}
-
-.product-lp--note .lp-final-cta {
-  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 66%, #3f2593 100%);
-}
-
-.product-lp--note .lp-footer {
-  background: #171226;
-}
-
-/* ---- Group color cohesion / Group は緑系で深みを与える ---- */
-.product-lp--group .lp-hero {
-  background:
-    radial-gradient(120% 92% at 88% -12%, rgba(var(--lp-accent-rgb), 0.12), transparent 56%),
-    linear-gradient(180deg, #f9fdfb 0%, var(--lp-canvas) 100%);
+  background: #292238;
 }
 
 .product-lp--group .lp-feature-card--wide {
-  background: linear-gradient(165deg, #123b2e 0%, #0c2a20 100%);
+  background: #173b2f;
 }
 
+.product-lp--note .lp-feature-card--wide h3,
+.product-lp--note .lp-feature-card--wide > p,
+.product-lp--group .lp-feature-card--wide h3,
+.product-lp--group .lp-feature-card--wide > p {
+  max-width: 44%;
+}
+
+.product-lp--note .lp-feature-card,
+.product-lp--group .lp-feature-card {
+  min-height: 235px;
+}
+
+.product-lp--group .lp-feature-card--accent {
+  min-height: 190px;
+  grid-column: 1 / -1;
+}
+
+.product-lp--note .lp-feature-card__icon,
+.product-lp--group .lp-card__icon {
+  border-radius: 10px;
+}
+
+.product-lp--note .lp-feature-card__demo,
+.product-lp--group .lp-share-visual {
+  top: 42px;
+  right: 42px;
+  bottom: 42px;
+  left: auto;
+  width: 44%;
+  height: auto;
+  min-height: 0;
+  border-radius: 12px;
+}
+
+/* Use cases / 抽象装飾を減らし、用途の文章を主役にする */
+.product-lp--note #use-cases,
+.product-lp--group #use-cases {
+  background: #fff;
+}
+
+.product-lp--note .lp-use-case-card {
+  min-height: 230px;
+  border-left: 3px solid var(--lp-accent);
+}
+
+.product-lp--note .lp-use-case-card__visual {
+  display: none;
+}
+
+.product-lp--note .lp-use-case-card__body {
+  padding: 30px;
+}
+
+.product-lp--note .lp-use-case-card:hover {
+  box-shadow: var(--lp-shadow-sm);
+  transform: translateY(-2px);
+}
+
+.product-lp--group .lp-use-card__scene {
+  height: 160px;
+  background: var(--lp-accent-soft);
+}
+
+.product-lp--group .lp-use-card__scene::before {
+  display: none;
+}
+
+/* FAQ, CTA and footer / 質問と行動導線に集中させる */
+.product-lp--note .lp-section--faq,
 .product-lp--group .lp-section--faq {
-  background: #eaf1ed;
+  background: #f1f0ee;
+}
+
+.product-lp--note .lp-faq-list,
+.product-lp--group .lp-faq-list,
+.product-lp--note .lp-faq-item,
+.product-lp--group .lp-faq-item {
+  border-color: var(--lp-line);
+}
+
+.product-lp--note .lp-faq-item summary,
+.product-lp--group .lp-faq-item summary {
+  font-weight: 700;
+}
+
+.product-lp--note .lp-final-cta,
+.product-lp--group .lp-final-cta {
+  padding: 96px 0;
+}
+
+.product-lp--note .lp-final-cta {
+  background: #292238;
 }
 
 .product-lp--group .lp-final-cta {
-  background: linear-gradient(160deg, var(--lp-accent) 0%, var(--lp-accent-dark) 68%, #06442f 100%);
+  background: #173b2f;
+}
+
+.product-lp--note .lp-final-cta::before,
+.product-lp--note .lp-final-cta::after,
+.product-lp--note .lp-final-cta__glow,
+.product-lp--group .lp-final-cta::before,
+.product-lp--group .lp-final-cta::after {
+  display: none;
+}
+
+.product-lp--note .lp-final-cta h2,
+.product-lp--group .lp-final-cta h2 {
+  font-weight: 760;
+}
+
+.product-lp--group .lp-final-cta .lp-button--primary {
+  color: var(--lp-accent-dark) !important;
+  background: #fff;
+}
+
+.product-lp--group .lp-final-cta .lp-button--secondary {
+  border-color: rgba(255, 255, 255, 0.34);
+  color: #fff !important;
+  background: transparent;
+}
+
+.product-lp--note .lp-footer {
+  background: #171420;
 }
 
 .product-lp--group .lp-footer {
-  background: #0f1a15;
+  background: #101b16;
+}
+
+@media (max-width: 980px) {
+  .product-lp--note .lp-hero__grid,
+  .product-lp--group .lp-hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .product-lp--note .lp-page-shot,
+  .product-lp--group .lp-page-shot {
+    width: min(100%, 680px);
+    margin-inline: auto;
+  }
+
+  .product-lp--note .lp-feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .product-lp--note .lp-feature-card:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 760px) {
+  .product-lp--note .lp-hero,
+  .product-lp--group .lp-hero {
+    padding: 58px 0 72px;
+  }
+
+  .product-lp--note .lp-hero h1,
+  .product-lp--group .lp-hero h1 {
+    font-size: clamp(40px, 12vw, 56px);
+  }
+
+  .product-lp--note .lp-trust__items .lp-trust__item:nth-child(even),
+  .product-lp--group .lp-trust__items .lp-trust__item:nth-child(even) {
+    border-right: 0;
+  }
+
+  .product-lp--note .lp-section,
+  .product-lp--group .lp-section {
+    padding: 78px 0;
+  }
+
+  .product-lp--note .lp-feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .product-lp--note .lp-feature-card:last-child {
+    grid-column: auto;
+  }
+
+  .product-lp--note .lp-feature-card--wide,
+  .product-lp--group .lp-feature-card--wide {
+    min-height: 510px;
+    padding: 30px;
+  }
+
+  .product-lp--note .lp-feature-card--wide h3,
+  .product-lp--note .lp-feature-card--wide > p,
+  .product-lp--group .lp-feature-card--wide h3,
+  .product-lp--group .lp-feature-card--wide > p {
+    max-width: none;
+  }
+
+  .product-lp--note .lp-feature-card__demo,
+  .product-lp--group .lp-share-visual {
+    top: auto;
+    right: 30px;
+    bottom: 30px;
+    left: 30px;
+    width: auto;
+    height: 190px;
+  }
+}
+
+@media (max-width: 430px) {
+  .product-lp--note .lp-page-shot,
+  .product-lp--group .lp-page-shot {
+    padding: 6px;
+    border-radius: 16px;
+  }
+
+  .product-lp--note .lp-floating-status {
+    display: none;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -619,7 +619,7 @@
       <ul class="menu-list">
         <li>
 
-          <a href="/group-file-sharing" class="menu-item group">
+          <a href="/group_menu" class="menu-item group">
 
             <i class="fas fa-users"></i>
             <h2>グループで共有</h2>
@@ -627,7 +627,7 @@
         </li>
         <li>
 
-          <a href="/file-sharing" class="menu-item fs-qr">
+          <a href="/fs-qr_menu" class="menu-item fs-qr">
 
             <i class="fas fa-qrcode"></i>
             <h2>QRコード共有</h2>
@@ -635,7 +635,7 @@
         </li>
         <li>
 
-          <a href="/shared-note" class="menu-item note mb-3">
+          <a href="/note_menu" class="menu-item note mb-3">
 
             <i class="fas fa-pencil-alt"></i>
             <h2>ノート共有</h2>

--- a/tests/test_product_landing_pages.py
+++ b/tests/test_product_landing_pages.py
@@ -32,7 +32,7 @@ LANDING_PAGES = (
     ),
 )
 
-LANDING_VISUALS = (
+ILLUSTRATED_LANDING_VISUALS = (
     ("/file-sharing", "apple-touch-icon.png", "fsqr-illustration.jpg"),
     ("/group-file-sharing", "apple-touch-icon2.png", "group-illustration.jpg"),
     ("/shared-note", "apple-touch-icon4.png", "note-illustration.jpg"),
@@ -106,7 +106,7 @@ def test_home_page_links_to_product_landing_pages(test_client: TestClient):
         assert f'href="{path}"' in response.text
 
 
-@pytest.mark.parametrize("path,icon_name,page_image_name", LANDING_VISUALS)
+@pytest.mark.parametrize("path,icon_name,page_image_name", ILLUSTRATED_LANDING_VISUALS)
 def test_product_landing_page_uses_service_icon_and_generated_illustration(
     test_client: TestClient,
     path: str,
@@ -124,6 +124,18 @@ def test_product_landing_page_uses_service_icon_and_generated_illustration(
     image_response = test_client.get(image_path)
     assert image_response.status_code == 200
     assert image_response.headers["content-type"] == "image/jpeg"
+
+
+def test_file_sharing_landing_page_also_uses_product_ui_visual(
+    test_client: TestClient,
+):
+    """FS!QR LPは生成イラストに加え、利用方法が伝わるUI図解も表示する。"""
+    response = test_client.get("/file-sharing")
+
+    assert response.status_code == 200
+    assert "/static/apple-touch-icon.png" in response.text
+    assert "lp-mockup--fsqr" in response.text
+    assert "fsqr-illustration.jpg" in response.text
 
 
 @pytest.mark.parametrize("path,_,__,___", LANDING_PAGES)

--- a/tests/test_product_landing_pages.py
+++ b/tests/test_product_landing_pages.py
@@ -44,6 +44,8 @@ PRODUCT_UI_VISUALS = (
     ("/group-file-sharing", "lp-process-preview--group", "提案資料_最新版.pdf"),
 )
 
+HOME_SERVICE_MENU_LINKS = ("/fs-qr_menu", "/group_menu", "/note_menu")
+
 
 @pytest.mark.parametrize("path,brand,primary_cta,search_marker", LANDING_PAGES)
 def test_product_landing_page_has_indexable_seo_content(
@@ -103,13 +105,16 @@ def test_product_landing_pages_are_listed_in_sitemap(test_client: TestClient):
         assert f"https://fs-qr.net{path}" in locations
 
 
-def test_home_page_links_to_product_landing_pages(test_client: TestClient):
-    """検索流入だけでなくサイト内導線からも各LPへ到達できる。"""
+def test_home_page_links_to_service_menu_pages(test_client: TestClient):
+    """トップページのサービスカードはLPではなく各メニュー画面へ案内する。"""
     response = test_client.get("/")
 
     assert response.status_code == 200
-    for path, *_ in LANDING_PAGES:
+    for path in HOME_SERVICE_MENU_LINKS:
         assert f'href="{path}"' in response.text
+
+    for path, *_ in LANDING_PAGES:
+        assert f'href="{path}"' not in response.text
 
 
 @pytest.mark.parametrize("path,icon_name,page_image_name", ILLUSTRATED_LANDING_VISUALS)

--- a/tests/test_product_landing_pages.py
+++ b/tests/test_product_landing_pages.py
@@ -38,6 +38,12 @@ ILLUSTRATED_LANDING_VISUALS = (
     ("/shared-note", "apple-touch-icon4.png", "note-illustration.jpg"),
 )
 
+PRODUCT_UI_VISUALS = (
+    ("/file-sharing", "lp-mockup--fsqr", "共有の準備ができました"),
+    ("/shared-note", "lp-process-preview--note", "リアルタイム同期"),
+    ("/group-file-sharing", "lp-process-preview--group", "提案資料_最新版.pdf"),
+)
+
 
 @pytest.mark.parametrize("path,brand,primary_cta,search_marker", LANDING_PAGES)
 def test_product_landing_page_has_indexable_seo_content(
@@ -126,16 +132,19 @@ def test_product_landing_page_uses_service_icon_and_generated_illustration(
     assert image_response.headers["content-type"] == "image/jpeg"
 
 
-def test_file_sharing_landing_page_also_uses_product_ui_visual(
+@pytest.mark.parametrize("path,visual_class,content_marker", PRODUCT_UI_VISUALS)
+def test_product_landing_page_also_uses_product_ui_visual(
     test_client: TestClient,
+    path: str,
+    visual_class: str,
+    content_marker: str,
 ):
-    """FS!QR LPは生成イラストに加え、利用方法が伝わるUI図解も表示する。"""
-    response = test_client.get("/file-sharing")
+    """各LPは生成イラストに加え、利用方法が伝わるUI図解も表示する。"""
+    response = test_client.get(path)
 
     assert response.status_code == 200
-    assert "/static/apple-touch-icon.png" in response.text
-    assert "lp-mockup--fsqr" in response.text
-    assert "fsqr-illustration.jpg" in response.text
+    assert visual_class in response.text
+    assert content_marker in response.text
 
 
 @pytest.mark.parametrize("path,_,__,___", LANDING_PAGES)


### PR DESCRIPTION
## 日本語

### 概要
- `/file-sharing`、`/shared-note`、`/group-file-sharing` の3つのプロダクトLPを、落ち着いたブランドカラー、明確な罫線、読みやすい余白を中心としたデザインへ刷新しました。
- 各サービスを直感的に理解できる既存の生成イラストは、すべてファーストビューに残しています。
- 3ステップの説明後に、各サービス固有のUI図解を追加しました。
  - FS!QR: ファイル選択、暗号化、QRコード発行
  - Note: 複数人の共同編集、保存状態、リアルタイム同期
  - Group: ルーム情報、共有ファイル一覧、アップロード領域
- 英字中心だった章ラベルや数値だけの訴求を、日本語の章立てと具体的な利用情報へ変更しました。
- 強いグラデーション、回転、大きな影、抽象的な円装飾を抑え、CTA、特長カード、利用シーン、FAQ、フッターまで視覚表現を統一しました。
- トップページの3サービスカードはLPへ直接遷移せず、各メニュー画面（`/fs-qr_menu`、`/group_menu`、`/note_menu`）へ案内するよう変更しました。
- デスクトップとモバイルのレスポンシブ表示、生成イラストとUI図解の併用、トップページの導線を回帰テストで保護しました。
- Groupの利用シーンでは、抽象的な図解を削除し、用途を読みやすく伝える文章カードへ変更しました。

### 設定・マイグレーション
- 設定変更、データベースマイグレーションはありません。
- ロールバックする場合は、このPRの4コミットをrevertすることで元の状態へ戻せます。

### 自動テスト
- `python3 -m pytest` — 650 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — passed
- `python3 -m mypy --config-file pyproject.toml` — passed
- `git diff --check` — passed

### 手動確認
- 3ページのHTMLレンダリング、主要CTA、構造化データ、生成イラスト、サービス固有のUI図解をテストクライアントで確認しました。
- トップページのサービスカードが各メニュー画面へ遷移し、LPへ直接リンクしないことを確認しました。
- UIスクリーンショットは未添付です。環境内Chromiumが `libnspr4.so` 不足で起動できず、ブラウザベースの画像取得を実施できませんでした。

### 関連Issue・レビュー
- 関連Issue: なし
- FSQR、Note、Group各モジュールのメンテナーにレビューをお願いします。

## English

### Summary
- Redesigned the three product landing pages at `/file-sharing`, `/shared-note`, and `/group-file-sharing` around restrained brand colors, clear rules, and more readable spacing.
- Kept the existing generated illustrations in every hero so each service remains easy to understand at a glance.
- Added a service-specific product UI visual after each three-step explanation.
  - FS!QR: file selection, encryption, and QR code generation
  - Note: multi-user editing, save state, and real-time synchronization
  - Group: room details, shared file list, and upload area
- Replaced English-heavy section labels and numeric-only claims with Japanese section labels and concrete usage information.
- Reduced strong gradients, rotated panels, large shadows, and abstract circular decoration while unifying CTAs, feature cards, use cases, FAQ, and footers.
- Changed the three service cards on the home page to point to their menu pages (`/fs-qr_menu`, `/group_menu`, and `/note_menu`) rather than directly to the landing pages.
- Added regression coverage for responsive landing-page content, the presence of both generated illustrations and product UI visuals, and home-page navigation.
- Removed the abstract diagrams from the Group use-case cards and made them text-first cards that communicate each use case more clearly.

### Configuration and migrations
- No configuration changes or database migrations are required.
- To roll back, revert the four commits in this pull request.

### Automated checks
- `python3 -m pytest` — 649 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — passed
- `python3 -m mypy --config-file pyproject.toml` — passed
- `git diff --check` — passed

### Manual verification
- Verified HTML rendering, primary CTAs, structured data, generated illustrations, and service-specific UI visuals for all three pages through the test client.
- Verified that home-page service cards lead to the corresponding menu pages and no longer link directly to the landing pages.
- No UI screenshots are attached. The bundled Chromium could not launch because `libnspr4.so` is unavailable in the environment, so browser-based screenshot capture was not possible.

### Related issue and review
- Related issue: none
- Please request review from the maintainers responsible for the FSQR, Note, and Group modules.
