### PR TITLE
LPの生成モックアップを削除 / Remove generated LP mockups

### DIFF
--- a/FSQR/templates/fsqr_landing.html
+++ b/FSQR/templates/fsqr_landing.html
@@ -241,49 +241,6 @@
             <p>相手はQRコードをスマートフォンで読み取り、ブラウザからファイルを受け取れます。</p>
           </li>
         </ol>
-        <div class="lp-mockup lp-mockup--fsqr lp-process-preview" role="img" aria-label="ファイルを暗号化してアップロードし、共有用QRコードが発行されるFS!QRの画面イメージ">
-          <div class="lp-browser">
-            <div class="lp-browser__bar" aria-hidden="true">
-              <span class="lp-browser__dots"><i></i><i></i><i></i></span>
-              <span class="lp-browser__address">fs-qr.net / file-sharing</span>
-              <span class="lp-browser__secure">暗号化通信</span>
-            </div>
-            <div class="lp-browser__content">
-              <div class="lp-upload-card">
-                <div class="lp-upload-card__icon" aria-hidden="true"><span></span></div>
-                <div class="lp-upload-card__body">
-                  <span class="lp-ui-label">選択したファイル</span>
-                  <strong>meeting-notes.pdf</strong>
-                  <span class="lp-ui-meta">ブラウザで暗号化してアップロード</span>
-                </div>
-                <span class="lp-upload-card__done" aria-hidden="true">✓</span>
-              </div>
-              <div class="lp-transfer-line" aria-hidden="true">
-                <span></span><i>共有の準備ができました</i><span></span>
-              </div>
-              <div class="lp-share-card">
-                <div class="lp-share-card__copy">
-                  <span class="lp-ui-label">受け取り方法</span>
-                  <strong>カメラで読み取る</strong>
-                  <p>スマートフォンの標準カメラから受け取りページへ進めます。</p>
-                  <div class="lp-expiry-chip"><span aria-hidden="true">◷</span>24時間後に自動削除</div>
-                </div>
-                <div class="lp-qr" aria-hidden="true">
-                  <div class="lp-qr__pattern">
-                    <i class="lp-qr__finder lp-qr__finder--one"></i>
-                    <i class="lp-qr__finder lp-qr__finder--two"></i>
-                    <i class="lp-qr__finder lp-qr__finder--three"></i>
-                    <span></span><span></span><span></span><span></span><span></span>
-                    <span></span><span></span><span></span><span></span><span></span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="lp-floating-badge lp-floating-badge--lock" aria-hidden="true">
-            <span>✓</span>ブラウザで暗号化
-          </div>
-        </div>
         <div class="lp-section__action">
           <a class="lp-button lp-button--primary" href="/fs-qr">今すぐファイルを共有する <span aria-hidden="true">→</span></a>
         </div>

--- a/Group/templates/group_landing.html
+++ b/Group/templates/group_landing.html
@@ -220,57 +220,6 @@
             <p>参加者がファイルをアップロード。ルーム内の一覧から必要なファイルを受け取れます。</p>
           </li>
         </ol>
