### PR TITLE
AdSense所有権確認用メタタグを追加 / Add AdSense site ownership verification meta tag

### DIFF
--- a/FSQR/templates/fs-qr.html
+++ b/FSQR/templates/fs-qr.html
@@ -47,6 +47,8 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+    <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
     <script>
       window.FSQR_TAGS = Object.freeze({
         googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/Group/templates/group.html
+++ b/Group/templates/group.html
@@ -46,6 +46,8 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+    <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
     <script>
       window.FSQR_TAGS = Object.freeze({
         googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/Note/templates/note_layout.html
+++ b/Note/templates/note_layout.html
@@ -82,6 +82,8 @@
   <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
   <link href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
         rel="stylesheet">
+  <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+  <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
   <script>
     window.FSQR_TAGS = Object.freeze({
       googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/Note/templates/note_menu.html
+++ b/Note/templates/note_menu.html
@@ -47,6 +47,8 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
     
+    <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+    <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
     <script>
       window.FSQR_TAGS = Object.freeze({
         googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/templates/group_layout.html
+++ b/templates/group_layout.html
@@ -84,6 +84,8 @@
     <link
       href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
       rel="stylesheet">
+    <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+    <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
     <script>
       window.FSQR_TAGS = Object.freeze({
         googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,8 @@
   <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
   <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
   
+  <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+  <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
   <script>
     window.FSQR_TAGS = Object.freeze({
       googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,6 +84,8 @@
     <link
       href="https://fonts.googleapis.com/css2?family=Kaisei+Opti&display=swap"
       rel="stylesheet">
+    <!-- AdSense サイト所有権の確認 / AdSense site ownership verification -->
+    <meta name="google-adsense-account" content="{{ google_adsense_account_id }}">
     <script>
       window.FSQR_TAGS = Object.freeze({
         googleAnalyticsId: {{ google_analytics_id | tojson }},

--- a/tests/test_basic_routes.py
+++ b/tests/test_basic_routes.py
@@ -267,6 +267,32 @@ def test_google_tags_are_loaded_through_cookie_consent(test_client: TestClient):
         )
 
 
+ADSENSE_ACCOUNT_META = (
+    '<meta name="google-adsense-account" content="ca-pub-4557554518872474">'
+)
+
+
+def test_adsense_account_meta_tag_is_present_on_every_page(test_client: TestClient):
+    """所有権確認メタタグは Cookie も広告も伴わないため全ページへ出す。
+
+    The ownership meta tag sets no cookie and serves no ad, so it is emitted
+    regardless of the ad-serving allowlist.
+    """
+    for path in (
+        "/",
+        "/about",
+        "/usage",
+        "/articles",
+        "/fs-qr",
+        "/group",
+        "/note",
+        "/create_room",
+    ):
+        response = test_client.get(path)
+        assert response.status_code == 200
+        assert ADSENSE_ACCOUNT_META in response.text
+
+
 def test_adsense_is_not_exposed_on_functional_pages(test_client: TestClient):
     for path in (
         "/fs-qr",
@@ -280,7 +306,12 @@ def test_adsense_is_not_exposed_on_functional_pages(test_client: TestClient):
         assert response.status_code == 200
         assert "window.FSQR_TAGS" in response.text
         assert 'googleAnalyticsId: "G-D26D8ZXKNV"' in response.text
-        assert "ca-pub-4557554518872474" not in response.text
+        # 広告は配信しない: ローダーへ client id を渡さず、広告枠も置かない。
+        # pub-ID は所有権確認メタタグの 1 箇所だけに現れる。
+        assert "adsenseClientId: null" in response.text
+        assert 'class="adsbygoogle"' not in response.text
+        assert response.text.count("ca-pub-4557554518872474") == 1
+        assert ADSENSE_ACCOUNT_META in response.text
         assert 'src="https://www.googletagmanager.com/gtag/js' not in response.text
         assert (
             'src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'

--- a/web.py
+++ b/web.py
@@ -352,6 +352,10 @@ def render_template(request: Request, template_name: str, **context: Any):
         "t": make_translator(language),
         "google_analytics_id": GOOGLE_ANALYTICS_ID,
         "google_adsense_client_id": adsense_client_id,
+        # サイト所有権の確認用メタタグは Cookie を使わず広告も配信しないため、
+        # 広告面の制限（_is_adsense_allowed_path）とは無関係に全ページへ出す。
+        # Site ownership verification only; sets no cookie and serves no ad.
+        "google_adsense_account_id": GOOGLE_ADSENSE_CLIENT_ID,
     }
     payload.update(context)
     try:


### PR DESCRIPTION
## 日本語

### 概要
AdSense のサイト所有権確認用に `google-adsense-account` メタタグを、`<head>` を持つ全テンプレートへ無条件で出力します。

AdSense の所有権確認方法のうち「AdSense コードスニペット」は本サイトでは成立しません。`adsbygoogle.js` は Cookie 同意後にのみ `static/cookie-consent.js` から動的挿入する設計のため、同意操作を行わない確認クローラーはスクリプトを検出できないためです（`/`、`/about`、`/usage`、`/articles`、記事ページのいずれもサーバー側 HTML にスクリプトが出力されないことを実測で確認）。

そこで Cookie を使わずスクリプトも読み込まないメタタグ方式を採用しました。既存の Cookie 同意ゲート設計とプライバシー方針には一切手を入れていません。

### 変更点
- `web.py`: `google_adsense_account_id` をテンプレートコンテキストへ追加。pub-ID の定義箇所を増やさないため既存の `GOOGLE_ADSENSE_CLIENT_ID` を流用し、広告配信用の `google_adsense_client_id`（パス条件付き）とは別変数として役割を分離。
- テンプレート 7 件（`templates/layout.html`、`templates/index.html`、`templates/group_layout.html`、`Group/templates/group.html`、`Note/templates/note_layout.html`、`Note/templates/note_menu.html`、`FSQR/templates/fs-qr.html`）: `<head>` にメタタグを追加。

所有権の宣言はサイト単位のため、どの URL をクロールされても確認が成立するよう、広告面の許可リスト（`_is_adsense_allowed_path`）とは切り離して全ページに出力しています。

### 挙動を変えていない点
- 同意前に広告スクリプトを読み込まない挙動（`adsbygoogle.js` はサーバー側 HTML に一切出力されない）
- 機能画面で広告を配信しない挙動（`adsenseClientId` は `null` のまま）

### 設定・マイグレーションに関する注意
- DB スキーマ・環境変数・依存関係の変更はありません。
- **デプロイ後に AdSense コンソール側の対応が必要です。** 所有権確認方法を「メタタグ」または「ads.txt スニペット」に設定してください。「AdSense コードスニペット」のままでは、本変更を反映しても確認は通りません。`ads.txt` は既に正しい DIRECT 行（`pub-4557554518872474`）を配信しており、`/ads.txt` が 200 を返すことを確認済みです。

### 既存テストの修正について
`test_adsense_is_not_exposed_on_functional_pages` は機能画面で `"ca-pub-..." not in response.text` を検証していましたが、メタタグが pub-ID を含むためこのアサーションが失敗します。テストの本来の意図は「機能画面で広告を配信しないこと」であり、メタタグは Cookie も広告も伴わないため意図は保たれています。そこで文字列の不在ではなく実際の挙動を検証する形に厳密化しました。

- `adsenseClientId: null`（ローダーに client ID を渡さない）
- `class="adsbygoogle"` 不在（広告枠なし）
- `adsbygoogle.js` 未読込
- pub-ID の出現は所有権メタタグの 1 箇所のみ

あわせて `test_adsense_account_meta_tag_is_present_on_every_page` を新規追加し、公開ページ・機能画面の双方でメタタグが出力されることを検証しています。

### 実行した自動テスト
| 検査 | 結果 |
| --- | --- |
| `python3 -m pytest` | 652 passed |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |
| `python3 -m mypy --config-file pyproject.toml` | Success: no issues found in 12 source files |

### 手動検証の証跡
`TestClient` で実際のレンダリング結果を確認しました。

| URL | メタタグ | `adsbygoogle.js` | 広告枠 | `adsenseClientId` |
| --- | --- | --- | --- | --- |
| `/` | あり | なし | なし | `"ca-pub-4557554518872474"` |
| `/about` | あり | なし | なし | `"ca-pub-4557554518872474"` |
| `/usage` | あり | なし | なし | `"ca-pub-4557554518872474"` |
| `/articles` | あり | なし | なし | `"ca-pub-4557554518872474"` |
| `/file-sharing-troubleshooting` | あり | なし | なし | `"ca-pub-4557554518872474"` |
| `/fs-qr` | あり | なし | なし | `null` |
| `/group` | あり | なし | なし | `null` |
| `/note` | あり | なし | なし | `null` |
| `/create_room` | あり | なし | なし | `null` |

### 未実施の検証とその理由
- **実ブラウザでの目視確認・スクリーンショット**: メタタグは画面に描画されない `<head>` 内要素で UI 変更を伴わないため実施していません。
- **Docker / 本番相当環境でのスモークテスト**: ローカルに MySQL コンテナを用意できず、アプリ起動時の DB 起動チェックで失敗するため未実施です。変更はテンプレートのレンダリングとコンテキスト変数のみで DB に依存しないため、`TestClient` による検証で代替しています。
- **AdSense 確認クローラーによる実際の所有権確認**: 本番デプロイと AdSense コンソール側の設定変更が前提となるため、本 PR の範囲外です。

### 残存リスク
Google が所有権確認だけでなく「広告コードの実際の読み込み」まで確認する運用だった場合、本変更のみでは審査が進まない可能性があります。その場合は Consent Mode v2 への移行（スクリプトを常時読み込み、同意前は `denied` シグナルで非個人化・Cookie なし動作にする）が正攻法になります。本 PR では既存のプライバシー設計を維持することを優先し、変更を最小限に留めています。

### 関連 Issue
なし

---

## English

### Summary
Emits the `google-adsense-account` meta tag unconditionally from every template that owns a `<head>`, so AdSense can verify site ownership.

The "AdSense code snippet" verification method cannot work on this site: `adsbygoogle.js` is injected dynamically by `static/cookie-consent.js` only after cookie consent, so a verification crawler that never interacts with the consent banner will never find the script. This was confirmed empirically — the script is absent from the server-rendered HTML of `/`, `/about`, `/usage`, `/articles`, and article pages.

The meta tag method neither sets a cookie nor loads a script, so it verifies ownership without touching the existing consent-gating design or privacy posture.

### Changes
- `web.py`: adds `google_adsense_account_id` to the template context. It reuses the existing `GOOGLE_ADSENSE_CLIENT_ID` so the pub-ID stays defined in one place, while remaining a separate variable from the path-gated ad-serving `google_adsense_client_id`.
- 7 templates (`templates/layout.html`, `templates/index.html`, `templates/group_layout.html`, `Group/templates/group.html`, `Note/templates/note_layout.html`, `Note/templates/note_menu.html`, `FSQR/templates/fs-qr.html`): add the meta tag to `<head>`.

Ownership is declared per site, so the tag is emitted on every page — deliberately decoupled from the ad-serving allowlist (`_is_adsense_allowed_path`) — to keep verification working no matter which URL is crawled.

### Behavior deliberately left unchanged
- No ad script is loaded before consent (`adsbygoogle.js` never appears in server-rendered HTML).
- No ads are served on functional pages (`adsenseClientId` stays `null`).

### Configuration / migration notes
- No DB schema, environment variable, or dependency changes.
- **Action required in the AdSense console after deploy.** Set the ownership verification method to "Meta tag" or "Ads.txt snippet". Leaving it on "AdSense code snippet" will keep verification failing even with this change. `ads.txt` already serves the correct DIRECT line (`pub-4557554518872474`), and `/ads.txt` was confirmed to return 200.

### On the modified existing test
`test_adsense_is_not_exposed_on_functional_pages` asserted `"ca-pub-..." not in response.text` for functional pages, which now fails because the meta tag contains the pub-ID. The test's actual intent — that ads are not served on functional pages — still holds, since the meta tag involves neither cookies nor ads. The assertions were therefore tightened to verify real behavior instead of string absence:

- `adsenseClientId: null` (no client ID handed to the loader)
- no `class="adsbygoogle"` (no ad slot)
- `adsbygoogle.js` not loaded
- the pub-ID occurs exactly once, in the ownership meta tag

A new `test_adsense_account_meta_tag_is_present_on_every_page` also asserts the tag is emitted on both public and functional pages.

### Automated tests run
| Check | Result |
| --- | --- |
| `python3 -m pytest` | 652 passed |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |
| `python3 -m mypy --config-file pyproject.toml` | Success: no issues found in 12 source files |

### Manual verification evidence
Rendered output inspected via `TestClient`.

| URL | Meta tag | `adsbygoogle.js` | Ad slot | `adsenseClientId` |
| --- | --- | --- | --- | --- |
| `/` | yes | no | no | `"ca-pub-4557554518872474"` |
| `/about` | yes | no | no | `"ca-pub-4557554518872474"` |
| `/usage` | yes | no | no | `"ca-pub-4557554518872474"` |
| `/articles` | yes | no | no | `"ca-pub-4557554518872474"` |
| `/file-sharing-troubleshooting` | yes | no | no | `"ca-pub-4557554518872474"` |
| `/fs-qr` | yes | no | no | `null` |
| `/group` | yes | no | no | `null` |
| `/note` | yes | no | no | `null` |
| `/create_room` | yes | no | no | `null` |

### Verification not performed, and why
- **Real-browser visual check / screenshots**: the meta tag is a non-rendered `<head>` element with no UI impact.
- **Docker / production-like smoke test**: no local MySQL container is available, so the app's startup DB check fails. The change only affects template rendering and a context variable and does not depend on the DB, so `TestClient` verification was used instead.
- **Actual ownership verification by the AdSense crawler**: requires a production deploy plus the AdSense console change, so it is out of scope for this PR.

### Residual risk
If Google's review requires observing the ad code actually load — not just ownership verification — this change alone may not be sufficient. The proper escalation would be Consent Mode v2 (load the script always, defaulting consent signals to `denied` for non-personalized, cookieless operation until consent). This PR keeps the change minimal and preserves the existing privacy design.

### Related issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
