### PR TITLE
Group利用シーンの図解を削除 / Remove Group use-case diagrams

### DIFF
--- a/Group/templates/group_landing.html
+++ b/Group/templates/group_landing.html
@@ -372,9 +372,6 @@
         </div>
         <div class="lp-grid lp-grid--use-cases">
           <article class="lp-card lp-use-card">
-            <div class="lp-use-card__scene lp-use-card__scene--project" aria-hidden="true">
-              <span></span><span></span><span></span>
-            </div>
             <div class="lp-use-card__content">
               <p class="lp-use-card__tag">プロジェクトチーム</p>
               <h3>プロジェクト資料の集約</h3>
@@ -382,9 +379,6 @@
             </div>
           </article>
           <article class="lp-card lp-use-card">
-            <div class="lp-use-card__scene lp-use-card__scene--class" aria-hidden="true">
-              <span></span><span></span><span></span>
-            </div>
             <div class="lp-use-card__content">
               <p class="lp-use-card__tag">授業・イベント</p>
               <h3>授業・研修・イベント</h3>
@@ -392,9 +386,6 @@
             </div>
           </article>
           <article class="lp-card lp-use-card">
-            <div class="lp-use-card__scene lp-use-card__scene--partner" aria-hidden="true">
-              <span></span><span></span><span></span>
-            </div>
             <div class="lp-use-card__content">
               <p class="lp-use-card__tag">社外との連携</p>
               <h3>社外メンバーとの受け渡し</h3>

--- a/static/css/15-product-landing.css
+++ b/static/css/15-product-landing.css
@@ -1855,64 +1855,6 @@ body.product-lp {
   overflow: hidden;
 }
 
-.lp-use-card__scene {
-  position: relative;
-  display: flex;
-  height: 210px;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  overflow: hidden;
-  background: linear-gradient(145deg, var(--lp-accent-soft), #f9faf8);
-}
-
-.lp-use-card__scene::before {
-  position: absolute;
-  width: 190px;
-  height: 190px;
-  border: 1px solid rgba(var(--lp-accent-rgb), 0.15);
-  border-radius: 50%;
-  content: "";
-  box-shadow: 0 0 0 36px rgba(var(--lp-accent-rgb), 0.035);
-}
-
-.lp-use-card__scene span {
-  position: relative;
-  z-index: 1;
-  display: block;
-  width: 58px;
-  height: 76px;
-  border-radius: 11px;
-  background: #fff;
-  box-shadow: 0 12px 30px rgba(25, 45, 38, 0.12);
-}
-
-.lp-use-card__scene--project span {
-  border-top: 5px solid var(--lp-accent);
-}
-
-.lp-use-card__scene--class span {
-  width: 62px;
-  height: 62px;
-  border-radius: 50%;
-}
-
-.lp-use-card__scene--class span:nth-child(2) {
-  background: var(--lp-accent);
-  transform: translateY(18px);
-}
-
-.lp-use-card__scene--partner span {
-  height: 94px;
-  transform: rotate(-5deg);
-}
-
-.lp-use-card__scene--partner span:nth-child(2) {
-  z-index: 2;
-  background: var(--lp-accent);
-  transform: translateY(14px) rotate(4deg);
-}
-
 .lp-use-card__content {
   padding: 28px;
 }
@@ -3495,13 +3437,13 @@ body.product-lp {
   transform: translateY(-2px);
 }
 
-.product-lp--group .lp-use-card__scene {
-  height: 160px;
-  background: var(--lp-accent-soft);
+.product-lp--group .lp-use-card {
+  min-height: 230px;
+  border-left: 3px solid var(--lp-accent);
 }
 
-.product-lp--group .lp-use-card__scene::before {
-  display: none;
+.product-lp--group .lp-use-card__content {
+  padding: 30px;
 }
 
 /* FAQ, CTA and footer / 質問と行動導線に集中させる */

--- a/tests/test_product_landing_pages.py
+++ b/tests/test_product_landing_pages.py
@@ -152,6 +152,17 @@ def test_product_landing_page_also_uses_product_ui_visual(
     assert content_marker in response.text
 
 
+def test_group_landing_page_use_cases_do_not_include_abstract_scenes(
+    test_client: TestClient,
+):
+    """Group LPの利用シーンは装飾図ではなく、読みやすい文章カードで案内する。"""
+    response = test_client.get("/group-file-sharing")
+
+    assert response.status_code == 200
+    assert "lp-use-card__scene" not in response.text
+    assert "プロジェクト資料の集約" in response.text
+
+
 @pytest.mark.parametrize("path,_,__,___", LANDING_PAGES)
 def test_product_landing_page_normalizes_tracking_queries(
     test_client: TestClient,


### PR DESCRIPTION
## 日本語

### 概要
- `/group-file-sharing` の「利用シーン」カードから、抽象的な図解を削除しました。
- 各カードを、アクセント罫線と文章中心のレイアウトへ変更し、用途を読みやすく整理しました。
- 使われなくなった図解用CSSを削除しました。
- 利用シーンに抽象図クラスが含まれないことを回帰テストで確認します。

### 設定・マイグレーション
- 設定変更、データベースマイグレーションはありません。
- ロールバックする場合は、このPRのコミットをrevertしてください。

### 自動テスト
- `python3 -m pytest` — 650 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — passed
- `python3 -m mypy --config-file pyproject.toml` — passed
- `git diff --check` — passed

### 手動確認
- `/group-file-sharing` のHTMLレンダリングと、利用シーンカードから図解が除去されたことをテストクライアントで確認しました。
- UIスクリーンショットは未添付です。環境内Chromiumが `libnspr4.so` 不足で起動できなかったため、ブラウザベースの画像取得は実施できませんでした。

### 関連Issue・レビュー
- 関連Issue: なし
- Groupモジュールのメンテナーにレビューをお願いします。

## English

### Summary
- Removed the abstract diagrams from the use-case cards on `/group-file-sharing`.
- Changed each card to a text-first layout with an accent rule so the use cases are easier to read.
- Removed the now-unused CSS for those diagrams.
- Added regression coverage that ensures the abstract scene class is absent from the use-case section.

### Configuration and migrations
- No configuration changes or database migrations are required.
- To roll back, revert the commit in this pull request.

### Automated checks
- `python3 -m pytest` — 650 passed
- `python3 -m ruff check .` — passed
- `python3 -m ruff format --check .` — passed
- `python3 -m mypy --config-file pyproject.toml` — passed
- `git diff --check` — passed

### Manual verification
- Verified `/group-file-sharing` HTML rendering and removal of the use-case diagrams through the test client.
- No UI screenshot is attached. The bundled Chromium could not launch because `libnspr4.so` is unavailable in the environment, so browser-based screenshot capture was not possible.

### Related issue and review
- Related issue: none
- Please request review from the maintainer responsible for the Group module.