### PR TITLE
Cookie同意バナーのaria-hidden違反を修正 / Fix aria-hidden violation on cookie consent banner

### DIFF
--- a/static/cookie-consent.js
+++ b/static/cookie-consent.js
@@ -182,6 +182,15 @@
   function hideOverlay(overlay, options = {}) {
     closeOpenLangSelects();
     overlay.classList.remove('is-visible');
+
+    // The button that was just clicked (e.g. "accept") still holds focus at
+    // this point. Setting aria-hidden on its ancestor while it is focused
+    // hides a focused element from assistive tech, which browsers flag as a
+    // violation. Blur it first so aria-hidden never applies to a subtree
+    // that contains the active element.
+    if (overlay.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
     overlay.setAttribute('aria-hidden', 'true');
     overlay.removeAttribute('data-cookie-consent-active-view');
     overlay.removeAttribute('data-cookie-consent-closeable');


### PR DESCRIPTION
## 日本語

### 概要
Cookie 同意バナーで「同意する」「拒否する」などのボタンをクリックした際に発生していた、以下のブラウザ警告を修正します。

> Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users.

### 原因
`static/cookie-consent.js` の `hideOverlay()` が、フォーカスの移動より先に overlay へ `aria-hidden="true"` を付与していました。

```js
overlay.setAttribute('aria-hidden', 'true');   // ← 先にaria-hiddenを付与
...
lastFocusedElement.focus();                    // ← フォーカス移動は後
```

ボタンをクリックした瞬間、ボタン自身にブラウザ標準の挙動としてフォーカスが乗ります。その状態で祖先の overlay に `aria-hidden="true"` を付与するため、「フォーカス中の要素を支援技術から隠す」状態が発生します。

さらに、`lastFocusedElement`（初回表示時に `showOverlay()` が記録する `document.activeElement`）は多くの場合 `<body>` のようなフォーカス不可能な要素です。`<body>.focus()` は何もしない（no-op）ため、後続の `lastFocusedElement.focus()` を呼んでもボタンからフォーカスが外れず、この状態が実質的に残り続けていました。

### 修正内容
`overlay.setAttribute('aria-hidden', 'true')` を呼ぶ前に、overlay 内にフォーカスがあれば明示的に `blur()` するようにしました。

```js
if (overlay.contains(document.activeElement)) {
  document.activeElement.blur();
}
overlay.setAttribute('aria-hidden', 'true');
```

`lastFocusedElement` が有効な要素であれば直後の `.focus()` でそちらへフォーカスが戻り、無効（`<body>` など）であればフォーカスはどこにも残らず安全な状態になります。

同意バナーを閉じるすべての経路（同意する / 拒否する / カスタマイズ画面の保存 / 閉じるボタン / 背景クリック / Escape）が同じ `hideOverlay()` を通るため、1 箇所の修正で全経路に適用されます。

### 挙動を変えていない点
- 同意バナーの表示・非表示のタイミングやアニメーションは変更していません。
- Cookie 同意の保存ロジック（`setConsentCookie` 等）、AdSense/GA の読み込みロジック（`applyOptionalTags` 等）には触れていません。

### 実行した自動テスト
| 検査 | 結果 |
| --- | --- |
| `python3 -m pytest` | 652 passed（既存スイート。今回の変更は JS のみで Python 側への影響なし） |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |

型チェック（mypy）は Python ファイルの変更がないため対象外です。

### 手動検証の証跡
本リポジトリには JS 用のテストランナー（jest/vitest 等）が整備されておらず、また今回の検証環境では実ブラウザ（Playwright MCP がチャンネル `chrome` 未導入、システムライブラリ `libnspr4.so` 不足でヘッドレス Chromium も起動不可）を起動できなかったため、jsdom を用いて `hideOverlay()` の実装を修正前後で直接比較しました。

| 検証項目 | 修正前 | 修正後 |
| --- | --- | --- |
| クリック直前、ボタンにフォーカスがある | ○ | ○ |
| `aria-hidden="true"` 適用時にフォーカス済みの子孫が存在（=違反再現） | **○ 再現** | × なし |
| 最終的なフォーカス位置 | ボタンに残留（違反状態が継続） | `<body>`（安全） |

修正前のコードで実際にバグが再現し、修正後のコードで解消することを確認済みです。

### 未実施の検証とその理由
- **実ブラウザでの目視確認（DevTools コンソールでの警告消失確認）**: 上記の環境的制約により実施できませんでした。jsdom による直接比較で同一の原因・同一の修正内容を検証済みですが、実ブラウザでの最終確認を推奨します。
- **自動テストの追加**: リポジトリに JS 用のテストランナーが未整備のため、pytest 経由での自動テストは追加していません（AGENTS.md の対象は `tests/` 配下の pytest のみ）。

### 関連 Issue
なし

---

## English

### Summary
Fixes the following browser warning that fired when clicking any button (accept/reject/etc.) on the cookie consent banner:

> Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users.

### Root cause
`hideOverlay()` in `static/cookie-consent.js` applied `aria-hidden="true"` to the overlay before moving focus away:

```js
overlay.setAttribute('aria-hidden', 'true');   // aria-hidden applied first
...
lastFocusedElement.focus();                    // focus moved afterward
```

Clicking a button gives it focus as standard browser behavior. Setting `aria-hidden="true"` on its ancestor at that moment hides a currently-focused element from assistive technology.

Worse, `lastFocusedElement` (captured by `showOverlay()` as `document.activeElement` on first display) is typically `<body>` — a non-focusable element. Calling `.focus()` on it is a no-op, so the button never actually lost focus, leaving the violation in effect.

### Fix
Blur the active element before setting `aria-hidden="true"` if it's inside the overlay:

```js
if (overlay.contains(document.activeElement)) {
  document.activeElement.blur();
}
overlay.setAttribute('aria-hidden', 'true');
```

If `lastFocusedElement` is a valid focusable element, the subsequent `.focus()` call restores focus there; otherwise focus simply rests nowhere, which is safe.

Every path that closes the banner (accept, reject, save in settings, close button, backdrop click, Escape) goes through this same `hideOverlay()`, so the single fix covers all of them.

### Behavior deliberately left unchanged
- Banner show/hide timing and animation are untouched.
- Consent persistence logic (`setConsentCookie`, etc.) and the AdSense/GA loading logic (`applyOptionalTags`, etc.) are untouched.

### Automated tests run
| Check | Result |
| --- | --- |
| `python3 -m pytest` | 652 passed (existing suite; this change is JS-only, no Python impact) |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |

mypy was not run since no Python files changed.

### Manual verification evidence
This repo has no JS test runner (jest/vitest, etc.), and a real browser could not be launched in this verification environment (Playwright MCP's `chrome` channel isn't installed; headless Chromium also failed to start due to a missing `libnspr4.so` system library). Instead, `hideOverlay()` was compared directly, before vs. after, using jsdom.

| Check | Before | After |
| --- | --- | --- |
| Button focused right before hiding | yes | yes |
| Focused descendant present when `aria-hidden="true"` is applied (= violation reproduced) | **yes, reproduced** | no |
| Final focus location | stuck on the button (violation persists) | `<body>` (safe) |

The bug reproduced with the pre-fix code and was resolved with the post-fix code.

### Verification not performed, and why
- **Visual confirmation in a real browser (console warning gone)**: not possible given the environment constraints above. The jsdom comparison isolates and verifies the exact same root cause and fix, but a real-browser check is still recommended before merge.
- **Automated test addition**: not added since the repo has no JS test runner (AGENTS.md's automated-test scope is the pytest suite under `tests/`).

### Related issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