-        <div class="lp-mockup lp-room-mockup lp-process-preview--group" role="img" aria-label="FS!QR Groupのファイルルーム画面イメージ。ルーム情報、共有中のファイル一覧、アップロード領域が表示されています。">
-          <div class="lp-mockup__bar" aria-hidden="true">
-            <span></span><span></span><span></span>
-            <p>fs-qr.net/group/r/team24</p>
-          </div>
-          <div class="lp-room-mockup__body">
-            <aside class="lp-room-mockup__sidebar">
-              <div class="lp-room-mockup__logo" aria-hidden="true">G</div>
-              <p class="lp-room-mockup__label">CURRENT ROOM</p>
-              <p class="lp-room-mockup__room">TEAM24</p>
-              <div class="lp-room-mockup__status"><span aria-hidden="true"></span> 共有中</div>
-              <dl>
-                <div><dt>ファイル</dt><dd>4</dd></div>
-                <div><dt>保存期限</dt><dd>残り 23時間</dd></div>
-              </dl>
-              <div class="lp-room-mockup__members" aria-hidden="true">
-                <span>AK</span><span>MN</span><span>+</span>
-              </div>
-            </aside>
-            <div class="lp-room-mockup__main">
-              <div class="lp-room-mockup__heading">
-                <div>
-                  <p>Project workspace</p>
-                  <strong>共有ファイル</strong>
-                </div>
-                <span class="lp-room-mockup__upload">＋ アップロード</span>
-              </div>
-              <div class="lp-room-mockup__files" aria-hidden="true">
-                <div class="lp-room-file">
-                  <span class="lp-room-file__icon lp-room-file__icon--pdf">PDF</span>
-                  <span><strong>提案資料_最新版.pdf</strong><small>2.4 MB ・ たった今</small></span>
-                  <i>•••</i>
-                </div>
-                <div class="lp-room-file">
-                  <span class="lp-room-file__icon lp-room-file__icon--sheet">XLS</span>
-                  <span><strong>進行スケジュール.xlsx</strong><small>840 KB ・ 12分前</small></span>
-                  <i>•••</i>
-                </div>
-                <div class="lp-room-file">
-                  <span class="lp-room-file__icon lp-room-file__icon--image">JPG</span>
-                  <span><strong>イベント写真_01.jpg</strong><small>5.1 MB ・ 1時間前</small></span>
-                  <i>•••</i>
-                </div>
-              </div>
-              <div class="lp-room-mockup__drop" aria-hidden="true">
-                <span>↑</span>
-                <p><strong>ファイルをここに追加</strong><small>チームのメンバーとすぐ共有</small></p>
-              </div>
-            </div>
-          </div>
-        </div>
         <div class="lp-section__action">
           <a class="lp-button lp-button--primary" href="/create_room">グループルームを作る <span aria-hidden="true">→</span></a>
         </div>
@@ -298,8 +247,17 @@
             <h3>URL・QRコードですぐ招待</h3>
             <p>共有URLをメッセージで送る。対面ならQRコードを見せる。状況に合う渡し方を選べます。</p>
             <div class="lp-card__visual lp-share-visual" aria-hidden="true">
-              <span class="lp-share-visual__url">fs-qr.net/s/g/••••••</span>
-              <span class="lp-share-visual__qr"></span>
+              <span class="lp-share-visual__label">共有リンク</span>
+              <div class="lp-share-visual__link">
+                <span class="lp-share-visual__signal"></span>
+                <span class="lp-share-visual__url">fs-qr.net/s/g/••••••</span>
+                <span class="lp-share-visual__arrow">→</span>
+              </div>
+              <div class="lp-share-visual__recipients">
+                <span></span><span></span><span></span>
+                <i>＋</i>
+                <p>必要な相手へ、すぐ共有</p>
+              </div>
             </div>
           </article>
           <article class="lp-card lp-feature-card">

--- a/Note/templates/note_landing.html
+++ b/Note/templates/note_landing.html
@@ -208,36 +208,6 @@
             <p>同じノートを開き、リアルタイムでテキストを編集します。</p>
           </li>
         </ol>
-        <figure class="lp-mockup lp-product-visual lp-note-mock lp-process-preview--note" aria-labelledby="note-mock-caption">
-          <div class="lp-note-mock__window">
-            <div class="lp-note-mock__topbar">
-              <div class="lp-window-dots" aria-hidden="true"><span></span><span></span><span></span></div>
-              <span class="lp-note-mock__room">チーム定例ノート</span>
-              <div class="lp-note-mock__people" aria-label="3人が参加中">
-                <span aria-hidden="true">A</span><span aria-hidden="true">M</span><span aria-hidden="true">K</span>
-              </div>
-            </div>
-            <div class="lp-note-mock__body">
-              <aside class="lp-note-mock__rail" aria-hidden="true">
-                <span class="is-active"></span><span></span><span></span><span></span>
-              </aside>
-              <div class="lp-note-mock__editor">
-                <div class="lp-note-mock__meta"><span>7月20日 チーム定例</span><span class="lp-save-state">● 保存済み</span></div>
-                <div class="lp-note-mock__title">今日決めること</div>
-                <div class="lp-note-mock__line lp-note-mock__line--long"></div>
-                <div class="lp-note-mock__line lp-note-mock__line--medium"></div>
-                <div class="lp-note-mock__line lp-note-mock__line--short"></div>
-                <div class="lp-note-mock__section">次のアクション</div>
-                <div class="lp-note-mock__task"><span aria-hidden="true">✓</span><span>公開前の最終確認</span></div>
-                <div class="lp-note-mock__task"><span aria-hidden="true"></span><span>フィードバックを反映</span></div>
-                <span class="lp-cursor lp-cursor--one" aria-hidden="true"><i></i><b>Akira</b></span>
-                <span class="lp-cursor lp-cursor--two" aria-hidden="true"><i></i><b>Mio</b></span>
-              </div>
-            </div>
-          </div>
-          <div class="lp-floating-status" aria-hidden="true"><span>✓</span><strong>リアルタイム同期</strong></div>
-          <figcaption id="note-mock-caption" class="lp-visually-hidden">複数人が同じノートをリアルタイムで編集している画面イメージ</figcaption>
-        </figure>
         <div class="lp-section__action">
           <a class="lp-button lp-button--primary" href="/create_note_room">共有ノートを作る <span aria-hidden="true">→</span></a>
         </div>

