### PR TITLE
タスク管理画面のドロップダウンメニューのスタイル改善 / Improve dropdown menu styling on Task management pages

### DIFF
--- a/static/css/02-design-retention.css
+++ b/static/css/02-design-retention.css
@@ -549,6 +549,25 @@
   box-shadow: var(--retention-citrus-arrow-shadow);
 }
 
+.retention-select-wrapper--amber {
+  --retention-accent: #d97706;
+  --retention-accent-soft: rgba(245, 158, 11, 0.28);
+  --retention-accent-strong: rgba(217, 119, 6, 0.55);
+  --retention-text: #451a03;
+  --retention-trigger-bg: linear-gradient(135deg, rgba(245, 158, 11, 0.95), rgba(217, 119, 6, 0.95));
+  --retention-trigger-hover-bg: linear-gradient(135deg, rgba(217, 119, 6, 0.98), rgba(180, 83, 9, 0.96));
+  --retention-trigger-open-bg: linear-gradient(135deg, rgba(180, 83, 9, 1), rgba(146, 64, 14, 0.98));
+  --retention-trigger-text: #fffbeb;
+  --retention-trigger-hover-text: #fffbeb;
+  --retention-trigger-open-text: #fffbeb;
+  --retention-trigger-shadow: 0 12px 24px -16px rgba(217, 119, 6, 0.6);
+  --retention-trigger-hover-shadow: 0 18px 32px -14px rgba(217, 119, 6, 0.68);
+  --retention-trigger-open-shadow: 0 20px 36px -14px rgba(180, 83, 9, 0.72);
+  --retention-wrapper-border: rgba(245, 158, 11, 0.55);
+  --retention-menu-border: rgba(217, 119, 6, 0.38);
+  --retention-menu-shadow: 0 28px 50px -18px rgba(180, 83, 9, 0.6);
+}
+
 @media (max-width: 575.98px) {
   .retention-select-wrapper {
     max-width: 100%;

--- a/static/css/16-task-board.css
+++ b/static/css/16-task-board.css
@@ -135,10 +135,14 @@
   transition: all 0.15s ease;
 }
 
-.task-select-pill:hover,
-.task-select-pill:focus {
+.task-select-pill:hover {
+  border-color: var(--theme-task-end, #f59e0b);
+}
+
+.task-select-pill:focus-visible {
   border-color: var(--theme-task-end, #f59e0b);
   outline: none;
+  box-shadow: 0 0 0 3px var(--theme-task-focus-ring, rgba(245, 158, 11, 0.2));
 }
 
 .task-btn--add {
@@ -687,16 +691,31 @@
   right: 0.5rem;
   top: 2.5rem;
   display: grid;
-  min-width: 160px;
-  padding: 0.4rem;
-  border: 1px solid rgba(203, 213, 225, 0.8);
-  border-radius: 12px;
-  background: #ffffff;
-  box-shadow: 0 10px 25px -5px rgba(15, 23, 42, 0.18), 0 8px 10px -6px rgba(15, 23, 42, 0.08);
+  min-width: 168px;
+  padding: 0.45rem;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: var(--radius-lg, 14px);
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 16px 36px -10px rgba(15, 23, 42, 0.2), 0 0 0 1px rgba(255, 255, 255, 0.8) inset;
+  animation: taskMenuFadeIn 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: top right;
+}
+
+@keyframes taskMenuFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.94) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 .task-card__move-menu button {
-  padding: 0.5rem 0.65rem;
+  padding: 0.55rem 0.75rem;
   border: 0;
   border-radius: 8px;
   background: transparent;


### PR DESCRIPTION
## 日本語

### 概要
タスク管理画面（タスクボード作成画面 `/create_task_room`、入室画面 `/task_room_access`、タスクボード画面 `/task/<room_id>`）のドロップダウンメニューをクリックした際のデザインを、他ページ（FS!QR、Group、Note）と統一し、美しく見やすく改善しました。

- `static/css/02-design-retention.css` に、他サービス（`--azure`, `--emerald`, `--citrus`）と同様の Task 専用の `.retention-select-wrapper--amber` スタイル定義を追加しました。これにより、クリック時に Task テーマ（アンバー/オレンジ系）のリッチなグラデーション背景、シャドウ、選択肢のアクティブ/ホバー状態、チェックマークが正しく反映されるようになりました。
- `static/css/16-task-board.css` のタスクカード操作メニュー（`.task-card__move-menu`）に、グラスモーフィズム（backdrop-filter）、モダンなドロップシャドウ、滑らかなフェードインアニメーションを適用しました。
- タスクボードのセレクト要素（`.task-select-pill`）のフォーカスリングを Task のアクセントカラーに合わせて調整しました。

### 設定・マイグレーションに関する注意事項
- なし（CSSスタイルの追加・調整のみ）

### 実行した自動テスト
- `python3 -m pytest`（全676件のテストがパス）
- `python3 -m ruff check .`（静的解析パス）
- `python3 -m ruff format --check .`（フォーマット検査パス）
- `python3 -m mypy --config-file pyproject.toml`（型チェックパス）

### 手動検証
- `/create_task_room` および `/task_room_access` における保持期間ドロップダウンメニューのクリック・ホバー・キーボード操作時のスタイルが、FS!QR・Group・Noteと同等のアニメーション・配色で正常に表示されることを確認。
- `/task/<room_id>` におけるタスクカードの操作メニュー（`⋮`）クリック時のドロップダウンメニュー表示とアニメーションを確認。

### 未実施の検証とその理由
- 本番環境での実機ブラウザ（Safari/iOS）の物理デバイス検証（ローカルLinux環境のため自動テストおよびHTML/CSS検証で代替）。

---

## English

### Overview
Improved and unified the dropdown menu styling when clicked across Task management pages (`/create_task_room`, `/task_room_access`, and `/task/<room_id>`) to match the design system used in other pages (FS!QR, Group, Note).

- Added `.retention-select-wrapper--amber` definition to `static/css/02-design-retention.css` matching existing themes (`--azure`, `--emerald`, `--citrus`). This ensures proper amber/orange theme gradients, drop shadows, active/hover states, and checkmark indicators when clicking the retention select dropdown.
- Enhanced the task card action dropdown menu (`.task-card__move-menu`) in `static/css/16-task-board.css` with glassmorphism blur, modern shadow, and smooth fade-in animation.
- Polished the focus ring style of `.task-select-pill` to match Task accent color.

### Configuration / Migration Notes
- None (CSS styling adjustments only).

### Automated Tests Executed
- `python3 -m pytest` (All 676 tests passed)
- `python3 -m ruff check .` (Lint passed)
- `python3 -m ruff format --check .` (Format check passed)
- `python3 -m mypy --config-file pyproject.toml` (Type check passed)

### Manual Verification
- Verified that clicking/hovering/keyboard-navigating the retention dropdown on `/create_task_room` and `/task_room_access` displays the expected amber theme dropdown consistently with FS!QR, Group, and Note.
- Verified that clicking the card action menu button (`⋮`) on `/task/<room_id>` opens the action dropdown smoothly with the enhanced animation and styles.

### Verification Not Conducted & Reason
- Physical device testing on Safari/iOS (substituted with automated tests and local CSS inspection due to Linux environment).