### PR TITLE
View Transitionスキップ時の未処理rejectionを抑制 / Silence unhandled rejection on skipped view transitions

### DIFF
--- a/static/js/shared/ux-runtime.js
+++ b/static/js/shared/ux-runtime.js
@@ -433,6 +433,35 @@
   })();
 
   // ---------------------------------------------------------------------------
+  // Cross-document view transitions: silence expected skips
+  // ---------------------------------------------------------------------------
+  // 遷移は CSS の @view-transition (13-ux-interactions.css) だけで有効化して
+  // いるため、ブラウザが生成する ViewTransition オブジェクトをページ側は
+  // 参照していない。遷移がスキップされると ready promise が AbortError で
+  // reject し、誰も掴んでいないので "Uncaught (in promise)" になる。
+  // スキップ自体は正常な挙動（遷移先が未オプトイン、連続ナビゲーション等）
+  // なので、pagereveal / pageswap で受け取って no-op の catch を付ける。
+  //
+  // Skips are expected, not errors: attach a no-op catch to the promise the
+  // browser owns so the unhandled rejection stops reaching the console.
+  // Animation behaviour is unchanged.
+  (function viewTransitionRejections() {
+    ["pagereveal", "pageswap"].forEach(function (eventName) {
+      window.addEventListener(eventName, function (event) {
+        var transition = event && event.viewTransition;
+        if (!transition || !transition.ready) {
+          return;
+        }
+        try {
+          transition.ready.catch(function () {});
+        } catch (err) {
+          /* no-op */
+        }
+      });
+    });
+  })();
+
+  // ---------------------------------------------------------------------------
   // Link prefetch (connection-aware)
   // ---------------------------------------------------------------------------
   (function prefetch() {


### PR DESCRIPTION
## 日本語

### 概要
`/group_menu` などのページでコンソールに出ていた以下の未処理 Promise rejection を抑制します。

> Uncaught (in promise) AbortError: Transition was skipped

**機能面の影響はもともとありません。** 遷移がスキップされてもナビゲーション自体は正常に完了し、アニメーションが省略されるだけです。本 PR はコンソールノイズの解消のみを目的とし、遷移の挙動は変更していません。

### 原因
クロスドキュメント View Transitions は CSS だけで有効化しています。

```css
/* static/css/13-ux-interactions.css:30 */
@view-transition { navigation: auto; }
```

これは `static/style.css:13` から `@import` され、`layout.html` / `group.html` などを通じて各ページに適用されます。

一方で、`static/` 配下の JS は View Transitions API を一切呼んでいません（`startViewTransition` / `pageswap` / `pagereveal` の使用は grep で 0 件）。そのため、遷移がスキップされた際に reject する `ViewTransition.ready` promise はブラウザが生成・所有しており、ページ側のコードは参照すら持っていませんでした。誰もハンドラを付けていない promise が reject するため、ブラウザが "Uncaught (in promise)" として報告していた、というのが原因です。

つまりこれはコード側の promise 処理漏れではなく、既存コードでは構造的に catch できない状態でした。

### スキップ自体は正常な挙動
クロスドキュメント View Transitions は**遷移元と遷移先の両方**が `@view-transition` でオプトインしている必要があります。本リポジトリの現状は以下のとおりです。

| ページ種別 | `@view-transition` |
| --- | --- |
| トップ・各メニュー・記事（`layout.html` 継承） | オプトイン |
| LP 3本（`/file-sharing`, `/group-file-sharing`, `/shared-note`） | 未オプトイン |

LP 3本（`FSQR/templates/fsqr_landing.html`、`Group/templates/group_landing.html`、`Note/templates/note_landing.html`）は `layout.html` を継承せず独自の `<head>` を持ち、`css/15-product-landing.css` のみを読み込みます。このファイルに `@view-transition` はありません。

したがってオプトイン済みページと LP 間の遷移は**仕様どおりスキップされます**。連続ナビゲーションやタイムアウトでも同様に発生します。いずれもエラーではなく想定内の挙動です。

### 修正内容
`pagereveal` / `pageswap` でブラウザ所有の `ViewTransition` を受け取り、`ready` に no-op の `catch` を付けて未処理 rejection を止めます（`static/js/shared/ux-runtime.js`）。

```js
["pagereveal", "pageswap"].forEach(function (eventName) {
  window.addEventListener(eventName, function (event) {
    var transition = event && event.viewTransition;
    if (!transition || !transition.ready) {
      return;
    }
    try {
      transition.ready.catch(function () {});
    } catch (err) {
      /* no-op */
    }
  });
});
```

`ux-runtime.js` は共通レイアウト経由で全ページに読み込まれるため、1 箇所の追加で全ページに適用されます。

### 挙動を変えていない点
- 遷移アニメーションの有無・内容・タイミングは変更していません。
- LP 3本のオプトイン状況は現状維持です（意図的な設計の可能性があるため、本 PR の範囲外としました）。
- `FSQRUx` の公開 API（`progress` / `toast` / `isOnline` / `connection`）に変更はありません。
- プログレスバー、プリフェッチ、トースト、Service Worker 関連のロジックには触れていません。

### 実行した自動テスト
| 検査 | 結果 |
| --- | --- |
| `python3 -m pytest` | 652 passed（既存スイート。本変更は JS のみで Python 側への影響なし） |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |

mypy は Python ファイルの変更がないため対象外です。

### 手動検証の証跡
本リポジトリには JS 用のテストランナー（jest/vitest 等）が整備されておらず、この検証環境では実ブラウザを起動できなかったため（Playwright MCP がチャンネル `chrome` 未導入、システムライブラリ `libnspr4.so` 不足でヘッドレス Chromium も起動不可）、jsdom で実ファイル `static/js/shared/ux-runtime.js` を読み込んで検証しました。

ブラウザが "Uncaught (in promise)" を報告するのは「`ready` に誰もハンドラを付けなかった場合」のみなので、ハンドラ付与の有無を判定基準としています。

**1. ハンドラ付与の確認**

| イベント | `ux-runtime.js` なし（比較用） | `ux-runtime.js` あり（修正後） |
| --- | --- | --- |
| `pagereveal` | ハンドラなし | **ハンドラ付与を確認** |
| `pageswap` | ハンドラなし | **ハンドラ付与を確認** |

**2. ガード条件の確認（例外を出さないこと）**

| ケース | 結果 |
| --- | --- |
| `viewTransition` なし（View Transitions 未対応ブラウザ） | 例外なく通過 |
| `viewTransition = null` | 例外なく通過 |
| `ready` を持たないオブジェクト | 例外なく通過 |

**3. 公開 API の非破壊確認**

`window.FSQRUx` が `object` として初期化され、`progress`（object）/ `toast`（function）/ `isOnline`（function）がいずれも従来どおり存在することを確認。

### 未実施の検証とその理由
- **実ブラウザでの目視確認（DevTools コンソールで警告が消えること）**: 上記の環境的制約により実施できませんでした。jsdom で原因と修正内容を特定・検証していますが、実ブラウザでの最終確認を推奨します。
- **`/group_menu` で当該警告が出る正確なトリガーの特定**: どの遷移でスキップされたかの再現には実ブラウザが必要なため未実施です。ただし本修正はスキップ理由に依存せず、スキップ全般の未処理 rejection を抑制します。
- **自動テストの追加**: リポジトリに JS 用のテストランナーが未整備のため追加していません（AGENTS.md の自動テスト対象は `tests/` 配下の pytest のみ）。

### 補足: 今後の選択肢
LP 3本を `@view-transition` にオプトインさせればサイト全体で遷移アニメーションが統一されますが、LP の見た目（遷移時の挙動）が変わる設計判断になるため、本 PR には含めていません。

### 関連 Issue
なし

---

## English

### Summary
Silences the following unhandled promise rejection seen in the console on pages such as `/group_menu`:

> Uncaught (in promise) AbortError: Transition was skipped

**There was never any functional impact.** A skipped transition still completes the navigation normally; only the animation is dropped. This PR only removes console noise and does not change transition behavior.

### Root cause
Cross-document view transitions are enabled purely in CSS:

```css
/* static/css/13-ux-interactions.css:30 */
@view-transition { navigation: auto; }
```

It is `@import`ed from `static/style.css:13` and thus applies to pages via `layout.html`, `group.html`, and others.

Meanwhile, no JS under `static/` touches the View Transitions API (grep finds zero uses of `startViewTransition` / `pageswap` / `pagereveal`). The `ViewTransition.ready` promise that rejects on a skip is therefore created and owned by the browser, with page code never holding a reference to it. A promise rejecting with no attached handler is exactly what the browser reports as "Uncaught (in promise)".

In other words this was not a mishandled promise in our code — it was structurally impossible for existing code to catch.

### Skips are expected behavior
Cross-document view transitions require **both** the outgoing and incoming documents to opt in via `@view-transition`. Current state of this repo:

| Page type | `@view-transition` |
| --- | --- |
| Home, menus, articles (inherit `layout.html`) | opted in |
| The 3 LPs (`/file-sharing`, `/group-file-sharing`, `/shared-note`) | not opted in |

The three LP templates (`FSQR/templates/fsqr_landing.html`, `Group/templates/group_landing.html`, `Note/templates/note_landing.html`) do not extend `layout.html`; they have their own `<head>` and load only `css/15-product-landing.css`, which contains no `@view-transition`.

So navigations between an opted-in page and an LP are skipped **by specification**. The same happens on rapid successive navigations or timeouts. None of these are errors.

### Fix
Receive the browser-owned `ViewTransition` via `pagereveal` / `pageswap` and attach a no-op `catch` to `ready` (`static/js/shared/ux-runtime.js`):

```js
["pagereveal", "pageswap"].forEach(function (eventName) {
  window.addEventListener(eventName, function (event) {
    var transition = event && event.viewTransition;
    if (!transition || !transition.ready) {
      return;
    }
    try {
      transition.ready.catch(function () {});
    } catch (err) {
      /* no-op */
    }
  });
});
```

`ux-runtime.js` is loaded on every page through the shared layouts, so this single addition covers the whole site.

### Behavior deliberately left unchanged
- Transition animation presence, content, and timing are untouched.
- The 3 LPs' opt-in status is left as-is (possibly intentional design; out of scope here).
- `FSQRUx`'s public API (`progress` / `toast` / `isOnline` / `connection`) is unchanged.
- Progress bar, prefetch, toast, and service worker logic are untouched.

### Automated tests run
| Check | Result |
| --- | --- |
| `python3 -m pytest` | 652 passed (existing suite; JS-only change, no Python impact) |
| `python3 -m ruff check .` | All checks passed |
| `python3 -m ruff format --check .` | 115 files already formatted |

mypy was not run since no Python files changed.

### Manual verification evidence
This repo has no JS test runner (jest/vitest, etc.), and a real browser could not be launched in this environment (Playwright MCP's `chrome` channel isn't installed; headless Chromium also failed due to a missing `libnspr4.so` system library). Verification was done with jsdom loading the actual `static/js/shared/ux-runtime.js`.

Since the browser reports "Uncaught (in promise)" only when nobody attached a handler to `ready`, handler attachment is the criterion used.

**1. Handler attachment**

| Event | Without `ux-runtime.js` (control) | With `ux-runtime.js` (fixed) |
| --- | --- | --- |
| `pagereveal` | no handler | **handler attached** |
| `pageswap` | no handler | **handler attached** |

**2. Guard clauses (must not throw)**

| Case | Result |
| --- | --- |
| No `viewTransition` (browser without View Transitions) | passed, no exception |
| `viewTransition = null` | passed, no exception |
| Object without `ready` | passed, no exception |

**3. Public API not broken**

Confirmed `window.FSQRUx` still initializes as an `object` with `progress` (object), `toast` (function), and `isOnline` (function) present as before.

### Verification not performed, and why
- **Visual confirmation in a real browser (warning gone from DevTools)**: not possible given the environment constraints above. The jsdom work isolates and verifies the root cause and the fix, but a real-browser check is recommended before merge.
- **Pinpointing the exact trigger on `/group_menu`**: reproducing which navigation was skipped requires a real browser. The fix does not depend on the skip reason and suppresses unhandled rejections from skips generally.
- **Automated test addition**: not added since the repo has no JS test runner (AGENTS.md's automated-test scope is the pytest suite under `tests/`).

### Note on a possible follow-up
Opting the 3 LPs into `@view-transition` would unify transition animations site-wide, but that changes how the LPs behave visually, so it is intentionally excluded from this PR.

### Related issues
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