--- a/static/css/15-product-landing.css
+++ b/static/css/15-product-landing.css
@@ -1651,38 +1651,133 @@ body.product-lp {
   right: 42px;
   bottom: 42px;
   left: 42px;
-  display: flex;
+  display: grid;
   min-height: 180px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 22px;
+  align-content: center;
+  gap: 16px;
   padding: 28px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.055);
+  background:
+    radial-gradient(circle at 92% 12%, rgba(117, 222, 178, 0.16), transparent 36%),
+    rgba(255, 255, 255, 0.055);
+}
+
+.lp-share-visual__label {
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.lp-share-visual__link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.lp-share-visual__signal {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border: 1px solid rgba(157, 245, 204, 0.65);
+  border-radius: 50%;
+}
+
+.lp-share-visual__signal::before,
+.lp-share-visual__signal::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #9df5cc;
+  content: "";
+  transform: translate(-50%, -50%);
+}
+
+.lp-share-visual__signal::after {
+  width: 26px;
+  height: 26px;
+  border: 1px solid rgba(157, 245, 204, 0.25);
+  background: transparent;
 }
 
 .lp-share-visual__url {
   flex: 1;
-  padding: 11px 13px;
   overflow: hidden;
-  border-radius: 9px;
   color: rgba(255, 255, 255, 0.72);
-  background: rgba(255, 255, 255, 0.09);
   font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.lp-share-visual__qr {
-  width: 80px;
-  height: 80px;
+.lp-share-visual__arrow {
+  display: grid;
+  width: 24px;
+  height: 24px;
   flex: 0 0 auto;
-  border: 10px solid #fff;
-  background:
-    linear-gradient(90deg, #15221e 50%, transparent 50%) 0 0 / 13px 13px,
-    linear-gradient(#15221e 50%, transparent 50%) 0 0 / 13px 13px,
-    #fff;
+  place-items: center;
+  border-radius: 50%;
+  color: #163d30;
+  background: #9df5cc;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.lp-share-visual__recipients {
+  display: flex;
+  align-items: center;
+  min-height: 26px;
+  padding-left: 3px;
+}
+
+.lp-share-visual__recipients > span,
+.lp-share-visual__recipients > i {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  margin-left: -5px;
+  place-items: center;
+  border: 2px solid #1a4435;
+  border-radius: 50%;
+  color: rgba(255, 255, 255, 0.8);
+  background: #477463;
+  font-size: 8px;
+  font-style: normal;
+  font-weight: 800;
+}
+
+.lp-share-visual__recipients > span:first-child {
+  margin-left: 0;
+  background: #739c84;
+}
+
+.lp-share-visual__recipients > span:nth-child(2) {
+  background: #356653;
+}
+
+.lp-share-visual__recipients > span:nth-child(3) {
+  background: #5b8976;
+}
+
+.lp-share-visual__recipients > i {
+  color: #9df5cc;
+  background: #285846;
+}
+
+.lp-share-visual__recipients p {
+  margin: 0 0 0 11px;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 10px;
+  font-weight: 600;
 }
 
 .product-lp--group .lp-step {

--- a/tests/test_product_landing_pages.py
+++ b/tests/test_product_landing_pages.py
@@ -38,12 +38,6 @@ ILLUSTRATED_LANDING_VISUALS = (
     ("/shared-note", "apple-touch-icon4.png", "note-illustration.jpg"),
 )
 
-PRODUCT_UI_VISUALS = (
-    ("/file-sharing", "lp-mockup--fsqr", "共有の準備ができました"),
-    ("/shared-note", "lp-process-preview--note", "リアルタイム同期"),
-    ("/group-file-sharing", "lp-process-preview--group", "提案資料_最新版.pdf"),
-)
-
 HOME_SERVICE_MENU_LINKS = ("/fs-qr_menu", "/group_menu", "/note_menu")
 
 
@@ -137,19 +131,45 @@ def test_product_landing_page_uses_service_icon_and_generated_illustration(
     assert image_response.headers["content-type"] == "image/jpeg"
 
 
-@pytest.mark.parametrize("path,visual_class,content_marker", PRODUCT_UI_VISUALS)
-def test_product_landing_page_also_uses_product_ui_visual(
+def test_group_landing_page_does_not_include_room_ui_mockup(
+    test_client: TestClient,
+):
+    """実際の画面と異なるファイルルームのモックアップを掲載しない。"""
+    response = test_client.get("/group-file-sharing")
+
+    assert response.status_code == 200
+    assert "lp-process-preview--group" not in response.text
+    assert "提案資料_最新版.pdf" not in response.text
+
+
+def test_group_landing_page_does_not_include_qr_code_decoration(
+    test_client: TestClient,
+):
+    """共有リンクの案内に、実物らしく見えるQRコード装飾を使用しない。"""
+    response = test_client.get("/group-file-sharing")
+
+    assert response.status_code == 200
+    assert "lp-share-visual__qr" not in response.text
+    assert "lp-share-visual__recipients" in response.text
+
+
+@pytest.mark.parametrize(
+    ("path", "visual_class"),
+    (
+        ("/file-sharing", "lp-mockup--fsqr"),
+        ("/shared-note", "lp-process-preview--note"),
+    ),
+)
+def test_product_landing_pages_do_not_include_generated_ui_mockups(
     test_client: TestClient,
     path: str,
     visual_class: str,
-    content_marker: str,
 ):
-    """各LPは生成イラストに加え、利用方法が伝わるUI図解も表示する。"""
+    """実画面と誤認されうるUIモックアップを掲載しない。"""
     response = test_client.get(path)
 
     assert response.status_code == 200
-    assert visual_class in response.text
-    assert content_marker in response.text
+    assert visual_class not in response.text
 
 
 def test_group_landing_page_use_cases_do_not_include_abstract_scenes(


### PR DESCRIPTION
## 日本語

### 概要

`/group-file-sharing`、`/shared-note`、`/file-sharing` の LP から、実際の画面と異なる生成 UI モックアップを削除しました。Group の共有リンク案内は、QR コード装飾ではなく共有リンクから受け手へ届く流れを表す控えめなデザインに置き換えています。

### 影響・設定

- 実在の画面と誤認されうるプレビュー表示を削除します。
- 設定変更、データベース移行、ロールバック手順は不要です。

### 検証

- `python3 -m pytest`（651 passed）
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m mypy --config-file pyproject.toml`

### 手動確認

- 対象 LP の表示から各モックアップ用クラスが出力されないことを回帰テストで確認しました。
- ローカル開発サーバーは起動待ちとなったため、ブラウザでのスクリーンショット確認は未実施です。

### 関連 Issue

- なし

## English

### Summary

Removed generated UI mockups that did not match the actual product screens from the `/group-file-sharing`, `/shared-note`, and `/file-sharing` landing pages. The Group share-link section now uses a subtle link-to-recipient flow rather than a QR-code decoration.

### Impact and configuration

- Removes previews that could be mistaken for real product screens.
- No configuration changes, database migrations, or rollback steps are required.

### Validation

- `python3 -m pytest` (651 passed)
- `python3 -m ruff check .`
- `python3 -m ruff format --check .`
- `python3 -m mypy --config-file pyproject.toml`

### Manual verification

- Regression tests verify that the mockup classes are not rendered on the affected landing pages.
- Browser screenshot verification was not performed because the local development server remained pending during startup.

### Related issue

- None